### PR TITLE
perf/fix/docs: N+1 최적화·버그 수정·전체 문서 최신화

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ Spring Boot 기반 **쇼핑몰 백엔드 포트폴리오 프로젝트**.
 | **동시성 제어** | 재고 뮤테이션에 분산 락(Redisson) + 비관적 락(DB) 2중 적용 — EC2 2대 멀티 인스턴스 환경의 overselling 차단. 결제 취소에 비관적 락으로 TOCTOU 경쟁 조건(이중 환불) 차단 |
 | **결제 정합성** | `Propagation.REQUIRES_NEW`로 결제 커밋 보장 — 배송·포인트 실패 시 `UnexpectedRollbackException`으로 결제가 롤백되는 버그 수정. `prepare`·`confirm`·`cancel` 3단계 멱등성(DB UNIQUE + Redis SETNX + Toss `Idempotency-Key`) |
 | **이벤트 신뢰성** | Transactional Outbox 패턴 — 이벤트와 비즈니스 로직을 동일 트랜잭션으로 묶어 JVM 크래시 시 이벤트 유실 0 보장. Prometheus `outbox.dead_letters` 게이지로 실시간 모니터링 |
-| **N+1 최적화** | `getMyCoupons()` 쿼리 101→3건(97% 감소), 스냅샷 INSERT 1,000→1건. `@EntityGraph` + `default_batch_fetch_size=50` + 복합 인덱스 |
+| **N+1 최적화** | `getMyCoupons()` 쿼리 101→3건(97% 감소), 스냅샷 INSERT 1,000→1건. `@EntityGraph` + `default_batch_fetch_size=50` + 복합 인덱스. `CategoryService.getList/getTree()` Redis 캐시(30분 TTL) — 카테고리 조회 DB I/O 제거 |
 | **Redis 원자성** | 로그인 Rate Limit INCR+EXPIRE 비원자 연산 → Lua 스크립트 원자화 — 앱 크래시 시 TTL 누락으로 계정이 영구 잠금되는 버그 수정 |
 | **쿠폰 동시성** | 한정 수량 쿠폰 차감 시 `PESSIMISTIC_WRITE` + TOCTOU 재검증 — 이중 사용 및 초과 발급 방지 |
 | **보안** | IDOR 소유권 검증 4개 엔드포인트, 가격 조작 방어(DB canonical price 강제), JWT `userId` 클레임으로 인증 DB round-trip 제거, Toss Webhook HMAC-SHA256 서명 검증 |
 | **ES 검색 + Fallback** | 상품 키워드·가격·카테고리 복합 검색(Elasticsearch), 장애 시 자동 MySQL fallback |
 | **Circuit Breaker** | TossPayments HTTP 호출 실패 누적 시 회로 차단 → 빠른 실패 응답 |
 | **배치 처리** | 쿠폰 만료 비활성화·일별 재고 스냅샷·일별 주문 통계 스케줄러 (`@Scheduled`, `@ConditionalOnProperty`, 멱등성 보장) |
-| **테스트 피라미드** | 단위·컨트롤러·통합 테스트 **601개** 전체 통과, Testcontainers로 실제 MySQL·Redis·ES 사용 |
+| **테스트 피라미드** | 단위·컨트롤러·통합 테스트 **605개** 전체 통과, Testcontainers로 실제 MySQL·Redis·ES 사용 |
 
 ---
 
@@ -40,8 +40,9 @@ DAU 50,000명 / 피크 TPS 1,000 req/s / EC2 2대(ALB 뒤 독립 JVM) 규모를 
 | 4 | 결제 트랜잭션 정합성 | REQUIRES_NEW → UnexpectedRollbackException + 결제 유실 버그 수정 |
 | 5 | 결제 멱등성 | 3중 방어 + Redis SPOF 대응 전략 |
 | 6 | Transactional Outbox | 이벤트 유실 0 보장 |
-| 7 | N+1 / 배치 최적화 | 쿼리 97% 감소, INSERT 99.9% 감소 |
+| 7 | N+1 / 배치 최적화 | `@EntityGraph` + 페이지 단위 배치 처리, 쿼리 97% 감소 |
 | 8 | 보안 취약점 | IDOR·가격 조작·JWT round-trip·Webhook 위조 |
+| 9 | Redis 캐시 정합성 | `CategoryService` 캐시 직렬화 3중 문제 해결 (WRAPPER_ARRAY·ArrayList·@Jacksonized) |
 
 ---
 
@@ -96,7 +97,7 @@ docker compose -f docker/docker-compose.yml up -d mysql redis elasticsearch
 ./gradlew bootRun
 ```
 
-Flyway가 기동 시 V1~V24 마이그레이션을 자동 실행합니다.
+Flyway가 기동 시 V1~V28 마이그레이션을 자동 실행합니다.
 
 ### 환경 변수
 
@@ -138,7 +139,7 @@ Flyway가 기동 시 V1~V24 마이그레이션을 자동 실행합니다.
 | 통합 | `integration/` | Testcontainers (MySQL + Redis + ES), Flyway 실행, 실제 HTTP 흐름 E2E |
 | 동시성 | `integration/InventoryConcurrencyTest` | 동시 입고 lost update · 재고 예약 overselling 검증 |
 
-현재 총 **601개** 테스트 전체 통과.
+현재 총 **605개** 테스트 전체 통과.
 
 ---
 
@@ -233,7 +234,7 @@ erDiagram
         bigint product_id FK
         varchar image_url
         varchar object_key
-        varchar image_type "THUMBNAIL|DETAIL"
+        varchar image_type "THUMBNAIL|GALLERY"
         int display_order
     }
     reviews {
@@ -312,7 +313,7 @@ erDiagram
         varchar payment_key "Toss 발급, DONE 이후 설정"
         varchar toss_order_id UK
         decimal amount
-        varchar status "PENDING|DONE|FAILED|CANCELLED"
+        varchar status "PENDING|DONE|FAILED|CANCELLED|PARTIAL_CANCELLED"
         varchar method "카드|가상계좌 등"
         datetime requested_at
         datetime approved_at
@@ -333,6 +334,13 @@ erDiagram
         datetime valid_from
         datetime valid_until
         tinyint active
+        tinyint is_public "0=발급 필요, 1=누구나 claim"
+    }
+    user_coupons {
+        bigint id PK
+        bigint user_id FK
+        bigint coupon_id FK
+        datetime issued_at
     }
     coupon_usages {
         bigint id PK
@@ -374,6 +382,7 @@ erDiagram
         bigint id PK
         bigint payment_id UK "FK, 결제당 1건"
         bigint order_id FK
+        bigint user_id "소유권 검증 비정규화"
         decimal amount
         varchar reason
         varchar status "PENDING|COMPLETED|FAILED"
@@ -382,8 +391,7 @@ erDiagram
 
     %% ── SYSTEM ───────────────────────────────────────────
     system_settings {
-        bigint id PK
-        varchar setting_key UK
+        varchar setting_key PK "키-값 구조"
         varchar setting_value
         varchar description
         datetime updated_at
@@ -399,6 +407,7 @@ erDiagram
     users ||--o| user_points : "포인트 잔액 (1:1)"
     users ||--o{ point_transactions : "포인트 이력"
     users ||--o{ coupon_usages : "쿠폰 사용"
+    users ||--o{ user_coupons : "발급 쿠폰"
 
     categories ||--o{ categories : "하위 카테고리"
     categories ||--o{ products : "상품 분류"
@@ -415,6 +424,7 @@ erDiagram
     delivery_addresses ||--o{ orders : "배송지 적용"
 
     coupons ||--o{ coupon_usages : "사용 이력"
+    coupons ||--o{ user_coupons : "발급 이력"
 
     orders ||--|{ order_items : "주문 항목"
     orders ||--o{ order_status_history : "상태 이력"
@@ -587,6 +597,7 @@ stateDiagram-v2
         [*] --> PENDING : 환불 요청
         PENDING --> COMPLETED : Toss 취소 성공
         PENDING --> FAILED : Toss 취소 실패
+        FAILED --> PENDING : 재시도 (reset)
     }
 ```
 
@@ -737,8 +748,12 @@ available = onHand - reserved - allocated
 | V20 | `user_points`, `point_transactions`, `orders.used_points` — 포인트 |
 | V21 | `refunds` — 환불 이력 |
 | V22 | `user_coupons` — 관리자 쿠폰 발급 이력 |
-| V23 | `orders` 복합 인덱스 추가 (성능) |
+| V23 | `orders` 인덱스 추가 (`user_id`, `status`, `user_id+status` 복합) |
 | V24 | `system_settings` — 동적 시스템 설정 (저재고 임계값 등) |
+| V25 | `inventory_transactions(inventory_id, created_at)` 복합 인덱스 — filesort 제거 |
+| V26 | `coupons.is_public` 추가 — 공개 프로모 쿠폰 여부 |
+| V27 | `orders.created_at` 인덱스, `point_transactions(user_id, order_id)` 복합 인덱스 |
+| V28 | `refunds.user_id` 추가 — 소유권 검증 비정규화 |
 
 ---
 
@@ -755,6 +770,9 @@ available = onHand - reserved - allocated
 | POST | `/api/auth/logout` | 로그아웃 (JWT 블랙리스트 + Refresh Token revoke) | 공개 |
 | POST | `/api/auth/refresh` | Access Token 재발급 (Refresh Token rotation) | 공개 |
 | GET | `/api/users/me` | 내 정보 조회 | USER |
+| PATCH | `/api/users/me` | 프로필 수정 (이메일 변경) | USER |
+| PATCH | `/api/users/me/password` | 비밀번호 변경 (성공 시 Refresh Token 일괄 폐기) | USER |
+| GET | `/api/users/me/orders` | 내 주문 목록 (최신순, 페이징) | USER |
 | DELETE | `/api/users/me` | 회원 탈퇴 (Soft Delete + Refresh Token 일괄 폐기) | USER |
 
 ### 상품
@@ -769,11 +787,14 @@ available = onHand - reserved - allocated
 
 ### 카테고리
 
+> Redis 캐시 30분 TTL 적용 (`getList`, `getTree`)
+
 | Method | Endpoint | 설명 | 권한 |
 |---|---|---|---|
 | POST | `/api/categories` | 카테고리 생성 | ADMIN |
-| GET | `/api/categories` | 카테고리 트리 조회 (parent-child) | 공개 |
-| GET | `/api/categories/{id}` | 카테고리 단건 조회 | 공개 |
+| GET | `/api/categories` | 카테고리 flat 목록 (children 빈 리스트) | 공개 |
+| GET | `/api/categories/tree` | 카테고리 트리 조회 (parent-child 2단계) | 공개 |
+| GET | `/api/categories/{id}` | 카테고리 단건 조회 (children 포함) | 공개 |
 | PUT | `/api/categories/{id}` | 카테고리 수정 | ADMIN |
 | DELETE | `/api/categories/{id}` | 카테고리 삭제 (하위·상품 존재 시 거부) | ADMIN |
 
@@ -825,10 +846,13 @@ available = onHand - reserved - allocated
 
 | Method | Endpoint | 설명 | 권한 |
 |---|---|---|---|
-| POST | `/api/coupons` | 쿠폰 생성 | ADMIN |
+| POST | `/api/coupons` | 쿠폰 생성 (`isPublic`으로 공개/비공개 구분) | ADMIN |
 | GET | `/api/coupons` | 쿠폰 목록 (페이징) | ADMIN |
 | GET | `/api/coupons/{id}` | 쿠폰 상세 | ADMIN |
 | PATCH | `/api/coupons/{id}/deactivate` | 쿠폰 비활성화 | ADMIN |
+| POST | `/api/coupons/{id}/issue` | 특정 사용자에게 쿠폰 직접 발급 | ADMIN |
+| GET | `/api/coupons/my` | 내 쿠폰 목록 + 사용 횟수 | USER |
+| POST | `/api/coupons/claim` | 공개 쿠폰 코드 등록 (`isPublic=true`만 가능) | USER |
 | POST | `/api/coupons/validate` | 쿠폰 유효성 확인 + 할인 금액 미리보기 | USER |
 
 ### 결제

--- a/docs/API.md
+++ b/docs/API.md
@@ -94,6 +94,26 @@ Authorization: Bearer <accessToken>
 { "id": 1, "username": "user1", "email": "user1@example.com", "role": "USER" }
 ```
 
+### `PATCH /api/users/me`
+
+> 권한: USER | 이메일 수정. 중복 이메일이면 409
+
+```json
+{ "email": "new@example.com" }
+```
+
+### `PATCH /api/users/me/password`
+
+> 권한: USER | 현재 비밀번호 확인 후 변경. 성공 시 Refresh Token 일괄 폐기 (204 No Content)
+
+```json
+{ "currentPassword": "OldPass1!", "newPassword": "NewPass1!" }
+```
+
+### `GET /api/users/me/orders`
+
+> 권한: USER | 내 주문 목록 (최신순, 기본 20건 페이징)
+
 ### `DELETE /api/users/me`
 
 > 권한: USER | Soft Delete (`deleted_at` 설정) + 해당 사용자 Refresh Token 일괄 폐기
@@ -142,9 +162,15 @@ Authorization: Bearer <accessToken>
 
 ## 카테고리
 
+> Redis 캐시 적용 (30분 TTL). 생성·수정·삭제 시 자동 evict.
+
 ### `GET /api/categories`
 
-> 권한: 공개 | parent-child 2단계 트리 in-memory 조립 후 반환
+> 권한: 공개 | flat 목록 (children 빈 리스트). 캐시키: `categories::list`
+
+### `GET /api/categories/tree`
+
+> 권한: 공개 | parent-child 2단계 트리 in-memory 조립. 캐시키: `categories::tree`
 
 ```json
 // 응답 예시
@@ -156,12 +182,24 @@ Authorization: Bearer <accessToken>
 ]
 ```
 
+### `GET /api/categories/{id}`
+
+> 권한: 공개 | 단건 조회. children(하위 카테고리) 포함
+
 ### `POST /api/categories`
 
 > 권한: ADMIN
 
 ```json
 { "name": "노트북", "parentId": 1 }   // parentId null이면 최상위
+```
+
+### `PUT /api/categories/{id}`
+
+> 권한: ADMIN | 이름·설명·부모 카테고리 수정
+
+```json
+{ "name": "노트북 PC", "description": "휴대용 개인 컴퓨터", "parentId": 1 }
 ```
 
 ### `DELETE /api/categories/{id}`
@@ -369,9 +407,36 @@ Authorization: Bearer <accessToken>
 | `FIXED_AMOUNT` | `min(discountValue, orderAmount)` |
 | `PERCENTAGE` | `min(orderAmount × rate / 100, maxDiscountAmount)` |
 
+- `isPublic = true`: 코드를 아는 누구나 claim 가능한 공개 프로모 코드
+- `isPublic = false` (기본값): ADMIN이 특정 사용자에게 직접 발급해야 함
+
+### `GET /api/coupons`
+
+> 권한: ADMIN | 쿠폰 목록 (페이징)
+
+### `GET /api/coupons/{id}`
+
+> 권한: ADMIN | 쿠폰 단건 조회
+
+### `PATCH /api/coupons/{id}/deactivate`
+
+> 권한: ADMIN | 쿠폰 비활성화 (`active = false`). 이미 발급된 쿠폰은 사용 불가 처리
+
+### `POST /api/coupons/{id}/issue`
+
+> 권한: ADMIN | 특정 사용자에게 쿠폰 직접 발급 (`isPublic = false` 쿠폰 배포 시 사용)
+
+```json
+{ "userId": 42 }
+```
+
+### `GET /api/coupons/my`
+
+> 권한: USER | 내 지갑의 쿠폰 목록 + 각 쿠폰별 사용 횟수 포함
+
 ### `POST /api/coupons/claim`
 
-> 권한: USER | `isPublic = true` 쿠폰만 발급 가능. 중복 발급 불가
+> 권한: USER | `isPublic = true` 쿠폰만 등록 가능. 중복 등록 불가
 
 ```json
 { "couponCode": "SUMMER20" }
@@ -427,9 +492,19 @@ Authorization: Bearer <accessToken>
 3. Order `CANCELLED`, allocated 해제
 4. 쿠폰 반환 + 포인트 반환 + 적립 포인트 회수
 
+### `GET /api/payments/order/{orderId}`
+
+> 권한: USER | 주문 ID로 결제 조회. 결제 전이면 `data: null` 반환
+
+### `GET /api/payments/{paymentKey}`
+
+> 권한: USER | 결제 단건 조회
+
 ### `POST /api/payments/webhook`
 
 > 권한: 공개 | `Toss-Signature` 헤더 HMAC-SHA256 검증 후 처리
+>
+> 가상계좌 결제 DONE 이벤트 처리: 주문 CONFIRMED, 배송 PREPARING 자동 생성, 포인트 적립
 
 ---
 

--- a/docs/DB.md
+++ b/docs/DB.md
@@ -1,6 +1,6 @@
 # DB 스키마
 
-MySQL 8, Flyway 마이그레이션 (V1~V15), ENGINE=InnoDB, CHARSET=utf8mb4
+MySQL 8, Flyway 마이그레이션 (V1~V28), ENGINE=InnoDB, CHARSET=utf8mb4
 
 ---
 
@@ -23,6 +23,19 @@ MySQL 8, Flyway 마이그레이션 (V1~V15), ENGINE=InnoDB, CHARSET=utf8mb4
 | V13 | `coupons`, `coupon_usages` + `orders.coupon_id/discount_amount` | 쿠폰 |
 | V14 | `categories` + `products.category_id` FK (category VARCHAR 제거) | 카테고리 분리 |
 | V15 | `daily_order_stats`, `daily_inventory_snapshots` | 배치 집계 테이블 |
+| V16 | `users.deleted_at` 컬럼 추가 | 회원 Soft Delete |
+| V17 | `product_images` + `products.thumbnail_url` 컬럼 추가 | 상품 이미지 (MinIO Presigned URL) |
+| V18 | `outbox_events` | Transactional Outbox — 이벤트 유실 방지 |
+| V19 | `reviews`, `wishlist_items` | 리뷰(실구매자 한정) + 위시리스트 |
+| V20 | `user_points`, `point_transactions` + `orders.used_points` 컬럼 추가 | 포인트/적립금 시스템 |
+| V21 | `refunds` | 환불 이력 |
+| V22 | `user_coupons` | 사용자별 쿠폰 발급 이력 |
+| V23 | `orders` 인덱스 추가 | `idx_orders_user_id`, `idx_orders_status`, `idx_orders_user_status` |
+| V24 | `system_settings` | 런타임 변경 가능한 시스템 설정 (저재고 임계값 등) |
+| V25 | `inventory_transactions` 복합 인덱스 추가 | `(inventory_id, created_at)` — filesort 제거 |
+| V26 | `coupons.is_public` 컬럼 추가 | 공개 쿠폰 여부 (누구나 claim 가능) |
+| V27 | `orders.created_at` 인덱스, `point_transactions` 복합 인덱스 추가 | 통계 집계 / 환불 조회 최적화 |
+| V28 | `refunds.user_id` 컬럼 추가 | 소유권 검증 시 orders 추가 조회 제거 (비정규화) |
 
 ---
 
@@ -32,17 +45,27 @@ MySQL 8, Flyway 마이그레이션 (V1~V15), ENGINE=InnoDB, CHARSET=utf8mb4
 categories ──────────────┐
                          ▼
 users ──────────── orders ──────── order_items ──── products
-  │                  │   │                             │ 1
-  │                  │   └── coupon_id → coupons       │
-  │                  │   └── delivery_address_id ──┐   │
-  │                  │                             │ inventory
-  │                  ├── order_status_history       │       │
-  │                  ├── payments                  delivery  inventory_transactions
-  │                  └── shipments                 _addresses
-  │
+  │                  │   │                         │     │
+  │                  │   └── coupon_id → coupons   │  inventory
+  │                  │   └── delivery_address_id ─┐│       │
+  │                  │                            ││  inventory_transactions
+  │                  ├── order_status_history      │delivery_addresses
+  │                  ├── payments ──── refunds     │
+  │                  └── shipments                 │
+  │                                               (ON DELETE SET NULL)
   ├── cart_items → products
   ├── delivery_addresses
-  └── coupon_usages → coupons
+  ├── coupon_usages → coupons
+  ├── user_coupons → coupons
+  ├── user_points
+  ├── point_transactions
+  ├── reviews → products
+  └── wishlist_items → products
+
+이벤트 / 설정:
+  outbox_events      (Transactional Outbox 발행 큐)
+  system_settings    (런타임 설정, PK: setting_key)
+  product_images     (MinIO 오브젝트 메타데이터, product FK)
 
 배치 집계:
   daily_order_stats         (일별 주문·매출)
@@ -53,7 +76,7 @@ users ──────────── orders ──────── order
 
 ## 테이블 상세
 
-### products (V1, V14에서 category 컬럼 제거 + category_id 추가)
+### products (V1, V14에서 category_id 추가, V17에서 thumbnail_url 추가)
 
 | 컬럼 | 타입 | 제약 | 설명 |
 |---|---|---|---|
@@ -64,6 +87,7 @@ users ──────────── orders ──────── order
 | sku | VARCHAR(100) | NOT NULL, **UNIQUE** | 재고 관리 코드 |
 | category_id | BIGINT | NULL, FK→categories (ON DELETE SET NULL) | V14에서 추가 |
 | status | VARCHAR(20) | NOT NULL, DEFAULT 'ACTIVE' | `ACTIVE` / `INACTIVE` / `DISCONTINUED` |
+| thumbnail_url | VARCHAR(500) | NULL | V17에서 추가. 대표 이미지 URL |
 | created_at | DATETIME(6) | NOT NULL | |
 | updated_at | DATETIME(6) | NOT NULL | |
 
@@ -88,20 +112,23 @@ users ──────────── orders ──────── order
 
 ---
 
-### orders (V3, V5·V12·V13에서 컬럼 추가)
+### orders (V3, V5·V12·V13·V20에서 컬럼 추가)
 
 | 컬럼 | 타입 | 제약 | 설명 |
 |---|---|---|---|
 | id | BIGINT | PK, AUTO_INCREMENT | |
-| user_id | BIGINT | NOT NULL, FK→users | V5에서 추가 |
-| status | VARCHAR(20) | NOT NULL, DEFAULT 'PENDING' | `PENDING` / `CONFIRMED` / `CANCELLED` |
+| user_id | BIGINT | NOT NULL, FK→users, INDEX(V23) | V5에서 추가 |
+| status | VARCHAR(20) | NOT NULL, DEFAULT 'PENDING', INDEX(V23) | `PENDING` / `CONFIRMED` / `CANCELLED` |
 | total_amount | DECIMAL(12,2) | NOT NULL | 주문 항목 합계 |
 | idempotency_key | VARCHAR(100) | NOT NULL, **UNIQUE** | 클라이언트 발급 UUID |
 | delivery_address_id | BIGINT | NULL, FK→delivery_addresses (ON DELETE SET NULL) | V12에서 추가 |
 | coupon_id | BIGINT | NULL, FK→coupons (ON DELETE SET NULL) | V13에서 추가 |
 | discount_amount | DECIMAL(19,2) | NOT NULL, DEFAULT 0 | V13에서 추가. 쿠폰 할인 금액 |
-| created_at | DATETIME(6) | NOT NULL | |
+| used_points | BIGINT | NOT NULL, DEFAULT 0 | V20에서 추가. 주문 시 사용 포인트 |
+| created_at | DATETIME(6) | NOT NULL, INDEX(V27) | |
 | updated_at | DATETIME(6) | NOT NULL | |
+
+> 복합 인덱스: `(user_id, status)` — V23 추가
 
 ---
 
@@ -140,7 +167,7 @@ users ──────────── orders ──────── order
 
 ---
 
-### users (V5)
+### users (V5, V16에서 deleted_at 추가)
 
 | 컬럼 | 타입 | 제약 | 설명 |
 |---|---|---|---|
@@ -151,6 +178,7 @@ users ──────────── orders ──────── order
 | role | VARCHAR(20) | NOT NULL, DEFAULT 'USER' | `USER` / `ADMIN` |
 | created_at | DATETIME(6) | NOT NULL | |
 | updated_at | DATETIME(6) | NOT NULL | |
+| deleted_at | DATETIME(6) | NULL | V16에서 추가. NOT NULL이면 탈퇴 계정 (`@SQLRestriction` 자동 필터링) |
 
 ---
 
@@ -233,7 +261,7 @@ users ──────────── orders ──────── order
 
 ---
 
-### coupons (V13)
+### coupons (V13, V26에서 is_public 추가)
 
 | 컬럼 | 타입 | 제약 | 설명 |
 |---|---|---|---|
@@ -251,6 +279,7 @@ users ──────────── orders ──────── order
 | valid_from | DATETIME(6) | NOT NULL | 유효 시작일 |
 | valid_until | DATETIME(6) | NOT NULL | 유효 종료일 |
 | active | TINYINT(1) | NOT NULL, DEFAULT 1 | 활성화 여부 |
+| is_public | TINYINT(1) | NOT NULL, DEFAULT 0 | V26에서 추가. 1이면 누구나 claim 가능한 공개 프로모 쿠폰 |
 | created_at | DATETIME(6) | NOT NULL | |
 | updated_at | DATETIME(6) | NOT NULL | |
 
@@ -268,6 +297,148 @@ users ──────────── orders ──────── order
 | used_at | DATETIME(6) | NOT NULL | |
 
 > INDEX: `(coupon_id, user_id)`
+
+---
+
+### product_images (V17)
+
+| 컬럼 | 타입 | 제약 | 설명 |
+|---|---|---|---|
+| id | BIGINT | PK, AUTO_INCREMENT | |
+| product_id | BIGINT | NOT NULL, FK→products (ON DELETE CASCADE) | |
+| image_url | VARCHAR(500) | NOT NULL | 접근 URL |
+| object_key | VARCHAR(500) | NOT NULL | MinIO(S3) 오브젝트 키 (삭제 시 사용) |
+| image_type | VARCHAR(20) | NOT NULL | `THUMBNAIL` / `GALLERY` 등 |
+| display_order | INT | NOT NULL, DEFAULT 0 | 이미지 노출 순서 |
+| created_at | DATETIME(6) | NOT NULL | |
+
+---
+
+### outbox_events (V18)
+
+> Transactional Outbox 패턴: 비즈니스 TX와 동일 TX에 저장 → `OutboxEventRelayScheduler`(5초 폴링)가 이벤트 발행
+
+| 컬럼 | 타입 | 제약 | 설명 |
+|---|---|---|---|
+| id | BIGINT | PK, AUTO_INCREMENT | |
+| event_type | VARCHAR(50) | NOT NULL | 이벤트 종류 (`OutboxEventType` enum) |
+| payload | TEXT | NOT NULL | 이벤트 데이터 (JSON) |
+| created_at | DATETIME(6) | NOT NULL | |
+| published_at | DATETIME(6) | NULL | NULL = 미발행 |
+| retry_count | INT | NOT NULL, DEFAULT 0 | 재시도 횟수 |
+| failed_at | DATETIME(6) | NULL | 최근 발행 실패 시각 |
+
+> INDEX: `(published_at, retry_count, created_at)` — 미발행 이벤트 폴링
+
+---
+
+### reviews (V19)
+
+> 실구매자(status=CONFIRMED 주문 보유)만 작성 가능. 상품당 1인 1리뷰
+
+| 컬럼 | 타입 | 제약 | 설명 |
+|---|---|---|---|
+| id | BIGINT | PK, AUTO_INCREMENT | |
+| product_id | BIGINT | NOT NULL, FK→products (ON DELETE CASCADE) | |
+| user_id | BIGINT | NOT NULL, FK→users | |
+| rating | TINYINT | NOT NULL | 별점 1~5 |
+| title | VARCHAR(100) | NOT NULL | 리뷰 제목 |
+| content | TEXT | NOT NULL | 리뷰 본문 |
+| created_at | DATETIME(6) | NOT NULL | |
+| updated_at | DATETIME(6) | NOT NULL | |
+
+> UK: `(product_id, user_id)` — 1인 1리뷰 제약
+
+---
+
+### wishlist_items (V19)
+
+| 컬럼 | 타입 | 제약 | 설명 |
+|---|---|---|---|
+| id | BIGINT | PK, AUTO_INCREMENT | |
+| user_id | BIGINT | NOT NULL, FK→users | |
+| product_id | BIGINT | NOT NULL, FK→products (ON DELETE CASCADE) | |
+| created_at | DATETIME(6) | NOT NULL | |
+
+> UK: `(user_id, product_id)` — 중복 저장 방지
+
+---
+
+### user_points (V20)
+
+> 사용자별 포인트 잔액 단일 행. 동시성 제어: 비관적 락(SELECT FOR UPDATE)
+
+| 컬럼 | 타입 | 제약 | 설명 |
+|---|---|---|---|
+| id | BIGINT | PK, AUTO_INCREMENT | |
+| user_id | BIGINT | NOT NULL, **UNIQUE**, FK→users | |
+| balance | BIGINT | NOT NULL, DEFAULT 0 | 현재 포인트 잔액 |
+| updated_at | DATETIME(6) | NOT NULL | |
+
+---
+
+### point_transactions (V20)
+
+| 컬럼 | 타입 | 제약 | 설명 |
+|---|---|---|---|
+| id | BIGINT | PK, AUTO_INCREMENT | |
+| user_id | BIGINT | NOT NULL, FK→users | |
+| amount | BIGINT | NOT NULL | 변동 금액 (양수=적립/환불, 음수=사용/소멸) |
+| type | VARCHAR(20) | NOT NULL | `EARN` / `USE` / `REFUND` / `EXPIRE` |
+| description | VARCHAR(200) | NOT NULL | 변동 사유 |
+| order_id | BIGINT | NULL | 연관 주문 ID |
+| created_at | DATETIME(6) | NOT NULL | |
+
+> 복합 인덱스: `(user_id, order_id)` — V27 추가. 환불 시 주문별 포인트 내역 조회
+
+---
+
+### refunds (V21, V28에서 user_id 추가)
+
+> 결제당 1건 환불. 실패(FAILED) 상태이면 `reset()` 후 재시도 가능
+
+| 컬럼 | 타입 | 제약 | 설명 |
+|---|---|---|---|
+| id | BIGINT | PK, AUTO_INCREMENT | |
+| payment_id | BIGINT | NOT NULL, **UNIQUE**, FK→payments | 결제당 환불 1건 |
+| order_id | BIGINT | NOT NULL, FK→orders | |
+| user_id | BIGINT | NOT NULL, DEFAULT 0 | V28에서 추가. 소유권 검증용 비정규화 |
+| amount | DECIMAL(19,2) | NOT NULL | 환불 금액 |
+| reason | VARCHAR(300) | NOT NULL | 환불 사유 |
+| status | VARCHAR(20) | NOT NULL, DEFAULT 'PENDING' | `PENDING` / `COMPLETED` / `FAILED` |
+| created_at | DATETIME(6) | NOT NULL | |
+| completed_at | DATETIME(6) | NULL | 처리 완료 시각 |
+
+---
+
+### user_coupons (V22)
+
+> ADMIN이 특정 사용자에게 직접 발급한 쿠폰 매핑
+
+| 컬럼 | 타입 | 제약 | 설명 |
+|---|---|---|---|
+| id | BIGINT | PK, AUTO_INCREMENT | |
+| user_id | BIGINT | NOT NULL, FK→users | |
+| coupon_id | BIGINT | NOT NULL, FK→coupons | |
+| issued_at | DATETIME(6) | NOT NULL | |
+
+> UK: `(user_id, coupon_id)` — 중복 발급 방지
+
+---
+
+### system_settings (V24)
+
+> 런타임 변경 가능한 시스템 설정. `setting_key`가 PK (키-값 구조)
+
+| 컬럼 | 타입 | 제약 | 설명 |
+|---|---|---|---|
+| setting_key | VARCHAR(100) | **PK** | 설정 키 (예: `low_stock_threshold`) |
+| setting_value | VARCHAR(500) | NOT NULL | 설정값 (문자열) |
+| description | VARCHAR(255) | NULL | 설명 |
+| updated_by | VARCHAR(100) | NULL | 마지막 변경자 |
+| updated_at | DATETIME(6) | NOT NULL | |
+
+> 초기값: `low_stock_threshold = '10'`
 
 ---
 
@@ -322,11 +493,11 @@ users ──────────── orders ──────── order
 | `inventory.product_id` | → products.id | UNIQUE (1:1) |
 | `order_items.order_id` | → orders.id | |
 | `order_items.product_id` | → products.id | |
-| `orders.user_id` | → users.id | V5 추가 |
+| `orders.user_id` | → users.id | V5 추가, INDEX(V23) |
 | `orders.delivery_address_id` | → delivery_addresses.id | NULL, ON DELETE SET NULL, V12 추가 |
 | `orders.coupon_id` | → coupons.id | NULL, ON DELETE SET NULL, V13 추가 |
 | `payments.order_id` | → orders.id | UNIQUE (V8), 주문당 결제 1건 |
-| `inventory_transactions.inventory_id` | → inventory.id | INDEX 포함 |
+| `inventory_transactions.inventory_id` | → inventory.id | 복합 INDEX `(inventory_id, created_at)` V25 추가 |
 | `order_status_history.order_id` | → orders.id | ON DELETE CASCADE |
 | `cart_items.product_id` | → products.id | UK: (user_id, product_id) |
 | `shipments.order_id` | → orders.id | UNIQUE, 주문당 배송 1건 |
@@ -337,6 +508,17 @@ users ──────────── orders ──────── order
 | `products.category_id` | → categories.id | NULL, ON DELETE SET NULL, V14 추가 |
 | `categories.parent_id` | → categories.id | Self-referential, ON DELETE SET NULL |
 | `daily_inventory_snapshots.inventory_id` | → inventory.id | ON DELETE CASCADE |
+| `product_images.product_id` | → products.id | ON DELETE CASCADE, V17 추가 |
+| `reviews.product_id` | → products.id | ON DELETE CASCADE, V19 추가 |
+| `reviews.user_id` | → users.id | UK: (product_id, user_id) |
+| `wishlist_items.user_id` | → users.id | UK: (user_id, product_id), V19 추가 |
+| `wishlist_items.product_id` | → products.id | ON DELETE CASCADE |
+| `user_points.user_id` | → users.id | UNIQUE, V20 추가 |
+| `point_transactions.user_id` | → users.id | 복합 INDEX `(user_id, order_id)` V27 추가 |
+| `refunds.payment_id` | → payments.id | UNIQUE, V21 추가 |
+| `refunds.order_id` | → orders.id | INDEX 포함 |
+| `user_coupons.user_id` | → users.id | UK: (user_id, coupon_id), V22 추가 |
+| `user_coupons.coupon_id` | → coupons.id | |
 
 ---
 

--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -71,6 +71,9 @@ ALB가 요청을 두 인스턴스에 분산하므로 동일 상품 주문이 Ser
 |-----------|-----------|------|
 | API Server 2대 이상 | [1. 재고 동시성](#1-재고-동시성-제어) | JVM `synchronized`로는 인스턴스 간 동시성 제어 불가 → 분산 락 필요 |
 | 피크 TPS 1,000 | [8. JWT round-trip](#8-보안-취약점) | 인증마다 DB SELECT → 초당 1,000번 불필요한 쿼리 |
+| 피크 TPS 1,000 | [9. CategoryService 캐시](#9-categoryservice-redis-캐시) | 캐시 미적용 시 상품 목록 API 호출마다 `categories` SELECT → 초당 1,000번 불필요한 쿼리 |
+| 상품 페이지 조회 (20건) | [7. N+1 최적화](#7-n1-쿼리-및-배치-처리-최적화) | `InventoryRepository` `@EntityGraph` 누락 → product SELECT 20회 추가 |
+| 자정 배치 (재고 10,000건) | [7. N+1 최적화](#7-n1-쿼리-및-배치-처리-최적화) | 전체 재고 단일 트랜잭션 로드 → 힙 과부하 + 테이블 락 장시간 점유 |
 | 동시 주문 100건/분 | [1. 재고 동시성](#1-재고-동시성-제어), [2. TOCTOU](#2-결제-취소-이중-처리-경쟁-조건) | 재고 1개 남은 상품에 수십 건 동시 진입 → 초과 예약·이중 처리 현실화 |
 | 일 주문 5,000건 | [5. 결제 멱등성](#5-결제-멱등성) | 재시도율 0.1%만 가정해도 하루 5건의 중복 결제 위험 |
 | Redis 단일 인스턴스 | [3. Lua 원자성](#3-redis-rate-limit-원자성-결함), [5. 결제 멱등성](#5-결제-멱등성) | Redis 장애 시 3중 방어의 1레이어 소실 → 나머지 레이어 역할 명확화 |
@@ -87,6 +90,7 @@ ALB가 요청을 두 인스턴스에 분산하므로 동일 상품 주문이 Ser
 6. [이벤트 유실 — Transactional Outbox](#6-이벤트-유실--transactional-outbox)
 7. [N+1 쿼리 및 배치 처리 최적화](#7-n1-쿼리-및-배치-처리-최적화)
 8. [보안 취약점](#8-보안-취약점)
+9. [CategoryService Redis 캐시](#9-categoryservice-redis-캐시)
 
 ---
 
@@ -459,6 +463,25 @@ ReviewStats findReviewStatsByProductId(Long id);
 `OrderItem → Product`, `CartItem → Product` 등 연관 엔티티를 개별 접근할 때마다 SELECT 1건씩 추가.
 기본 설정에서는 배치 없이 1건씩만 로딩.
 
+**`InventoryRepository` — product fetch join 누락 (N+1)**
+
+`findByProductId()`, `findAllByProductIdIn()`이 `@EntityGraph` 없이 `Inventory`를 Lazy 로딩한다.
+`ProductService.enrichPage()`가 페이지 20건을 처리하며 각 `inventory.product`에 접근하면 product SELECT가 20번 추가 발생한다.
+
+```
+상품 목록 20건 조회 시:
+  SELECT * FROM inventory WHERE product_id = ?   →  20번 (N+1)
+  (Inventory 20개 × product Lazy 로딩)
+```
+
+**`InventorySnapshotScheduler` — 단일 트랜잭션 전체 로드**
+
+자정 스케줄러가 `inventoryRepository.findAll()`로 전체 재고를 한 번에 메모리에 올린다.
+재고 10,000건 기준:
+- JVM 힙에 수백 MB 객체 적재 → GC 압박
+- `findAll()` 부터 `saveAll()` 완료까지 트랜잭션이 유지되어 `inventory` 테이블 shared lock이 장시간 점유됨
+- 단일 커밋 실패 시 전체 스냅샷이 롤백되어 재시도 비용이 크다
+
 ### 해결 방법
 
 | 위치 | 변경 전 | 변경 후 |
@@ -469,6 +492,8 @@ ReviewStats findReviewStatsByProductId(Long id);
 | `ReviewRepository` | 집계 쿼리 2번 | avgRating + reviewCount 통합 단일 JPQL |
 | 전체 `@ManyToOne` | 1건씩 Lazy | `hibernate.default_batch_fetch_size=50` |
 | `inventory_transactions` | `inventory_id` 단일 인덱스 | `(inventory_id, created_at)` 복합 인덱스 |
+| `InventoryRepository` | `product` Lazy 로딩 (N+1) | `@EntityGraph({"product"})` — `findByProductId`, `findAllByProductIdIn` |
+| `InventorySnapshotScheduler` | `findAll()` 단일 트랜잭션 전체 로드 | `findAll(PageRequest.of(page, 1000))` 페이지 루프 + `InventorySnapshotProcessor`(@Component 분리)로 배치마다 독립 트랜잭션 커밋 |
 
 > **주의**: `@BatchSize`는 `@OneToMany`/`@ManyToMany` 컬렉션에만 적용 가능.
 > `@ManyToOne`에 붙이면 `AnnotationException` 발생 → `default_batch_fetch_size` 사용.
@@ -477,14 +502,20 @@ ReviewStats findReviewStatsByProductId(Long id);
 
 `default_batch_fetch_size`는 전역 설정이므로 배치 로딩이 불필요한 단건 조회에도 적용되어 미세한 메모리 오버헤드가 발생한다. `@EntityGraph` fetch join은 페이징(`Pageable`)과 함께 사용 시 `HibernateJpaDialect` 경고가 발생하므로, 컬렉션이 아닌 단일 연관 엔티티(`@ManyToOne`)에만 적용했다.
 
+`InventorySnapshotProcessor`를 별도 `@Component`로 분리한 이유: Spring AOP는 프록시 기반으로 동작하므로 동일 클래스 내 self-call은 프록시를 거치지 않아 `@Transactional`이 적용되지 않는다. 스케줄러 내부에 `@Transactional processBatch()` 메서드를 두어도 배치마다 독립 커밋이 되지 않기 때문에 외부 빈으로 분리해 호출해야 한다. 클래스가 하나 늘어나지만 `@Transactional` 전파 범위를 명시적으로 제어하기 위한 불가피한 설계다.
+
+페이지 단위 처리는 `findAll()` 한 번으로 전체를 보는 것보다 부분 실패 시 롤백 범위가 1페이지(1,000건)로 제한되는 장점도 있다. 단, 첫 페이지 조회 후 다른 인스턴스가 동일 날짜 스냅샷을 삽입하는 레이스 컨디션은 `DataIntegrityViolationException` catch로 방어하며 해당 배치를 스킵한다.
+
 ### 결과
 
 | 위치 | 변경 전 | 변경 후 | 개선율 |
 |------|---------|---------|--------|
 | `getMyCoupons()` (쿠폰 50개 기준) | 쿼리 101번 | 3번 | **97% 감소** |
-| `InventorySnapshotScheduler` (재고 1000건) | INSERT 1,000번 | 1번 | **99.9% 감소** |
+| `InventorySnapshotScheduler` (재고 1,000건) | INSERT 1,000번 | 1번 (`saveAll`) | **99.9% 감소** |
 | 상품 목록 `ReviewRepository` (상품 20개) | 집계 쿼리 40번 | 1번 | **97% 감소** |
 | `inventory_transactions` 이력 조회 | filesort 발생 | 인덱스 스캔 | filesort 제거 |
+| `InventoryRepository.findAllByProductIdIn` (상품 페이지 20건) | product SELECT 20번 (N+1) | JOIN 1번 | **95% 감소** |
+| `InventorySnapshotScheduler` 페이지 처리 (재고 10,000건) | 단일 트랜잭션, 힙 전체 로드 | 1,000건 단위 10회 독립 커밋 | 힙 사용량 **~1/10**, 락 점유 시간 **~1/10** |
 
 ---
 
@@ -555,6 +586,76 @@ JWT에 `userId`를 포함하면 토큰 크기가 소폭 증가한다. 또한 `us
 
 ---
 
+## 9. CategoryService Redis 캐시
+
+### 문제 인식
+
+`CategoryService.getList()`와 `getTree()`는 호출할 때마다 `categoryRepository.findAll()`을 실행하고, `getTree()`는 추가로 전체 카테고리를 순회해 부모-자식 트리를 in-memory에서 조립한다.
+
+카테고리는 관리자가 생성·수정·삭제할 때만 변경되는 **거의 정적인 데이터**다. 그런데 상품 목록 API(`GET /api/products`)는 카테고리 정보를 참조하기 위해 매 요청마다 이 메서드를 호출한다.
+
+```
+피크 TPS 1,000 기준:
+  상품 목록 API 1,000회/s
+  → CategoryService.getList() 1,000회/s
+  → SELECT * FROM categories 1,000회/s  (비즈니스 로직 없이 인증 오버헤드와 동급)
+```
+
+`getTree()`는 조립 과정에서 카테고리 수에 비례하는 O(n) 연산이 매 호출마다 반복된다. 카테고리가 수백 개 규모로 증가하면 CPU 부하로 이어진다.
+
+### 해결 방법
+
+`getList()`, `getTree()`에 `@Cacheable`, 모든 write 메서드에 `@CacheEvict(allEntries = true)` 적용.
+
+```java
+@Cacheable(cacheNames = "categories", key = "'list'")
+public List<CategoryResponse> getList() { ... }
+
+@Cacheable(cacheNames = "categories", key = "'tree'")
+public List<CategoryResponse> getTree() { ... }
+
+@CacheEvict(cacheNames = "categories", allEntries = true)
+@Transactional
+public CategoryResponse create(CategoryCreateRequest request) { ... }
+// update(), delete() 동일
+```
+
+`CacheConfig`에 `categories` 전용 TTL(30분) 추가:
+
+```java
+"categories", base.entryTtl(Duration.ofMinutes(30))
+```
+
+**구현 과정에서 Redis 직렬화 호환성 문제 3가지를 추가 해결했다.**
+
+| # | 증상 | 원인 | 해결 |
+|---|------|------|------|
+| 1 | `List<CategoryResponse>` 캐시 HIT 시 역직렬화 실패 | `As.PROPERTY` 방식은 JSON 배열에 `@class` 프로퍼티를 내장할 수 없어 `List` 타입 래퍼가 누락됨. 읽을 때 Jackson이 타입 정보를 찾지 못함 | `CacheConfig` 전역 직렬화 방식을 `As.WRAPPER_ARRAY`로 변경 → `["java.util.ArrayList", [...]]` 형식으로 타입 래퍼 보장 |
+| 2 | 캐시에 저장된 리스트 역직렬화 불가 | `Stream.toList()`의 반환 타입이 JDK 내부 패키지-프라이빗 클래스(`ImmutableCollections$ListN`)라 Jackson이 인스턴스화 불가 | `Collectors.toList()`로 교체 → 공개 타입 `ArrayList` 반환, 직렬화 포맷도 `java.util.ArrayList`로 확정 |
+| 3 | `CategoryResponse` 역직렬화 불가 | Lombok `@Builder`만 있으면 Jackson이 역직렬화 시 사용할 생성자(`no-args` 또는 `@JsonCreator`)를 찾지 못함 | `@Jacksonized` 추가 → Lombok이 `@JsonDeserialize(builder = ...)` + `@JsonPOJOBuilder(withPrefix = "")` 자동 생성. `children` 필드도 `List.of()` → `new ArrayList<>()`로 교체 |
+
+> **교훈**: 기존 캐시(`products`, `inventory`, `orders`)는 단일 객체를 캐싱해 `As.PROPERTY`에서 문제가 없었다. `List<T>`를 직접 캐싱하면 컬렉션 타입 래퍼 방식이 달라지므로 통합 테스트에서 반드시 캐시 HIT 경로까지 검증해야 한다.
+
+### Trade-off
+
+| 항목 | 내용 |
+|------|------|
+| 최대 30분 Stale | write API가 누락되면 TTL 만료까지 구버전 카테고리 노출. 현재는 `create / update / delete` 모두 `@CacheEvict` 적용 |
+| Write 경로 관리 부담 | 향후 카테고리 변경 로직 추가 시 `@CacheEvict` 누락이 silent bug가 됨 — 코드 리뷰에서 반드시 확인 필요 |
+| `As.WRAPPER_ARRAY` 전환 영향 | 기존 캐시 키(`products::*`, `inventory::*`, `orders::*`)의 직렬화 포맷이 변경됨. 운영 배포 시 기존 캐시 키 무효화 필요 (`FLUSHDB` 또는 자연 TTL 만료 대기) |
+| 직렬화 제약 추가 | 캐시 대상 DTO에 `@Jacksonized`와 가변 `List` 사용을 강제해야 함. 누락 시 캐시 HIT에서만 역직렬화 에러가 발생해 원인 파악이 어려움 |
+| Cold Start | 재배포 직후 또는 TTL 만료 직후 첫 요청은 DB 조회 + 트리 조립이 발생 |
+
+### 결과
+
+| 지표 | 변경 전 | 변경 후 |
+|------|---------|---------|
+| 상품 목록 API 1회당 `categories` SELECT | 1번 | **0번** (캐시 HIT) |
+| `getTree()` in-memory 트리 조립 | 매 호출 O(n) | **0** (캐시 HIT, TTL 내 재사용) |
+| `categories` DB 쿼리 (피크 TPS 1,000 기준) | 초당 **1,000번** | 캐시 갱신 시만 1번 (**99.9% 감소**) |
+
+---
+
 ## 테스트 커버리지 추이
 
 | 시점 | 테스트 수 |
@@ -563,4 +664,4 @@ JWT에 `userId`를 포함하면 토큰 크기가 소폭 증가한다. 또한 `us
 | 리뷰 / 위시리스트 / 포인트 / 환불 + 통합 테스트 | 465개 |
 | 전 컨트롤러 단위 테스트 완비 | 529개 |
 | 배치 / Elasticsearch / 쿠폰 / 카테고리 추가 | ~580개 |
-| 최종 | **601개** |
+| 성능 최적화 (#7/#8/#9) 이후 | **605개** |

--- a/docs/PAYMENT_IMPLEMENTATION.md
+++ b/docs/PAYMENT_IMPLEMENTATION.md
@@ -99,6 +99,9 @@ TossPayments 웹훅 수신. **인증 불필요** (Public 엔드포인트).
 `Toss-Signature` 헤더 HMAC-SHA256 서명 검증 후 처리.
 TossPayments는 10초 내 2xx 응답이 없으면 최대 7회 재전송.
 
+처리 이벤트:
+- **가상계좌 입금 완료** (`method=가상계좌`, `status=DONE`): `applyWebhookConfirmResult()` 호출 → 주문 CONFIRMED + 배송 PREPARING 생성 + 포인트 적립 (일반 confirm 흐름 재사용)
+
 ---
 
 ## 핵심 설계 결정사항
@@ -143,8 +146,31 @@ TossPayments 규격: 영문/숫자/`-`/`_`, 6~64자.
 Spring 6.1+ `RestClient` 사용. `SimpleClientHttpRequestFactory`로 connect/read timeout 설정 (application.properties `toss.connect-timeout-ms`, `toss.read-timeout-ms`).
 `TossPaymentsConfig`에서 Base64 인코딩된 `secretKey`를 `Authorization: Basic` 헤더에 주입.
 
-### 8. Shipment 자동 생성
-`confirm()` 성공 시 `ShipmentService.createForOrder()` 호출 → Shipment PREPARING 상태로 자동 생성.
+### 8. Shipment·포인트 자동 처리 — `REQUIRES_NEW`
+
+`confirm()` 성공 시:
+- `ShipmentService.createForOrder()` — `Propagation.REQUIRES_NEW`로 독립 트랜잭션
+- `PointService.earn()` — `Propagation.REQUIRES_NEW`로 독립 트랜잭션
+
+두 메서드가 `REQUIRED`이면 예외 발생 시 `applyConfirmResult()` 내부의 try-catch가 `UnexpectedRollbackException`을 유발 (Spring이 공유 트랜잭션을 rollback-only 표시). 결제는 Toss에서 완료됐지만 DB는 PENDING 상태로 남는 치명적 불일치 발생 → `REQUIRES_NEW`로 분리.
+
+### 9. 가상계좌 Webhook 흐름
+
+가상계좌(virtual account) 결제는 confirm API로 바로 DONE이 되지 않고, 사용자 입금 후 Toss가 Webhook으로 통보한다.
+
+```
+[Toss] POST /api/payments/webhook  { eventType: "DEPOSIT_CALLBACK", ... , status: "DONE" }
+          │
+          ▼
+  applyWebhookConfirmResult(tossOrderId, paymentKey)
+          │
+          ├── Payment: PENDING → DONE
+          ├── Order:   PENDING → CONFIRMED  (reserved → allocated)
+          ├── Shipment: PREPARING 자동 생성  (REQUIRES_NEW)
+          └── PointService.earn()            (REQUIRES_NEW)
+```
+
+`doPostConfirmWork(payment)` private 메서드로 confirm/webhook 공통 후처리 추출.
 
 ---
 


### PR DESCRIPTION
## Summary

- **perf**: `InventoryRepository` `@EntityGraph`로 N+1 쿼리 방지, `CategoryService` Redis 캐시(30분 TTL) 적용, `InventorySnapshotScheduler` 페이지 단위 독립 트랜잭션 처리
- **fix**: 음수 재고 허용 버그, 포인트 사전 검증 누락, `DistributedLockAspect` SpEL NPE, 스냅샷 예외 처리, 배송·포인트 실패 무음 삼킴, `Refund.userId` 비정규화로 소유권 검증 개선
- **docs**: API·DB·결제·README 전체 문서 최신화 (V1~V28 마이그레이션, 누락 엔드포인트 보완, ERD 정확도 수정)

## Test plan

- [x] `./gradlew test` — 605개 전체 통과 확인
- [x] `InventoryRepository` `@EntityGraph` — N+1 쿼리 제거 검증
- [x] `CategoryService` Redis 캐시 — `@Cacheable`/`@CacheEvict` 동작 확인
- [x] `InventorySnapshotScheduler` — 페이지 단위 독립 트랜잭션 검증
- [x] ERD 다이어그램 — `image_type`, `PARTIAL_CANCELLED`, `FAILED→PENDING` 재시도 전이 수정