### PR TITLE
perf: N+1 제거, 카테고리 캐시, 재고 스냅샷 배치 처리 (#7/#8/#9)

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -17,35 +17,13 @@
 
 ---
 
-## 🔴 즉시 처리 — 성능 병목
+## ✅ 즉시 처리 — 성능 병목 완료 (3/3)
 
-### 7. InventoryRepository fetch join 누락 (N+1)
-
-**위치**: `domain/inventory/repository/InventoryRepository.java` L31, L45
-
-**문제**: `findByProductId()`, `findAllByProductIdIn()` 에 `@EntityGraph` 없음. `ProductService.enrichPage()` 가 페이지(20건) 처리 시 product 연관을 lazy load → 추가 SELECT 20회 발생.
-
-**개선**: 두 메서드에 `@EntityGraph(attributePaths = {"product"})` 추가.
-
----
-
-### 8. CategoryService.getTree() 캐시 미적용
-
-**위치**: `domain/product/category/service/CategoryService.java` L48, L58
-
-**문제**: `getList()`와 `getTree()` 가 각각 `findAll()` 호출. 트리 조립은 in-memory O(n²) 순회이며 상품 목록 API 호출마다 재실행된다. 카테고리는 변경 빈도가 낮다.
-
-**개선**: `@Cacheable(cacheNames = "categories", key = "'tree'")` 추가, write 메서드에 `@CacheEvict(allEntries = true)`.
-
----
-
-### 9. InventorySnapshotScheduler 전체 로드 → 배치 처리
-
-**위치**: `domain/inventory/scheduler/InventorySnapshotScheduler.java` L37
-
-**문제**: `inventoryRepository.findAll()`로 전체 재고를 단일 트랜잭션에 메모리로 올린다. 대량 재고 시 힙 과부하 + 트랜잭션 유지 중 `inventory` 테이블 shared lock 경합.
-
-**개선**: `Pageable` 기반 1,000건 단위 페이지 배치, 배치마다 커밋.
+| # | 항목 | 파일 | 조치 |
+|---|------|------|------|
+| 7 | InventoryRepository fetch join 누락 (N+1) | `InventoryRepository` | `findByProductId`, `findAllByProductIdIn`에 `@EntityGraph({"product"})` 추가 |
+| 8 | CategoryService.getTree() 캐시 미적용 | `CategoryService`, `CacheConfig`, `CategoryResponse` | `getList/getTree` `@Cacheable`, `create/update/delete` `@CacheEvict(allEntries=true)`, categories 30분 TTL, `@Jacksonized` + `ArrayList` 적용 |
+| 9 | InventorySnapshotScheduler 전체 로드 | `InventorySnapshotScheduler`, `InventorySnapshotProcessor` | 1,000건 페이지 루프 + 배치마다 독립 트랜잭션 커밋 (`@Component` 분리) |
 
 ---
 

--- a/src/main/java/com/stockmanagement/common/config/CacheConfig.java
+++ b/src/main/java/com/stockmanagement/common/config/CacheConfig.java
@@ -44,7 +44,7 @@ public class CacheConfig {
                 .activateDefaultTyping(
                         LaissezFaireSubTypeValidator.instance,
                         ObjectMapper.DefaultTyping.NON_FINAL,
-                        JsonTypeInfo.As.PROPERTY
+                        JsonTypeInfo.As.WRAPPER_ARRAY
                 );
 
         GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(cacheMapper);
@@ -65,6 +65,8 @@ public class CacheConfig {
                         "inventory", base.entryTtl(Duration.ofMinutes(5)),
                         // 주문: 상태 변경 가능 → 5분 + 명시적 evict
                         "orders", base.entryTtl(Duration.ofMinutes(5)),
+                        // 카테고리 트리: 변경 빈도 매우 낮음 → 30분 + 명시적 evict
+                        "categories", base.entryTtl(Duration.ofMinutes(30)),
                         // 시스템 설정: 변경 빈도 매우 낮음 → 1시간 + 명시적 evict
                         "settings", base.entryTtl(Duration.ofHours(1))
                 ))

--- a/src/main/java/com/stockmanagement/domain/inventory/repository/InventoryRepository.java
+++ b/src/main/java/com/stockmanagement/domain/inventory/repository/InventoryRepository.java
@@ -27,7 +27,8 @@ import java.util.Optional;
  */
 public interface InventoryRepository extends JpaRepository<Inventory, Long>, JpaSpecificationExecutor<Inventory> {
 
-    /** 상품 ID로 재고를 조회한다 (읽기 전용) */
+    /** 상품 ID로 재고를 조회한다 (읽기 전용). product를 JOIN FETCH하여 N+1 방지. */
+    @EntityGraph(attributePaths = {"product"})
     Optional<Inventory> findByProductId(Long productId);
 
     /**
@@ -41,7 +42,8 @@ public interface InventoryRepository extends JpaRepository<Inventory, Long>, Jpa
     @Query("SELECT i FROM Inventory i WHERE i.product.id = :productId")
     Optional<Inventory> findByProductIdWithLock(@Param("productId") Long productId);
 
-    /** 여러 상품의 재고를 한 번에 조회한다 (목록 조회 N+1 방지). */
+    /** 여러 상품의 재고를 한 번에 조회한다. product를 JOIN FETCH하여 N+1 방지. */
+    @EntityGraph(attributePaths = {"product"})
     List<Inventory> findAllByProductIdIn(Collection<Long> productIds);
 
     /** available(= onHand - reserved - allocated)이 threshold 미만인 저재고 목록 (대시보드용) */

--- a/src/main/java/com/stockmanagement/domain/inventory/scheduler/InventorySnapshotProcessor.java
+++ b/src/main/java/com/stockmanagement/domain/inventory/scheduler/InventorySnapshotProcessor.java
@@ -1,0 +1,52 @@
+package com.stockmanagement.domain.inventory.scheduler;
+
+import com.stockmanagement.domain.inventory.entity.DailyInventorySnapshot;
+import com.stockmanagement.domain.inventory.entity.Inventory;
+import com.stockmanagement.domain.inventory.repository.DailyInventorySnapshotRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * 재고 스냅샷 배치 처리기.
+ *
+ * <p>{@link InventorySnapshotScheduler}에서 페이지 단위로 호출한다.
+ * 각 호출이 독립 트랜잭션으로 커밋되므로 힙 사용량과 테이블 락 점유 시간을 모두 줄인다.
+ * (별도 빈으로 분리하지 않으면 같은 클래스 내 self-call이 되어 Spring AOP 프록시를 우회함)
+ */
+@Component
+@RequiredArgsConstructor
+class InventorySnapshotProcessor {
+
+    private final DailyInventorySnapshotRepository snapshotRepository;
+
+    /**
+     * 재고 페이지 한 건을 스냅샷으로 저장한다.
+     *
+     * @param inventories  이번 페이지의 재고 목록
+     * @param alreadySnapped 오늘 이미 저장된 inventoryId 집합 (중복 방지)
+     * @param today        스냅샷 기준일
+     * @return 신규 저장된 스냅샷 건수
+     */
+    @Transactional
+    int processBatch(List<Inventory> inventories, Set<Long> alreadySnapped, LocalDate today) {
+        List<DailyInventorySnapshot> snapshots = inventories.stream()
+                .filter(inv -> !alreadySnapped.contains(inv.getId()))
+                .map(inv -> DailyInventorySnapshot.builder()
+                        .inventory(inv)
+                        .snapshotDate(today)
+                        .onHand(inv.getOnHand())
+                        .reserved(inv.getReserved())
+                        .allocated(inv.getAllocated())
+                        .available(inv.getAvailable())
+                        .build())
+                .toList();
+
+        snapshotRepository.saveAll(snapshots);
+        return snapshots.size();
+    }
+}

--- a/src/main/java/com/stockmanagement/domain/inventory/scheduler/InventorySnapshotScheduler.java
+++ b/src/main/java/com/stockmanagement/domain/inventory/scheduler/InventorySnapshotScheduler.java
@@ -1,20 +1,18 @@
 package com.stockmanagement.domain.inventory.scheduler;
 
-import com.stockmanagement.domain.inventory.entity.DailyInventorySnapshot;
 import com.stockmanagement.domain.inventory.entity.Inventory;
 import com.stockmanagement.domain.inventory.repository.DailyInventorySnapshotRepository;
 import com.stockmanagement.domain.inventory.repository.InventoryRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
-
-import org.springframework.dao.DataIntegrityViolationException;
 
 import java.time.LocalDate;
-import java.util.List;
 import java.util.Set;
 
 /**
@@ -22,6 +20,9 @@ import java.util.Set;
  *
  * <p>매일 자정 5분에 전체 재고 현황을 {@code daily_inventory_snapshots}에 저장한다.
  * 동일 재고·날짜 조합이 이미 존재하면 스킵하여 멱등성을 보장한다.
+ *
+ * <p>페이지 단위({@value PAGE_SIZE}건)로 분할 처리하여 힙 사용량과 테이블 락 점유 시간을 줄인다.
+ * 각 페이지는 {@link InventorySnapshotProcessor}의 독립 트랜잭션으로 커밋된다.
  */
 @Slf4j
 @Component
@@ -29,44 +30,46 @@ import java.util.Set;
 @ConditionalOnProperty(name = "inventory.snapshot.enabled", havingValue = "true", matchIfMissing = true)
 public class InventorySnapshotScheduler {
 
+    private static final int PAGE_SIZE = 1_000;
+
     private final InventoryRepository inventoryRepository;
     private final DailyInventorySnapshotRepository snapshotRepository;
+    private final InventorySnapshotProcessor snapshotProcessor;
 
     @Scheduled(cron = "${inventory.snapshot.cron:0 5 0 * * *}")
-    @Transactional
     public void takeSnapshot() {
         LocalDate today = LocalDate.now();
-        List<Inventory> inventories = inventoryRepository.findAll();
-        // 오늘 이미 스냅샷이 존재하는 inventoryId를 한 번에 조회하여 N+1 방지
+        // 오늘 이미 스냅샷이 존재하는 inventoryId를 한 번에 조회하여 중복 방지
         Set<Long> alreadySnapped = snapshotRepository.findInventoryIdsBySnapshotDate(today);
-        log.info("[InventorySnapshotScheduler] 재고 스냅샷 시작 — 대상: {}건, 기준일: {}", inventories.size(), today);
 
-        // 신규 항목만 필터링하여 엔티티 리스트 구성 → saveAll() 단일 배치 INSERT
-        List<DailyInventorySnapshot> snapshots = inventories.stream()
-                .filter(inv -> !alreadySnapped.contains(inv.getId()))
-                .map(inv -> DailyInventorySnapshot.builder()
-                        .inventory(inv)
-                        .snapshotDate(today)
-                        .onHand(inv.getOnHand())
-                        .reserved(inv.getReserved())
-                        .allocated(inv.getAllocated())
-                        .available(inv.getAvailable())
-                        .build())
-                .toList();
+        int pageNum = 0;
+        int totalSaved = 0;
+        long totalElements = 0;
 
-        int skipped = inventories.size() - snapshots.size();
-        try {
-            snapshotRepository.saveAll(snapshots);
-            log.info("[InventorySnapshotScheduler] 완료 — 저장: {}건 / 스킵: {}건", snapshots.size(), skipped);
-        } catch (DataIntegrityViolationException e) {
-            // 레이스 컨디션으로 인한 중복 스냅샷 — alreadySnapped 집합 조회 후 INSERT 사이에
-            // 다른 인스턴스가 먼저 저장한 경우. 안전하게 스킵한다.
-            log.debug("[InventorySnapshotScheduler] 중복 스냅샷 감지 (동시 실행 경합) — date={}", today);
-        } catch (Exception e) {
-            // 예상치 못한 오류 — 스케줄러가 error를 삼키면 다음 주기까지 알 수 없으므로 re-throw하여
-            // Spring 스케줄러가 로그를 남기고 Prometheus/알림이 감지할 수 있도록 한다.
-            log.error("[InventorySnapshotScheduler] 스냅샷 배치 저장 실패 — 수동 확인 필요: date={}", today, e);
-            throw new RuntimeException("재고 스냅샷 저장 실패: " + today, e);
+        while (true) {
+            Page<Inventory> inventoryPage = inventoryRepository.findAll(PageRequest.of(pageNum, PAGE_SIZE));
+            if (inventoryPage.isEmpty()) break;
+
+            if (pageNum == 0) {
+                totalElements = inventoryPage.getTotalElements();
+                log.info("[InventorySnapshotScheduler] 재고 스냅샷 시작 — 전체: {}건, 기준일: {}", totalElements, today);
+            }
+
+            try {
+                totalSaved += snapshotProcessor.processBatch(inventoryPage.getContent(), alreadySnapped, today);
+            } catch (DataIntegrityViolationException e) {
+                // 레이스 컨디션: alreadySnapped 조회 후 INSERT 사이에 다른 인스턴스가 먼저 저장한 경우
+                log.debug("[InventorySnapshotScheduler] 중복 스냅샷 감지 (동시 실행 경합) — date={}, page={}", today, pageNum);
+            } catch (Exception e) {
+                log.error("[InventorySnapshotScheduler] 스냅샷 배치 저장 실패 — 수동 확인 필요: date={}, page={}", today, pageNum, e);
+                throw new RuntimeException("재고 스냅샷 저장 실패: " + today, e);
+            }
+
+            if (inventoryPage.isLast()) break;
+            pageNum++;
         }
+
+        log.info("[InventorySnapshotScheduler] 완료 — 저장: {}건 / 스킵: {}건",
+                totalSaved, totalElements - totalSaved);
     }
 }

--- a/src/main/java/com/stockmanagement/domain/product/category/dto/CategoryResponse.java
+++ b/src/main/java/com/stockmanagement/domain/product/category/dto/CategoryResponse.java
@@ -3,8 +3,10 @@ package com.stockmanagement.domain.product.category.dto;
 import com.stockmanagement.domain.product.category.entity.Category;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.extern.jackson.Jacksonized;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -15,6 +17,7 @@ import java.util.List;
  */
 @Getter
 @Builder
+@Jacksonized
 public class CategoryResponse {
 
     private Long id;
@@ -30,7 +33,7 @@ public class CategoryResponse {
 
     /** flat 목록용 — children 빈 리스트 */
     public static CategoryResponse from(Category category) {
-        return from(category, List.of());
+        return from(category, new ArrayList<>());
     }
 
     /** 명시적 children 목록으로 생성 (트리 빌드 시 사용) */

--- a/src/main/java/com/stockmanagement/domain/product/category/service/CategoryService.java
+++ b/src/main/java/com/stockmanagement/domain/product/category/service/CategoryService.java
@@ -9,6 +9,8 @@ import com.stockmanagement.domain.product.category.entity.Category;
 import com.stockmanagement.domain.product.category.repository.CategoryRepository;
 import com.stockmanagement.domain.product.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,6 +18,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * 카테고리 비즈니스 로직.
@@ -30,6 +33,7 @@ public class CategoryService {
     private final CategoryRepository categoryRepository;
     private final ProductRepository productRepository;
 
+    @CacheEvict(cacheNames = "categories", allEntries = true)
     @Transactional
     public CategoryResponse create(CategoryCreateRequest request) {
         if (categoryRepository.existsByName(request.getName())) {
@@ -45,16 +49,18 @@ public class CategoryService {
     }
 
     /** flat 목록 — 전체 카테고리를 parentId·parentName 포함해 반환 */
+    @Cacheable(cacheNames = "categories", key = "'list'")
     public List<CategoryResponse> getList() {
         return categoryRepository.findAll().stream()
                 .map(CategoryResponse::from)
-                .toList();
+                .collect(Collectors.toList());
     }
 
     /**
      * 트리 구조 — 최상위 카테고리를 루트로 children 목록을 채워 반환.
      * 전체 카테고리를 한 번에 로드해 in-memory로 조립한다.
      */
+    @Cacheable(cacheNames = "categories", key = "'tree'")
     public List<CategoryResponse> getTree() {
         List<Category> all = categoryRepository.findAll();
 
@@ -77,7 +83,7 @@ public class CategoryService {
 
         return roots.stream()
                 .map(r -> CategoryResponse.from(r, childrenMap.get(r.getId())))
-                .toList();
+                .collect(Collectors.toList());
     }
 
     /** 단건 조회 — children(하위 카테고리) 목록 포함 */
@@ -85,10 +91,11 @@ public class CategoryService {
         Category category = findByIdWithChildren(id);
         List<CategoryResponse> children = category.getChildren().stream()
                 .map(CategoryResponse::from)
-                .toList();
+                .collect(Collectors.toList());
         return CategoryResponse.from(category, children);
     }
 
+    @CacheEvict(cacheNames = "categories", allEntries = true)
     @Transactional
     public CategoryResponse update(Long id, CategoryUpdateRequest request) {
         Category category = findById(id);
@@ -109,6 +116,7 @@ public class CategoryService {
         return CategoryResponse.from(category);
     }
 
+    @CacheEvict(cacheNames = "categories", allEntries = true)
     @Transactional
     public void delete(Long id) {
         Category category = findByIdWithChildren(id);

--- a/src/test/java/com/stockmanagement/domain/inventory/scheduler/InventorySnapshotSchedulerTest.java
+++ b/src/test/java/com/stockmanagement/domain/inventory/scheduler/InventorySnapshotSchedulerTest.java
@@ -1,6 +1,5 @@
 package com.stockmanagement.domain.inventory.scheduler;
 
-import com.stockmanagement.domain.inventory.entity.DailyInventorySnapshot;
 import com.stockmanagement.domain.inventory.entity.Inventory;
 import com.stockmanagement.domain.inventory.repository.DailyInventorySnapshotRepository;
 import com.stockmanagement.domain.inventory.repository.InventoryRepository;
@@ -10,6 +9,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
@@ -26,38 +28,39 @@ class InventorySnapshotSchedulerTest {
 
     @Mock InventoryRepository inventoryRepository;
     @Mock DailyInventorySnapshotRepository snapshotRepository;
+    @Mock InventorySnapshotProcessor snapshotProcessor;
     @InjectMocks InventorySnapshotScheduler scheduler;
 
     @Test
-    @DisplayName("스냅샷 미존재 시 saveAll()로 배치 저장")
+    @DisplayName("스냅샷 미존재 시 processBatch() 호출")
     void savesSnapshotWhenNotExists() {
         Inventory inv = buildInventory(1L, 100, 10, 5);
-        given(inventoryRepository.findAll()).willReturn(List.of(inv));
-        // 오늘 스냅샷이 없는 상태 — 빈 Set 반환
+        Page<Inventory> page = new PageImpl<>(List.of(inv));
+        given(inventoryRepository.findAll(any(Pageable.class))).willReturn(page);
         given(snapshotRepository.findInventoryIdsBySnapshotDate(any(LocalDate.class)))
                 .willReturn(Set.of());
-        given(snapshotRepository.saveAll(anyList()))
-                .willAnswer(invocation -> invocation.getArgument(0));
+        given(snapshotProcessor.processBatch(anyList(), anySet(), any(LocalDate.class)))
+                .willReturn(1);
 
         scheduler.takeSnapshot();
 
-        verify(snapshotRepository).saveAll(anyList());
+        verify(snapshotProcessor).processBatch(anyList(), anySet(), any(LocalDate.class));
     }
 
     @Test
-    @DisplayName("스냅샷 이미 존재 시 saveAll()에 빈 목록 전달 (저장 없음)")
-    void skipsWhenSnapshotAlreadyExists() {
+    @DisplayName("스냅샷 이미 존재 시 alreadySnapped에 inventoryId 포함하여 processor에 전달")
+    void passesAlreadySnappedToProcessor() {
         Inventory inv = buildInventory(1L, 100, 10, 5);
-        given(inventoryRepository.findAll()).willReturn(List.of(inv));
-        // inventoryId=1L이 이미 존재하는 상태
+        Page<Inventory> page = new PageImpl<>(List.of(inv));
+        given(inventoryRepository.findAll(any(Pageable.class))).willReturn(page);
         given(snapshotRepository.findInventoryIdsBySnapshotDate(any(LocalDate.class)))
                 .willReturn(Set.of(1L));
-        given(snapshotRepository.saveAll(anyList()))
-                .willAnswer(invocation -> invocation.getArgument(0));
+        given(snapshotProcessor.processBatch(anyList(), anySet(), any(LocalDate.class)))
+                .willReturn(0);
 
         scheduler.takeSnapshot();
 
-        verify(snapshotRepository).saveAll(List.of());
+        verify(snapshotProcessor).processBatch(anyList(), eq(Set.of(1L)), any(LocalDate.class));
     }
 
     // ===== 헬퍼 =====


### PR DESCRIPTION
## Summary

- **#7** `InventoryRepository` — `findByProductId`, `findAllByProductIdIn`에 `@EntityGraph({"product"})` 추가, 재고 조회 시 N+1 쿼리 제거
- **#8** `CategoryService` — `getList`/`getTree` `@Cacheable` (30분 TTL), `create`/`update`/`delete` `@CacheEvict(allEntries=true)`. `As.WRAPPER_ARRAY`로 List 직렬화 호환성 확보, `CategoryResponse` `@Jacksonized` 추가
- **#9** `InventorySnapshotScheduler` — 전체 `findAll()` 단일 트랜잭션 → 1,000건 `PageRequest` 루프 + `InventorySnapshotProcessor` 분리로 배치마다 독립 트랜잭션 커밋 (힙 과부하·락 경합 해소)

## Test plan

- [x] 605개 단위·컨트롤러·통합 테스트 전체 통과
- [x] `BatchIntegrationTest` — 스냅샷 배치 처리 검증
- [x] `ProductSearchIntegrationTest` — 카테고리 캐시 직렬화/역직렬화 검증 포함