### PR TITLE
fix: 프로덕션 버그·보안취약점·성능 개선 + PAYMENT_IN_PROGRESS 경합 해결

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -35,349 +35,137 @@ Client
 
 ---
 
-## ✅ 즉시 수정 완료 — 프로덕션 데이터 정합성 위험 (6/6)
+## 🔴 보안 취약점 진단 (0/10)
 
-| # | 항목 | 파일 | 조치 |
-|---|------|------|------|
-| 1 | 음수 재고 허용 버그 | `InventoryService` | `BusinessException(INVENTORY_STATE_INCONSISTENT)` throw |
-| 2 | 포인트 롤백 불일치 | `OrderService.create()` | `validateBalance()` fail-fast 사전 검증 추가 |
-| 3 | 배송·포인트 무음 삼킴 | `PaymentTransactionHelper` | Outbox 패턴(`SHIPMENT_CREATE`, `POINT_EARN`) 전환 |
-| 4 | null userId NPE | `OrderExpiryScheduler` | `cancelBySystem()` 전용 메서드, Order에서 userId 직접 조회 |
-| 5 | saveAll() 예외 무음 삼킴 | `InventorySnapshotScheduler` | `DataIntegrityViolationException` 분리, 장애 시 re-throw |
-| 6 | SpEL null NPE | `DistributedLockAspect` | `resolveKey()` null/예외 시 `BusinessException` throw |
+> 전체 코드베이스 보안 분석. IDOR·인증 누락·설정 오류 중심.
 
 ---
 
-## ✅ 즉시 처리 — 성능 병목 완료 (3/3)
+### 56. `PaymentController.getByPaymentKey()` — 인증·소유권 검증 없음 (IDOR)
 
-| # | 항목 | 파일 | 조치 |
-|---|------|------|------|
-| 7 | InventoryRepository fetch join 누락 (N+1) | `InventoryRepository` | `findByProductId`, `findAllByProductIdIn`에 `@EntityGraph({"product"})` 추가 |
-| 8 | CategoryService.getTree() 캐시 미적용 | `CategoryService`, `CacheConfig`, `CategoryResponse` | `getList/getTree` `@Cacheable`, `create/update/delete` `@CacheEvict(allEntries=true)`, categories 30분 TTL, `@Jacksonized` + `ArrayList` 적용 |
-| 9 | InventorySnapshotScheduler 전체 로드 | `InventorySnapshotScheduler`, `InventorySnapshotProcessor` | 1,000건 페이지 루프 + 배치마다 독립 트랜잭션 커밋 (`@Component` 분리) |
+**위치**: `domain/payment/controller/PaymentController.java` L87-91
 
----
+**문제**: `GET /api/payments/{paymentKey}` 엔드포인트에 `@AuthenticationPrincipal`이 없고 결제 소유권을 검증하지 않음. 인증된 사용자라면 누구나 paymentKey를 알거나 추측해 타인의 결제 정보(금액·주문 ID·카드 정보)를 조회할 수 있음.
 
-## ✅ 스프린트 내 처리 완료 (8/11)
-
-| # | 항목 | 파일 | 조치 |
-|---|------|------|------|
-| 10 | applyConfirmResult() 이중 DB 조회 | `PaymentTransactionHelper` | `confirm()` → `Order` 반환, 재사용 |
-| 11 | Outbox 배치 크기 하드코딩 | `OutboxEventRelayScheduler` | `@Value("${outbox.relay.batch-size:100}")` + Prometheus counter (이미 완료) |
-| 12 | DB 인덱스 누락 | V23/V25/V27 마이그레이션 | 모든 항목 기존 마이그레이션으로 커버 |
-| 14 | RefundService 이중 쿼리 | `Refund` 엔티티 + `RefundService` | `userId` 비정규화 저장 → `validateOwnership()` orders 조회 제거, V28 마이그레이션 |
-| 17 | P6Spy 운영 오버헤드 | `build.gradle` | `implementation` → `runtimeOnly` |
-| 18 | Zipkin 샘플링 100% | `application.properties` | 1.0 → 0.1 (운영: 0.01~0.1) |
-| 19 | OrderSearchRequest mutable DTO | `OrderSpecification` + `OrderService` | `of(request, forceUserId)` 오버로드, DTO 변경 제거 |
-
-## 🟠 미처리 (3/11) — 아키텍처/인프라 판단 필요
-
-### 13. 오프셋 페이지네이션 성능 한계
-
-**위치**: 주문 목록, 재고 이력, 리뷰 등 `Pageable` 엔드포인트
-
-**문제**: `LIMIT ? OFFSET ?`는 페이지 번호가 클수록 앞 레코드를 모두 스캔 후 버린다. 대량 이력 보유 사용자의 마지막 페이지 조회 시 풀스캔.
-
-**개선**: 스크롤 조회(주문 이력, 재고 이력)는 `WHERE id < :lastId LIMIT ?` 커서 기반 페이지네이션으로 전환.
-
----
-
-### 15. AdminService.getOrders() 사용자명 조회 비효율
-
-**위치**: `domain/admin/service/AdminService.java` L108–125
-
-**문제**: 주문 페이지 조회 후 userId 목록으로 `userRepository.findAllById()` 별도 호출. 현재는 단일 `SELECT ... IN (...)` 1쿼리이므로 심각한 수준은 아님.
-
-**개선**: `"usernames"` Redis 캐시(5분 TTL) 추가 또는 Order 쿼리에 username 프로젝션 포함.
-
----
-
-### 16. OrderExpiryScheduler 순차 취소 → 배치 처리
-
-**위치**: `domain/order/scheduler/OrderExpiryScheduler.java` L38–60
-
-**문제**: 만료 주문마다 개별 트랜잭션으로 `cancelBySystem()` 호출. 100건 발생 시 100회 DB 왕복.
-
-**개선**: 건수 ≤10이면 현행 유지, 초과 시 `UPDATE orders SET status='CANCELLED' WHERE id IN (...)` 벌크 + 재고 일괄 해제.
-
----
-
-### 20. 리드 레플리카 라우팅 미적용
-
-**위치**: 전체 `@Transactional(readOnly = true)` 쿼리
-
-**문제**: 읽기 전용 트랜잭션이 모두 MySQL Primary로 연결됨. Replica가 있어도 읽기 부하 분산 없음.
-
-**개선**: `AbstractRoutingDataSource` 또는 AWS Aurora Reader Endpoint 활용.
-
----
-
-## ✅ 기술 부채 완료 (7/8)
-
-| # | 항목 | 파일 | 조치 |
-|---|------|------|------|
-| 21 | 동시성 통합 테스트 부재 | `ConcurrencyIntegrationTest`, `InventoryConcurrencyTest` | 이미 구현 완료 (ExecutorService + CountDownLatch, reserve() 재고 불변 조건 검증) |
-| 22 | Pitest targetClasses 제한적 | `build.gradle` | 6개 → 15개로 확장 (shipment·product·review·wishlist·category·user·address·cart 추가) |
-| 23 | 전체 Refresh Token 무효화 불가 | `RefreshTokenStore`, `UserService` | 이미 구현 완료 (`revokeAll()` + 비밀번호 변경 시 자동 호출) |
-| 24 | 쿠폰 코드 엔트로피 검증 없음 | `CouponCreateRequest` | 이미 구현 완료 (`@Pattern` 영문+숫자 혼합 8자 이상 강제) |
-| 26 | Dockerfile HEALTHCHECK 미정의 | `Dockerfile` | 이미 구현 완료 (`--interval=30s --retries=3`) |
-| 27 | `storage.enabled` 문서화 누락 | `application.properties` | 이미 구현 완료 (`storage.enabled=false` + 주석) |
-| 28 | Payment 도메인 주석 언어 불일치 | `PaymentService`, `PaymentTransactionHelper` | 영어 inline 주석·Javadoc·log 메시지 → 한국어(키워드 영문) 통일 |
-
-## 🟡 미처리 기술 부채 (1/8)
-
-### 25. API 버전 관리 부재
-
-**위치**: 모든 컨트롤러 (`/api/products`, `/api/orders` 등)
-
-**문제**: 버전 prefix 없이 `/api/` 직접 사용. 응답 스키마 변경 시 하위 호환성 관리 불가.
-
-**개선**: `/api/v1/` prefix 도입.
-
----
-
-## ✅ DBA 진단 — 스키마 결함 및 누락 제약 (9/13)
-
-### ✅ 33. `refunds.user_id DEFAULT 0` — 기존 환불 소유권 검증 영구 실패 (V28 결함)
-
-**위치**: `V29__backfill_refunds_user_id.sql`
-
-**조치**: V29 마이그레이션 추가 — `orders.user_id` JOIN 백필 + `fk_refunds_user` FK 제약 추가.
-
----
-
-### ✅ 34. `payments` 테이블 — `ENGINE` · `CHARSET` · `COLLATE` 미정의 (V4 결함)
-
-**위치**: `V4__create_payment_tables.sql`
-
-**문제**: V4의 `CREATE TABLE payments` 구문에 `ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci`가 없음. 서버 기본 collation(`utf8mb4_0900_ai_ci`)이 적용되어 다른 테이블(`utf8mb4_unicode_ci`)과 collation이 달라짐. `payments JOIN orders`, `payments JOIN users` 조인 시 `Illegal mix of collations` 에러 또는 인덱스 미사용 가능.
-
-**개선**: V29 마이그레이션:
-```sql
-ALTER TABLE payments CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+```java
+// 현재 — 소유권 검증 없음
+@GetMapping("/{paymentKey}")
+public ApiResponse<PaymentResponse> getByPaymentKey(@PathVariable String paymentKey) {
+    return ApiResponse.ok(paymentService.getByPaymentKey(paymentKey));
+}
 ```
 
----
-
-### ✅ 35. `orders` — `(status, created_at)` 복합 인덱스 누락
-
-**위치**: `V23__add_orders_indexes.sql`, `OrderRepository.countByStatusAndCreatedAtBetween()`
-
-**문제**: `DailyOrderStatsScheduler`가 매일 자정 `countByStatusAndCreatedAtBetween(CONFIRMED, start, end)`과 `countByStatusAndCreatedAtBetween(CANCELLED, start, end)`을 2회 실행. 쿼리: `WHERE status = ? AND created_at >= ? AND created_at < ?`. 현재 `idx_orders_status(status)` + `idx_orders_created_at(created_at)` 각각 존재하나 복합 조건에는 단일 인덱스 선택 후 나머지 필터링(filesort). 운영 주문이 누적될수록 성능 저하.
-
-**개선**: V29 마이그레이션:
-```sql
-ALTER TABLE orders ADD INDEX idx_orders_status_created (status, created_at);
-```
+**개선**: `@AuthenticationPrincipal String username`에서 userId를 추출해 결제 소유자와 일치하는지 검증하거나, ADMIN 권한일 경우에만 허용한다.
 
 ---
 
-### ✅ 36. `coupons` — `(valid_until, active)` 복합 인덱스 누락 + 만료 처리 벌크 UPDATE 미적용
+### 57. `TossWebhookVerifier` — `Mac` 인스턴스 `synchronized` 직렬화로 처리량 저하
 
-**위치**: `CouponRepository.findExpiredActiveCoupons()`, `CouponExpiryScheduler`
+**위치**: `common/security/TossWebhookVerifier.java` L34-58
 
-**문제**:
-- 쿼리 `WHERE valid_until < :now AND active = true` — 인덱스 없으면 전체 coupons 테이블 풀스캔 (매일 새벽 1시 실행)
-- `deactivate()` Dirty Checking으로 쿠폰 수만큼 개별 `UPDATE` 발생 — 만료 쿠폰 100건 = 100 UPDATE
+**문제**: `Mac` 객체를 싱글턴으로 유지하고 `synchronized(mac)` 블록에서 사용. Webhook 트래픽이 몰릴 때 MAC 연산이 직렬화되어 병목 발생. 복잡한 동시성 관리보다 매 호출마다 새 인스턴스를 생성하는 것이 더 단순하고 안전하다.
+
+**개선**: `@PostConstruct`에서 Mac 초기화를 제거하고, `verify()` 호출 시 `Mac.getInstance(ALGORITHM)` + `mac.init(key)`를 수행한 뒤 사용 후 버린다.
+
+---
+
+### 58. Admin 기본 자격증명 (`admin/changeme`) — 운영 배포 시 변경 누락 위험
+
+**위치**: `common/config/AdminSecurityConfig.java`, `application.properties`
+
+**문제**: `ADMIN_USERNAME` / `ADMIN_PASSWORD` 환경변수 미설정 시 `admin/changeme`로 동작. Spring Boot Admin UI(`/admin-ui`)에 로그인 가능 → 모든 actuator 엔드포인트(힙 덤프·스레드 덤프·환경변수) 접근 허용.
+
+**개선**: #46(JWT Secret)과 동일한 패턴 — `@PostConstruct`에서 기본값 사용 감지 시 `IllegalStateException`으로 시작 실패 처리.
+
+---
+
+### 59. MySQL `useSSL=false` + `allowPublicKeyRetrieval=true` — 평문 DB 통신
+
+**위치**: `src/main/resources/application.properties` datasource URL
+
+**문제**: `useSSL=false`로 DB 연결이 평문 전송. 같은 네트워크에서 패킷 스니핑 시 쿼리·결과·자격증명 노출 가능. `allowPublicKeyRetrieval=true`는 MITM 공격자가 MySQL 서버로 위장해 공개키를 제공하고 비밀번호를 탈취할 수 있는 추가 벡터가 됨.
+
+**개선**: 운영 환경에서는 `useSSL=true&requireSSL=true`로 변경하고, 환경변수(`DB_SSL_ENABLED`)로 개발/운영을 분리한다.
+
+---
+
+### 60. Toss Webhook — 타임스탬프 검증 없음 (Replay Attack 가능)
+
+**위치**: `domain/payment/controller/PaymentController.java` `/webhook` 핸들러, `common/security/TossWebhookVerifier.java`
+
+**문제**: HMAC 서명 검증은 되어 있지만 요청 타임스탬프를 확인하지 않음. 공격자가 유효한 Webhook 요청을 캡처해 나중에 재전송하면 동일한 결제 확정 이벤트가 여러 번 처리될 수 있음. `PaymentIdempotencyManager`가 중복 처리를 일부 차단하지만 멱등성 키 만료 이후에는 방어되지 않음.
+
+**개선**: Toss 요청 헤더의 타임스탬프를 추출해 현재 시각과의 차이가 5분 초과 시 거부한다.
+
+---
+
+### 61. CSP `unsafe-inline` script-src — XSS 완화 효과 반감
+
+**위치**: `common/config/SecurityConfig.java` `contentSecurityPolicy()`
+
+**문제**: `script-src 'self' 'unsafe-inline'` 설정으로 인라인 `<script>` 태그가 실행됨. XSS 취약점이 발견되었을 때 CSP가 실질적인 방어선 역할을 하지 못함. `unsafe-eval`은 이미 제거됐으나 `unsafe-inline`이 더 큰 위험 벡터다.
+
+**개선**: `unsafe-inline` 제거 후 nonce 기반 CSP(`'nonce-{random}'`) 적용. 서버에서 매 요청마다 랜덤 nonce를 생성해 헤더와 `<script nonce="...">` 태그에 주입한다.
+
+---
+
+### 62. DB 자격증명 — 환경변수 미설정 시 하드코딩 평문 사용
+
+**위치**: `src/main/resources/application.properties` `spring.datasource.username/password`
+
+**문제**: `${DB_USERNAME:root}` / `${DB_PASSWORD:root}` 형식으로 환경변수 미설정 시 `root/root` 사용. 애플리케이션 JAR 또는 설정 파일이 유출되면 DB 자격증명이 노출됨. 프로덕션 설정 검토 누락 시 root 계정으로 DB 직접 접근 가능.
+
+**개선**: 기본값 제거(`${DB_USERNAME}` + `${DB_PASSWORD}`). 미설정 시 Spring Boot 시작 실패 → 운영 배포 전 누락 즉시 감지. Vault, AWS Secrets Manager, 또는 Kubernetes Secret 연동 권장.
+
+---
+
+### 63. Actuator — `/env`, `/beans`, `/loggers` 엔드포인트 외부 노출
+
+**위치**: `src/main/resources/application.properties` `management.endpoints.web.exposure.include`
+
+**문제**: `health,info,prometheus,metrics,loggers,env,beans,mappings,threaddump,heapdump` 전체 노출. `env` 엔드포인트는 환경변수(JWT Secret, DB 비밀번호 등)를 마스킹된 형태로 표시하지만 일부 값은 노출됨. `heapdump`는 힙 메모리 덤프를 통해 평문 비밀번호·토큰을 추출 가능.
 
 **개선**:
-- 인덱스: `ADD INDEX idx_coupons_expiry (valid_until, active)` (V29 마이그레이션)
-- 벌크 UPDATE: `UPDATE coupons SET active = false WHERE valid_until < :now AND active = true` 단일 쿼리로 대체
-
----
-
-### ✅ 37. `products.status` 인덱스 누락
-
-**위치**: `V1__init_schema.sql`, `ProductRepository`
-
-**문제**: `ProductRepository`의 `findAllActiveBySpec()`, `findWithSpec()` 등이 `WHERE status = 'ACTIVE'` 조건을 항상 포함. status 인덱스가 V1~V28 어디에도 없어 전체 products 스캔 후 필터링. ES fallback 쿼리에서도 동일하게 사용.
-
-**개선**: V29 마이그레이션:
-```sql
-ALTER TABLE products ADD INDEX idx_products_status (status);
+```properties
+# 공개 허용
+management.endpoints.web.exposure.include=health,info,prometheus,metrics
+# ADMIN 전용 (AdminSecurityConfig에서 인증 처리)
+management.endpoint.env.enabled=false
+management.endpoint.heapdump.enabled=false
 ```
 
 ---
 
-### ✅ 38. `cart_items.user_id` — FK 누락, 사용자 탈퇴 시 고아 레코드
+### 64. `CouponValidateRequest.couponCode` — `@Size` 검증 누락
 
-**위치**: `V10__create_cart_tables.sql`
+**위치**: `domain/coupon/dto/CouponValidateRequest.java`
 
-**문제**: `cart_items`에 `product_id → products FK`는 있지만 `user_id → users FK`가 없음. `users.deleted_at`(소프트 삭제, V16)에도 불구하고, 사용자 삭제 시 `cart_items` 레코드는 고아(orphan)로 남아 user_id가 무효한 상태로 유지됨.
+**문제**: `@NotBlank`만 있고 `@Size(max=50)` 가 없음. 악의적 사용자가 수백 KB의 couponCode를 전송하면 `LOWER(code) = LOWER(:code)` 쿼리 파라미터로 그대로 전달됨. 쿼리 실행 오버헤드 외에도 파라미터 바인딩 시 DB 드라이버가 대형 문자열을 처리함.
 
-**개선**: V29 마이그레이션:
-```sql
-ALTER TABLE cart_items
-    ADD CONSTRAINT fk_cart_user FOREIGN KEY (user_id) REFERENCES users (id);
+**개선**: `@Size(min=8, max=50)` 추가. `CouponCreateRequest.code`의 `@Pattern`과 동일한 길이 제약을 검증에도 적용한다.
+
+---
+
+### 65. `GlobalExceptionHandler` — 예외 메시지 클라이언트 노출
+
+**위치**: `common/exception/GlobalExceptionHandler.java`
+
+**문제**: `handleException(Exception e)` 폴백 핸들러가 `e.getMessage()`를 응답 본문에 포함할 경우 내부 스택 정보(클래스명, SQL 오류 등)가 외부에 노출될 수 있음. 특히 JPA `DataIntegrityViolationException`, `ConstraintViolationException` 등은 테이블명·컬럼명을 메시지에 포함함.
+
+**개선**: 폴백 핸들러는 `ErrorCode.INTERNAL_SERVER_ERROR`의 고정 메시지만 반환하고, 실제 예외 메시지는 서버 로그에만 기록한다.
+
+```java
+@ExceptionHandler(Exception.class)
+public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+    log.error("예상치 못한 오류 발생", e);
+    return ResponseEntity.status(INTERNAL_SERVER_ERROR)
+        .body(ApiResponse.fail(ErrorCode.INTERNAL_SERVER_ERROR)); // e.getMessage() 제거
+}
 ```
 
 ---
 
-### ✅ 39. `point_transactions.order_id` — FK 누락, 고아 참조 가능
-
-**위치**: `V20__create_point_tables.sql`
-
-**문제**: `point_transactions.order_id BIGINT NULL`이지만 `orders(id)` FK가 없음. 주문 삭제 시 포인트 이력의 `order_id`는 유효하지 않은 ID를 참조하게 되어 데이터 조회 정합성 훼손 가능. `user_id`에는 FK가 있지만 `order_id`에는 없어 일관성 없음.
-
-**개선**: V29 마이그레이션 (ON DELETE SET NULL — 주문 삭제 시 이력 보존):
-```sql
-ALTER TABLE point_transactions
-    ADD CONSTRAINT fk_pt_order FOREIGN KEY (order_id) REFERENCES orders (id) ON DELETE SET NULL;
-```
-
----
-
-### ✅ 40. `created_at` / `updated_at` — `DEFAULT CURRENT_TIMESTAMP` 없는 테이블 6개
-
-**위치**: V4(`payments`), V10(`cart_items`), V11(`shipments`), V12(`delivery_addresses`), V17(`product_images`), V22(`user_coupons`)
-
-**문제**: 6개 테이블의 `created_at DATETIME(6) NOT NULL`에 `DEFAULT CURRENT_TIMESTAMP(6)`이 없음. Hibernate `@CreationTimestamp`에만 의존 — bulk INSERT 또는 DB 직접 조작 시 `NULL` 삽입으로 `NOT NULL` 제약 위반 또는 묵시적 `'0000-00-00'` 저장 가능. 나머지 테이블들(V1~V3, V5, V6 등)은 모두 DEFAULT가 있어 불일치.
-
-**개선**: V29 마이그레이션으로 각 컬럼 ALTER (6개 테이블):
-```sql
-ALTER TABLE payments   MODIFY created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);
-ALTER TABLE shipments  MODIFY created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);
--- ... (4개 더)
-```
-
----
-
-### 41. `DECIMAL` precision 불일치 — `DECIMAL(19,2)` vs `DECIMAL(12,2)`
-
-**위치**: `V13__create_coupon_tables.sql`, `V21__create_refunds_table.sql`, `V15__create_batch_tables.sql`
-
-**문제**: 같은 비즈니스 도메인(금액) 컬럼이 두 precision으로 혼재:
-- `DECIMAL(12,2)`: `orders.total_amount`, `payments.amount`, `inventory_transactions` 스냅샷값
-- `DECIMAL(19,2)`: `coupons.discount_value`, `coupon_usages.discount_amount`, `refunds.amount`, `daily_order_stats.total_revenue`
-
-`orders.total_amount(12,2)`와 `coupons.discount_value(19,2)` 비교 시 묵시적 캐스팅 발생. 최대 12자리 금액(9,999,999.99원)으로 충분한 도메인에서 DECIMAL(19,2)는 불필요하게 큰 저장 공간 사용.
-
-**개선**: 금액 컬럼 precision을 `DECIMAL(15,2)`로 통일 (최대 999억원 지원, 일별 매출·누적 집계에 충분).
-
----
-
-### 42. `delivery_addresses` — 기본 배송지 복수 방지 DB 제약 없음
-
-**위치**: `V12__create_delivery_address_tables.sql`, `DeliveryAddressService`
-
-**문제**: `is_default TINYINT(1)` 컬럼만 있고 "사용자별 `is_default = 1` 레코드는 최대 1개" 제약이 DB에 없음. 애플리케이션 버그 또는 직접 DB 수정 시 기본 배송지가 여러 개 생성될 수 있음. MySQL은 partial unique index를 지원하지 않으므로 트리거 또는 CHECK 제약으로 보완 필요.
-
-**개선 옵션**:
-1. `BEFORE INSERT/UPDATE` 트리거 — `is_default = 1` 설정 시 동일 user의 다른 레코드를 0으로 초기화
-2. 애플리케이션 레벨 검증 강화 + 정기 정합성 점검 쿼리 추가
-
----
-
-### 43. `orders.findOrderStats()` — 전체 테이블 GROUP BY (대시보드 성능)
-
-**위치**: `OrderRepository.findOrderStats()`, `AdminService.getDashboard()`
-
-**문제**: `SELECT status, COUNT(*), SUM(totalAmount) FROM orders GROUP BY status` — 주문 데이터가 누적될수록 대시보드 API 응답 지연 증가. 현재 `idx_orders_status` 인덱스로 인덱스 스캔은 가능하지만 전체 행을 읽음. `daily_order_stats` 테이블이 이미 존재하지만 실시간 대시보드는 live orders 테이블 집계 사용.
-
-**개선**: 대시보드 통계를 `daily_order_stats` 캐시 + 당일 분만 live 집계로 전환. 또는 `AdminService` 응답에 Redis 캐시(5분 TTL) 적용.
-
----
-
-### ✅ 44. 일부 테이블 `COLLATE` 미정의 — collation 불일치
-
-**위치**: `V15`(`daily_order_stats`, `daily_inventory_snapshots`), `V18`(`outbox_events`)
-
-**문제**: 3개 테이블이 `DEFAULT CHARSET=utf8mb4` 없이 생성되거나 COLLATE 없이 생성됨. 서버 기본 collation(`utf8mb4_0900_ai_ci`)이 적용되어 나머지 테이블(`utf8mb4_unicode_ci`)과 불일치. 직접 JOIN은 없지만 `SHOW CREATE TABLE`에서 혼재 확인 → 운영 이관 시 혼란.
-
-**개선**: V29 마이그레이션:
-```sql
-ALTER TABLE daily_order_stats        CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-ALTER TABLE daily_inventory_snapshots CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-ALTER TABLE outbox_events             CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-```
-
----
-
-### 45. `refunds.payment_id UNIQUE` — `PARTIAL_CANCELLED`(부분 취소) 여러 건 이력 불가
-
-**위치**: `V21__create_refunds_table.sql`, `payments.status = PARTIAL_CANCELLED`
-
-**문제**: `payments.status`에 `PARTIAL_CANCELLED`(부분 취소) 상태가 정의되어 있어 한 결제에 대해 여러 차례 부분 환불이 가능해야 하지만, `refunds.payment_id UNIQUE` 제약이 결제당 단 1건의 환불 레코드만 허용. 부분 취소 두 번째 시도 시 DB에서 `Duplicate entry` 에러 발생.
-
-**개선**: 부분 취소 이력이 필요하면 UNIQUE 제약 제거 + `(payment_id, created_at)` 복합 인덱스 전환. 현재는 `reset()` 재사용으로 FAILED 재시도만 지원하나, 부분 취소 누적 이력은 불가.
-
----
-
-> **요약**: #33~#40 · #44 완료(V29~V34) → 아키텍처 판단(#41~#43 · #45) 보류
-
----
-
-## ✅ 신규 발굴 성능 병목 (4/4)
-
-### ✅ 29. ReviewService · WishlistService `findByUsername()` DB round-trip
-
-**위치**: `ReviewService.create/update/delete`, `WishlistService.add/remove/isWishlisted/getList`
-
-**문제**: 7개 메서드 전부 `userRepository.findByUsername(username)` 쿼리로 시작. JWT claim에 이미 `userId`가 포함되어 있음에도 매 요청마다 불필요한 DB round-trip 발생. `OrderService`, `ShipmentService`는 이미 `resolveUserId()` 패턴으로 전환됨.
-
-**개선**: 컨트롤러에서 `@AuthenticationPrincipal String username` → `Long userId` (`resolveUserId()` 헬퍼 패턴) 전환. 7개 write 메서드에서 `userRepository.findByUsername()` 제거.
-
----
-
-### ✅ 30. OutboxEventRelayScheduler 지수 백오프 없음
-
-**위치**: `OutboxEventRepository.findPendingEvents()`, `OutboxEventRelayScheduler`
-
-**문제**: 실패한 이벤트(`failedAt != null`)를 5초 후 무조건 재시도. 다운스트림(ShipmentService · PointService · EmailService) 장애 시 100건 × 5초 간격으로 연속 폭격 발생. `failedAt` 컬럼이 존재하지만 relay 쿼리에서 전혀 활용되지 않음.
-
-**개선**: `findPendingEvents()` 쿼리에 `AND (e.failedAt IS NULL OR e.failedAt <= :cutoff)` 조건 추가. cutoff = `now - min(retryCount² × 5초, 300초)`. 재시도 간격: 1회→5s, 2회→20s, 3회→45s, 4회→80s, 5회→125s.
-
----
-
-### ~~31. `outbox_events` 쿼리 인덱스 누락~~ ✅ 이미 구현됨
-
-`V18__create_outbox_events.sql`에 `INDEX idx_outbox_unpublished (published_at, retry_count, created_at)` 이미 포함. 조치 불필요.
-
----
-
-### ✅ 32. ReviewService.create() 불필요한 `Product` 전체 엔티티 로드
-
-**위치**: `ReviewService.create()` L40-41, `ReviewService.getList()` L65-66
-
-**문제**: `productRepository.findById(productId)`로 Product + category(Lazy) 전체를 로드하지만 실제 사용 필드는 `product.getId()` 하나뿐. 1인 1리뷰 검증(`existsByProductIdAndUserId`)과 구매 이력 확인(`existsPurchaseByUserIdAndProductId`)에 productId를 직접 사용 가능.
-
-**개선**: `productRepository.findById()` → `productRepository.existsById()` 전환. 불필요한 Product 객체 생성·category JOIN 제거.
-
----
-
-## ✅ 완료
-
-### 보안·버그 수정
-
-| 항목 | 비고 |
-|------|------|
-| PaymentService JWT userId 적용 | DB 라운드트립 제거, `resolveUserId()` 패턴 |
-| ES 상품 동기화 | `@TransactionalEventListener(AFTER_COMMIT)` + `ProductEventListener` |
-| CSP `unsafe-eval` 제거 | `SecurityConfig` script-src 정책 강화 |
-| 가상계좌 Webhook 처리 | `applyWebhookConfirmResult()` confirm 흐름 재사용 |
-| JWT 시크릿 기본값 경고 | `@PostConstruct` ERROR 로그 |
-| RefundService 영구 재시도 불가 버그 | FAILED 상태 환불 `reset()` 후 재사용 |
-| LoginRateLimiter Lua 원자화 | `RAtomicLong` → Lua INCR+EXPIRE 원자적 처리 |
-| ShipmentService / PointService `REQUIRES_NEW` | `UnexpectedRollbackException` 방지 |
-| DeliveryAddressRepository `findFirstBy...` | 기본 배송지 삭제 후 1건만 조회 |
-
-### 기능 구현 완료
-
-| 기능 | 기능 |
-|------|------|
-| 인증 (로그인/로그아웃/토큰 재발급) | 상품 목록/검색 (Elasticsearch) |
-| 상품 상세 (재고 상태·별점 통합) | 카테고리 트리 |
-| 장바구니 (품절 상태 포함) | 주문 생성/취소/목록/이력 |
-| TossPayments 결제/취소 | 배송 조회 |
-| 환불 | 리뷰 작성/수정/조회/삭제 |
-| 위시리스트 | 포인트 잔액/이력 |
-| 배송지 관리 | 내 쿠폰 목록 / 공개 쿠폰 claim |
-| 프로필 수정 / 비밀번호 변경 | 상품 이미지 업로드 (MinIO Presigned URL) |
-| 주문 아이템 리뷰 작성 여부 | 주문 상세 통합 응답 |
-
----
-
-## 🔴 시니어 엔지니어 코드리뷰 — 구조·성능·보안 (0/10)
+## 🔴 코드리뷰 — 구조·성능·보안 (0/10)
 
 > 182개 Java 파일 전수 분석. 우선순위 순으로 정렬.
 
@@ -525,130 +313,218 @@ return RefundResponse.from(refund); // HTTP 200, status=FAILED
 
 ---
 
-## 🔴 보안 취약점 진단 (0/10)
-
-> 전체 코드베이스 보안 분석. IDOR·인증 누락·설정 오류 중심.
+## 🟠 미처리 — 성능·아키텍처 판단 필요
 
 ---
 
-### 56. `PaymentController.getByPaymentKey()` — 인증·소유권 검증 없음 (IDOR)
+### 13. 오프셋 페이지네이션 성능 한계
 
-**위치**: `domain/payment/controller/PaymentController.java` L87-91
+**위치**: 주문 목록, 재고 이력, 리뷰 등 `Pageable` 엔드포인트
 
-**문제**: `GET /api/payments/{paymentKey}` 엔드포인트에 `@AuthenticationPrincipal`이 없고 결제 소유권을 검증하지 않음. 인증된 사용자라면 누구나 paymentKey를 알거나 추측해 타인의 결제 정보(금액·주문 ID·카드 정보)를 조회할 수 있음.
+**문제**: `LIMIT ? OFFSET ?`는 페이지 번호가 클수록 앞 레코드를 모두 스캔 후 버린다. 대량 이력 보유 사용자의 마지막 페이지 조회 시 풀스캔.
 
-```java
-// 현재 — 소유권 검증 없음
-@GetMapping("/{paymentKey}")
-public ApiResponse<PaymentResponse> getByPaymentKey(@PathVariable String paymentKey) {
-    return ApiResponse.ok(paymentService.getByPaymentKey(paymentKey));
-}
-```
-
-**개선**: `@AuthenticationPrincipal String username`에서 userId를 추출해 결제 소유자와 일치하는지 검증하거나, ADMIN 권한일 경우에만 허용한다.
+**개선**: 스크롤 조회(주문 이력, 재고 이력)는 `WHERE id < :lastId LIMIT ?` 커서 기반 페이지네이션으로 전환.
 
 ---
 
-### 57. `TossWebhookVerifier` — `Mac` 인스턴스 `synchronized` 직렬화로 처리량 저하
+### 15. AdminService.getOrders() 사용자명 조회 비효율
 
-**위치**: `common/security/TossWebhookVerifier.java` L34-58
+**위치**: `domain/admin/service/AdminService.java` L108–125
 
-**문제**: `Mac` 객체를 싱글턴으로 유지하고 `synchronized(mac)` 블록에서 사용. Webhook 트래픽이 몰릴 때 MAC 연산이 직렬화되어 병목 발생. 복잡한 동시성 관리보다 매 호출마다 새 인스턴스를 생성하는 것이 더 단순하고 안전하다.
+**문제**: 주문 페이지 조회 후 userId 목록으로 `userRepository.findAllById()` 별도 호출. 현재는 단일 `SELECT ... IN (...)` 1쿼리이므로 심각한 수준은 아님.
 
-**개선**: `@PostConstruct`에서 Mac 초기화를 제거하고, `verify()` 호출 시 `Mac.getInstance(ALGORITHM)` + `mac.init(key)`를 수행한 뒤 사용 후 버린다.
-
----
-
-### 58. Admin 기본 자격증명 (`admin/changeme`) — 운영 배포 시 변경 누락 위험
-
-**위치**: `common/config/AdminSecurityConfig.java`, `application.properties`
-
-**문제**: `ADMIN_USERNAME` / `ADMIN_PASSWORD` 환경변수 미설정 시 `admin/changeme`로 동작. Spring Boot Admin UI(`/admin-ui`)에 로그인 가능 → 모든 actuator 엔드포인트(힙 덤프·스레드 덤프·환경변수) 접근 허용.
-
-**개선**: #46(JWT Secret)과 동일한 패턴 — `@PostConstruct`에서 기본값 사용 감지 시 `IllegalStateException`으로 시작 실패 처리.
+**개선**: `"usernames"` Redis 캐시(5분 TTL) 추가 또는 Order 쿼리에 username 프로젝션 포함.
 
 ---
 
-### 59. MySQL `useSSL=false` + `allowPublicKeyRetrieval=true` — 평문 DB 통신
+### 16. OrderExpiryScheduler 순차 취소 → 배치 처리
 
-**위치**: `src/main/resources/application.properties` datasource URL
+**위치**: `domain/order/scheduler/OrderExpiryScheduler.java` L38–60
 
-**문제**: `useSSL=false`로 DB 연결이 평문 전송. 같은 네트워크에서 패킷 스니핑 시 쿼리·결과·자격증명 노출 가능. `allowPublicKeyRetrieval=true`는 MITM 공격자가 MySQL 서버로 위장해 공개키를 제공하고 비밀번호를 탈취할 수 있는 추가 벡터가 됨.
+**문제**: 만료 주문마다 개별 트랜잭션으로 `cancelBySystem()` 호출. 100건 발생 시 100회 DB 왕복.
 
-**개선**: 운영 환경에서는 `useSSL=true&requireSSL=true`로 변경하고, 환경변수(`DB_SSL_ENABLED`)로 개발/운영을 분리한다.
-
----
-
-### 60. Toss Webhook — 타임스탬프 검증 없음 (Replay Attack 가능)
-
-**위치**: `domain/payment/controller/PaymentController.java` `/webhook` 핸들러, `common/security/TossWebhookVerifier.java`
-
-**문제**: HMAC 서명 검증은 되어 있지만 요청 타임스탬프를 확인하지 않음. 공격자가 유효한 Webhook 요청을 캡처해 나중에 재전송하면 동일한 결제 확정 이벤트가 여러 번 처리될 수 있음. `PaymentIdempotencyManager`가 중복 처리를 일부 차단하지만 멱등성 키 만료 이후에는 방어되지 않음.
-
-**개선**: Toss 요청 헤더의 타임스탬프를 추출해 현재 시각과의 차이가 5분 초과 시 거부한다.
+**개선**: 건수 ≤10이면 현행 유지, 초과 시 `UPDATE orders SET status='CANCELLED' WHERE id IN (...)` 벌크 + 재고 일괄 해제.
 
 ---
 
-### 61. CSP `unsafe-inline` script-src — XSS 완화 효과 반감
+### 20. 리드 레플리카 라우팅 미적용
 
-**위치**: `common/config/SecurityConfig.java` `contentSecurityPolicy()`
+**위치**: 전체 `@Transactional(readOnly = true)` 쿼리
 
-**문제**: `script-src 'self' 'unsafe-inline'` 설정으로 인라인 `<script>` 태그가 실행됨. XSS 취약점이 발견되었을 때 CSP가 실질적인 방어선 역할을 하지 못함. `unsafe-eval`은 이미 제거됐으나 `unsafe-inline`이 더 큰 위험 벡터다.
+**문제**: 읽기 전용 트랜잭션이 모두 MySQL Primary로 연결됨. Replica가 있어도 읽기 부하 분산 없음.
 
-**개선**: `unsafe-inline` 제거 후 nonce 기반 CSP(`'nonce-{random}'`) 적용. 서버에서 매 요청마다 랜덤 nonce를 생성해 헤더와 `<script nonce="...">` 태그에 주입한다.
-
----
-
-### 62. DB 자격증명 — 환경변수 미설정 시 하드코딩 평문 사용
-
-**위치**: `src/main/resources/application.properties` `spring.datasource.username/password`
-
-**문제**: `${DB_USERNAME:root}` / `${DB_PASSWORD:root}` 형식으로 환경변수 미설정 시 `root/root` 사용. 애플리케이션 JAR 또는 설정 파일이 유출되면 DB 자격증명이 노출됨. 프로덕션 설정 검토 누락 시 root 계정으로 DB 직접 접근 가능.
-
-**개선**: 기본값 제거(`${DB_USERNAME}` + `${DB_PASSWORD}`). 미설정 시 Spring Boot 시작 실패 → 운영 배포 전 누락 즉시 감지. Vault, AWS Secrets Manager, 또는 Kubernetes Secret 연동 권장.
+**개선**: `AbstractRoutingDataSource` 또는 AWS Aurora Reader Endpoint 활용.
 
 ---
 
-### 63. Actuator — `/env`, `/beans`, `/loggers` 엔드포인트 외부 노출
-
-**위치**: `src/main/resources/application.properties` `management.endpoints.web.exposure.include`
-
-**문제**: `health,info,prometheus,metrics,loggers,env,beans,mappings,threaddump,heapdump` 전체 노출. `env` 엔드포인트는 환경변수(JWT Secret, DB 비밀번호 등)를 마스킹된 형태로 표시하지만 일부 값은 노출됨. `heapdump`는 힙 메모리 덤프를 통해 평문 비밀번호·토큰을 추출 가능.
-
-**개선**:
-```properties
-# 공개 허용
-management.endpoints.web.exposure.include=health,info,prometheus,metrics
-# ADMIN 전용 (AdminSecurityConfig에서 인증 처리)
-management.endpoint.env.enabled=false
-management.endpoint.heapdump.enabled=false
-```
+## 🟡 미처리 기술 부채
 
 ---
 
-### 64. `CouponValidateRequest.couponCode` — `@Size` 검증 누락
+### 25. API 버전 관리 부재
 
-**위치**: `domain/coupon/dto/CouponValidateRequest.java`
+**위치**: 모든 컨트롤러 (`/api/products`, `/api/orders` 등)
 
-**문제**: `@NotBlank`만 있고 `@Size(max=50)` 가 없음. 악의적 사용자가 수백 KB의 couponCode를 전송하면 `LOWER(code) = LOWER(:code)` 쿼리 파라미터로 그대로 전달됨. 쿼리 실행 오버헤드 외에도 파라미터 바인딩 시 DB 드라이버가 대형 문자열을 처리함.
+**문제**: 버전 prefix 없이 `/api/` 직접 사용. 응답 스키마 변경 시 하위 호환성 관리 불가.
 
-**개선**: `@Size(min=8, max=50)` 추가. `CouponCreateRequest.code`의 `@Pattern`과 동일한 길이 제약을 검증에도 적용한다.
+**개선**: `/api/v1/` prefix 도입.
 
 ---
 
-### 65. `GlobalExceptionHandler` — 예외 메시지 클라이언트 노출
+## 🟡 DBA 스키마 미처리 — 아키텍처 판단 필요
 
-**위치**: `common/exception/GlobalExceptionHandler.java`
+---
 
-**문제**: `handleException(Exception e)` 폴백 핸들러가 `e.getMessage()`를 응답 본문에 포함할 경우 내부 스택 정보(클래스명, SQL 오류 등)가 외부에 노출될 수 있음. 특히 JPA `DataIntegrityViolationException`, `ConstraintViolationException` 등은 테이블명·컬럼명을 메시지에 포함함.
+### 41. `DECIMAL` precision 불일치 — `DECIMAL(19,2)` vs `DECIMAL(12,2)`
 
-**개선**: 폴백 핸들러는 `ErrorCode.INTERNAL_SERVER_ERROR`의 고정 메시지만 반환하고, 실제 예외 메시지는 서버 로그에만 기록한다.
+**위치**: `V13__create_coupon_tables.sql`, `V21__create_refunds_table.sql`, `V15__create_batch_tables.sql`
 
-```java
-@ExceptionHandler(Exception.class)
-public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
-    log.error("예상치 못한 오류 발생", e);
-    return ResponseEntity.status(INTERNAL_SERVER_ERROR)
-        .body(ApiResponse.fail(ErrorCode.INTERNAL_SERVER_ERROR)); // e.getMessage() 제거
-}
-```
+**문제**: 같은 비즈니스 도메인(금액) 컬럼이 두 precision으로 혼재:
+- `DECIMAL(12,2)`: `orders.total_amount`, `payments.amount`, `inventory_transactions` 스냅샷값
+- `DECIMAL(19,2)`: `coupons.discount_value`, `coupon_usages.discount_amount`, `refunds.amount`, `daily_order_stats.total_revenue`
+
+`orders.total_amount(12,2)`와 `coupons.discount_value(19,2)` 비교 시 묵시적 캐스팅 발생. 최대 12자리 금액(9,999,999.99원)으로 충분한 도메인에서 DECIMAL(19,2)는 불필요하게 큰 저장 공간 사용.
+
+**개선**: 금액 컬럼 precision을 `DECIMAL(15,2)`로 통일 (최대 999억원 지원, 일별 매출·누적 집계에 충분).
+
+---
+
+### 42. `delivery_addresses` — 기본 배송지 복수 방지 DB 제약 없음
+
+**위치**: `V12__create_delivery_address_tables.sql`, `DeliveryAddressService`
+
+**문제**: `is_default TINYINT(1)` 컬럼만 있고 "사용자별 `is_default = 1` 레코드는 최대 1개" 제약이 DB에 없음. 애플리케이션 버그 또는 직접 DB 수정 시 기본 배송지가 여러 개 생성될 수 있음. MySQL은 partial unique index를 지원하지 않으므로 트리거 또는 CHECK 제약으로 보완 필요.
+
+**개선 옵션**:
+1. `BEFORE INSERT/UPDATE` 트리거 — `is_default = 1` 설정 시 동일 user의 다른 레코드를 0으로 초기화
+2. 애플리케이션 레벨 검증 강화 + 정기 정합성 점검 쿼리 추가
+
+---
+
+### 43. `orders.findOrderStats()` — 전체 테이블 GROUP BY (대시보드 성능)
+
+**위치**: `OrderRepository.findOrderStats()`, `AdminService.getDashboard()`
+
+**문제**: `SELECT status, COUNT(*), SUM(totalAmount) FROM orders GROUP BY status` — 주문 데이터가 누적될수록 대시보드 API 응답 지연 증가. 현재 `idx_orders_status` 인덱스로 인덱스 스캔은 가능하지만 전체 행을 읽음. `daily_order_stats` 테이블이 이미 존재하지만 실시간 대시보드는 live orders 테이블 집계 사용.
+
+**개선**: 대시보드 통계를 `daily_order_stats` 캐시 + 당일 분만 live 집계로 전환. 또는 `AdminService` 응답에 Redis 캐시(5분 TTL) 적용.
+
+---
+
+### 45. `refunds.payment_id UNIQUE` — `PARTIAL_CANCELLED`(부분 취소) 여러 건 이력 불가
+
+**위치**: `V21__create_refunds_table.sql`, `payments.status = PARTIAL_CANCELLED`
+
+**문제**: `payments.status`에 `PARTIAL_CANCELLED`(부분 취소) 상태가 정의되어 있어 한 결제에 대해 여러 차례 부분 환불이 가능해야 하지만, `refunds.payment_id UNIQUE` 제약이 결제당 단 1건의 환불 레코드만 허용. 부분 취소 두 번째 시도 시 DB에서 `Duplicate entry` 에러 발생.
+
+**개선**: 부분 취소 이력이 필요하면 UNIQUE 제약 제거 + `(payment_id, created_at)` 복합 인덱스 전환. 현재는 `reset()` 재사용으로 FAILED 재시도만 지원하나, 부분 취소 누적 이력은 불가.
+
+---
+
+## ✅ 완료된 항목
+
+---
+
+### ✅ 즉시 수정 완료 — 프로덕션 데이터 정합성 위험 (6/6)
+
+| # | 항목 | 파일 | 조치 |
+|---|------|------|------|
+| 1 | 음수 재고 허용 버그 | `InventoryService` | `BusinessException(INVENTORY_STATE_INCONSISTENT)` throw |
+| 2 | 포인트 롤백 불일치 | `OrderService.create()` | `validateBalance()` fail-fast 사전 검증 추가 |
+| 3 | 배송·포인트 무음 삼킴 | `PaymentTransactionHelper` | Outbox 패턴(`SHIPMENT_CREATE`, `POINT_EARN`) 전환 |
+| 4 | null userId NPE | `OrderExpiryScheduler` | `cancelBySystem()` 전용 메서드, Order에서 userId 직접 조회 |
+| 5 | saveAll() 예외 무음 삼킴 | `InventorySnapshotScheduler` | `DataIntegrityViolationException` 분리, 장애 시 re-throw |
+| 6 | SpEL null NPE | `DistributedLockAspect` | `resolveKey()` null/예외 시 `BusinessException` throw |
+
+---
+
+### ✅ 성능 병목 완료 (3/3)
+
+| # | 항목 | 파일 | 조치 |
+|---|------|------|------|
+| 7 | InventoryRepository fetch join 누락 (N+1) | `InventoryRepository` | `findByProductId`, `findAllByProductIdIn`에 `@EntityGraph({"product"})` 추가 |
+| 8 | CategoryService.getTree() 캐시 미적용 | `CategoryService`, `CacheConfig`, `CategoryResponse` | `getList/getTree` `@Cacheable`, `create/update/delete` `@CacheEvict(allEntries=true)`, categories 30분 TTL, `@Jacksonized` + `ArrayList` 적용 |
+| 9 | InventorySnapshotScheduler 전체 로드 | `InventorySnapshotScheduler`, `InventorySnapshotProcessor` | 1,000건 페이지 루프 + 배치마다 독립 트랜잭션 커밋 (`@Component` 분리) |
+
+---
+
+### ✅ 신규 발굴 성능 병목 완료 (4/4)
+
+| # | 항목 | 조치 |
+|---|------|------|
+| 29 | ReviewService · WishlistService `findByUsername()` DB round-trip | 컨트롤러 `resolveUserId()` 헬퍼 패턴 전환, `userRepository.findByUsername()` 제거 |
+| 30 | OutboxEventRelayScheduler 지수 백오프 없음 | `nextRetryAt` 컬럼(V34) + `findPendingEvents()` 조건 추가, 최대 1시간 백오프 |
+| ~~31~~ | `outbox_events` 쿼리 인덱스 누락 | V18에 이미 `idx_outbox_unpublished` 포함 — 조치 불필요 |
+| 32 | ReviewService.create() 불필요한 Product 전체 엔티티 로드 | `productRepository.findById()` → `existsById()` 전환 |
+
+---
+
+### ✅ 스프린트 완료 (8/11)
+
+| # | 항목 | 파일 | 조치 |
+|---|------|------|------|
+| 10 | applyConfirmResult() 이중 DB 조회 | `PaymentTransactionHelper` | `confirm()` → `Order` 반환, 재사용 |
+| 11 | Outbox 배치 크기 하드코딩 | `OutboxEventRelayScheduler` | `@Value("${outbox.relay.batch-size:100}")` + Prometheus counter |
+| 12 | DB 인덱스 누락 | V23/V25/V27 마이그레이션 | 모든 항목 기존 마이그레이션으로 커버 |
+| 14 | RefundService 이중 쿼리 | `Refund` 엔티티 + `RefundService` | `userId` 비정규화 저장 → `validateOwnership()` orders 조회 제거, V28 마이그레이션 |
+| 17 | P6Spy 운영 오버헤드 | `build.gradle` | `implementation` → `runtimeOnly` |
+| 18 | Zipkin 샘플링 100% | `application.properties` | 1.0 → 0.1 (운영: 0.01~0.1) |
+| 19 | OrderSearchRequest mutable DTO | `OrderSpecification` + `OrderService` | `of(request, forceUserId)` 오버로드, DTO 변경 제거 |
+
+---
+
+### ✅ 기술 부채 완료 (7/8)
+
+| # | 항목 | 파일 | 조치 |
+|---|------|------|------|
+| 21 | 동시성 통합 테스트 부재 | `ConcurrencyIntegrationTest`, `InventoryConcurrencyTest` | 이미 구현 완료 (ExecutorService + CountDownLatch, reserve() 재고 불변 조건 검증) |
+| 22 | Pitest targetClasses 제한적 | `build.gradle` | 6개 → 15개로 확장 (shipment·product·review·wishlist·category·user·address·cart 추가) |
+| 23 | 전체 Refresh Token 무효화 불가 | `RefreshTokenStore`, `UserService` | 이미 구현 완료 (`revokeAll()` + 비밀번호 변경 시 자동 호출) |
+| 24 | 쿠폰 코드 엔트로피 검증 없음 | `CouponCreateRequest` | 이미 구현 완료 (`@Pattern` 영문+숫자 혼합 8자 이상 강제) |
+| 26 | Dockerfile HEALTHCHECK 미정의 | `Dockerfile` | 이미 구현 완료 (`--interval=30s --retries=3`) |
+| 27 | `storage.enabled` 문서화 누락 | `application.properties` | 이미 구현 완료 (`storage.enabled=false` + 주석) |
+| 28 | Payment 도메인 주석 언어 불일치 | `PaymentService`, `PaymentTransactionHelper` | 영어 inline 주석·Javadoc·log 메시지 → 한국어(키워드 영문) 통일 |
+
+---
+
+### ✅ DBA 진단 완료 (9/13)
+
+| # | 항목 | 조치 |
+|---|------|------|
+| 33 | `refunds.user_id DEFAULT 0` — 소유권 검증 영구 실패 | V29 백필 마이그레이션 + FK 제약 추가 |
+| 34 | `payments` 테이블 CHARSET/COLLATE 미정의 | V29 `ALTER TABLE ... CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci` |
+| 35 | `orders` `(status, created_at)` 복합 인덱스 누락 | V29 `ADD INDEX idx_orders_status_created` |
+| 36 | `coupons` 복합 인덱스 누락 + 만료 처리 N UPDATE | V29 인덱스 추가 + `@Modifying` 벌크 UPDATE 전환 |
+| 37 | `products.status` 인덱스 누락 | V29 `ADD INDEX idx_products_status` |
+| 38 | `cart_items.user_id` FK 누락 | V29 `fk_cart_user` FK 제약 추가 |
+| 39 | `point_transactions.order_id` FK 누락 | V29 `fk_pt_order` FK (ON DELETE SET NULL) 추가 |
+| 40 | `created_at` DEFAULT CURRENT_TIMESTAMP 없는 테이블 6개 | V33 각 컬럼 ALTER |
+| 44 | 일부 테이블 COLLATE 미정의 | V30 3개 테이블 charset/collation 통일 |
+
+---
+
+### ✅ 보안·버그·기능 완료
+
+| 항목 | 비고 |
+|------|------|
+| PaymentService JWT userId 적용 | DB 라운드트립 제거, `resolveUserId()` 패턴 |
+| ES 상품 동기화 | `@TransactionalEventListener(AFTER_COMMIT)` + `ProductEventListener` |
+| CSP `unsafe-eval` 제거 | `SecurityConfig` script-src 정책 강화 |
+| 가상계좌 Webhook 처리 | `applyWebhookConfirmResult()` confirm 흐름 재사용 |
+| JWT 시크릿 기본값 경고 | `@PostConstruct` ERROR 로그 |
+| RefundService 영구 재시도 불가 버그 | FAILED 상태 환불 `reset()` 후 재사용 |
+| LoginRateLimiter Lua 원자화 | `RAtomicLong` → Lua INCR+EXPIRE 원자적 처리 |
+| ShipmentService / PointService `REQUIRES_NEW` | `UnexpectedRollbackException` 방지 |
+| DeliveryAddressRepository `findFirstBy...` | 기본 배송지 삭제 후 1건만 조회 |
+
+| 기능 | 기능 |
+|------|------|
+| 인증 (로그인/로그아웃/토큰 재발급) | 상품 목록/검색 (Elasticsearch) |
+| 상품 상세 (재고 상태·별점 통합) | 카테고리 트리 |
+| 장바구니 (품절 상태 포함) | 주문 생성/취소/목록/이력 |
+| TossPayments 결제/취소 | 배송 조회 |
+| 환불 | 리뷰 작성/수정/조회/삭제 |
+| 위시리스트 | 포인트 잔액/이력 |
+| 배송지 관리 | 내 쿠폰 목록 / 공개 쿠폰 claim |
+| 프로필 수정 / 비밀번호 변경 | 상품 이미지 업로드 (MinIO Presigned URL) |
+| 주문 아이템 리뷰 작성 여부 | 주문 상세 통합 응답 |

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -35,13 +35,13 @@ Client
 
 ---
 
-## 🔴 보안 취약점 진단 (0/10)
+## 🔴 보안 취약점 진단 (5/10 완료)
 
 > 전체 코드베이스 보안 분석. IDOR·인증 누락·설정 오류 중심.
 
 ---
 
-### 56. `PaymentController.getByPaymentKey()` — 인증·소유권 검증 없음 (IDOR)
+### ✅ 56. `PaymentController.getByPaymentKey()` — 인증·소유권 검증 없음 (IDOR)
 
 **위치**: `domain/payment/controller/PaymentController.java` L87-91
 
@@ -59,7 +59,7 @@ public ApiResponse<PaymentResponse> getByPaymentKey(@PathVariable String payment
 
 ---
 
-### 57. `TossWebhookVerifier` — `Mac` 인스턴스 `synchronized` 직렬화로 처리량 저하
+### ✅ 57. `TossWebhookVerifier` — `Mac` 인스턴스 `synchronized` 직렬화로 처리량 저하
 
 **위치**: `common/security/TossWebhookVerifier.java` L34-58
 
@@ -69,7 +69,7 @@ public ApiResponse<PaymentResponse> getByPaymentKey(@PathVariable String payment
 
 ---
 
-### 58. Admin 기본 자격증명 (`admin/changeme`) — 운영 배포 시 변경 누락 위험
+### ✅ 58. Admin 기본 자격증명 (`admin/changeme`) — 운영 배포 시 변경 누락 위험
 
 **위치**: `common/config/AdminSecurityConfig.java`, `application.properties`
 
@@ -119,7 +119,7 @@ public ApiResponse<PaymentResponse> getByPaymentKey(@PathVariable String payment
 
 ---
 
-### 63. Actuator — `/env`, `/beans`, `/loggers` 엔드포인트 외부 노출
+### ✅ 63. Actuator — `/env`, `/beans`, `/loggers` 엔드포인트 외부 노출
 
 **위치**: `src/main/resources/application.properties` `management.endpoints.web.exposure.include`
 
@@ -136,7 +136,7 @@ management.endpoint.heapdump.enabled=false
 
 ---
 
-### 64. `CouponValidateRequest.couponCode` — `@Size` 검증 누락
+### ✅ 64. `CouponValidateRequest.couponCode` — `@Size` 검증 누락
 
 **위치**: `domain/coupon/dto/CouponValidateRequest.java`
 
@@ -165,13 +165,13 @@ public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
 
 ---
 
-## 🔴 코드리뷰 — 구조·성능·보안 (0/10)
+## 🔴 코드리뷰 — 구조·성능·보안 (6/10 완료)
 
 > 182개 Java 파일 전수 분석. 우선순위 순으로 정렬.
 
 ---
 
-### 46. JWT Secret 기본값 — 로그 경고만 출력, 시작 실패 없음
+### ✅ 46. JWT Secret 기본값 — 로그 경고만 출력, 시작 실패 없음
 
 **위치**: `common/security/JwtTokenProvider.java` `@PostConstruct`
 
@@ -205,7 +205,7 @@ return ips[idx].trim();
 
 ---
 
-### 48. `CartService.getCart()` — Product 지연로딩 N+1
+### ✅ 48. `CartService.getCart()` — Product 지연로딩 N+1
 
 **위치**: `domain/order/cart/service/CartService.java` `getCart()`
 
@@ -220,7 +220,7 @@ List<CartItem> findByUserIdWithProduct(@Param("userId") Long userId);
 
 ---
 
-### 49. `ShipmentService.getByOrderId()` — 소유권 검증에 Order 전체 엔티티 로드
+### ✅ 49. `ShipmentService.getByOrderId()` — 소유권 검증에 Order 전체 엔티티 로드
 
 **위치**: `domain/shipment/service/ShipmentService.java` `getByOrderId()`
 
@@ -236,7 +236,7 @@ Optional<Long> findUserIdById(@Param("orderId") Long orderId);
 
 ---
 
-### 50. `CouponService` — 동일 조건 중복 검증 (3곳)
+### ✅ 50. `CouponService` — 동일 조건 중복 검증 (3곳)
 
 **위치**: `domain/coupon/service/CouponService.java`
 
@@ -286,7 +286,7 @@ Optional<Long> findUserIdById(@Param("orderId") Long orderId);
 
 ---
 
-### 54. `DistributedLock` + Pessimistic Lock 이중 제어 — 단일 인스턴스에서 불필요한 오버헤드
+### ✅ 54. `DistributedLock` + Pessimistic Lock 이중 제어 — 단일 인스턴스에서 불필요한 오버헤드
 
 **위치**: `domain/inventory/service/InventoryService.java` `reserve()` / `releaseReservation()` 등
 
@@ -296,7 +296,7 @@ Optional<Long> findUserIdById(@Param("orderId") Long orderId);
 
 ---
 
-### 55. `RefundService.requestRefund()` — `noRollbackFor + throw` 패턴 불명확
+### ✅ 55. `RefundService.requestRefund()` — `noRollbackFor + throw` 패턴 불명확
 
 **위치**: `domain/refund/service/RefundService.java` `requestRefund()` L58-107
 
@@ -507,11 +507,21 @@ return RefundResponse.from(refund); // HTTP 200, status=FAILED
 
 | 항목 | 비고 |
 |------|------|
+| #46 JWT Secret 기본값 → 시작 실패 | `JwtTokenProvider @PostConstruct` `IllegalStateException` throw |
+| #48 CartService N+1 | `CartRepository.findByUserId()` 이미 `@EntityGraph(product)` 적용 |
+| #49 ShipmentService userId 프로젝션 | `orderRepository.findUserIdById()` — Order 전체 로드 불필요 |
+| #50 CouponService 검증 중복 제거 | `applyCoupon()` → `validateConditions()` 통합 호출 |
+| #54 InventoryService 이중 락 문서화 | `reserve()` Javadoc: Redis 장애 시 DB 비관적 락이 최후 방어선 |
+| #55 RefundService noRollbackFor 문서화 | 이미 주석 존재 (confirmed) |
+| #56 PaymentController IDOR 수정 | `getByPaymentKey()` 소유권 검증 + `orderRepository.findUserIdById()` |
+| #57 TossWebhookVerifier Mac per-call | 싱글턴 + `synchronized` → 호출마다 `Mac.getInstance()` |
+| #58 Admin 기본 자격증명 → 시작 실패 | `AdminSecurityConfig @PostConstruct` `IllegalStateException` throw |
+| #63 Actuator 엔드포인트 최소화 | `env/heapdump/threaddump/beans/mappings/loggers` 비활성화 |
+| #64 CouponValidateRequest @Size 추가 | `@Size(min=8, max=50)` 입력 크기 제한 |
 | PaymentService JWT userId 적용 | DB 라운드트립 제거, `resolveUserId()` 패턴 |
 | ES 상품 동기화 | `@TransactionalEventListener(AFTER_COMMIT)` + `ProductEventListener` |
 | CSP `unsafe-eval` 제거 | `SecurityConfig` script-src 정책 강화 |
 | 가상계좌 Webhook 처리 | `applyWebhookConfirmResult()` confirm 흐름 재사용 |
-| JWT 시크릿 기본값 경고 | `@PostConstruct` ERROR 로그 |
 | RefundService 영구 재시도 불가 버그 | FAILED 상태 환불 `reset()` 후 재사용 |
 | LoginRateLimiter Lua 원자화 | `RAtomicLong` → Lua INCR+EXPIRE 원자적 처리 |
 | ShipmentService / PointService `REQUIRES_NEW` | `UnexpectedRollbackException` 방지 |

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -35,7 +35,7 @@ Client
 
 ---
 
-## 🔴 보안 취약점 진단 (5/10 완료)
+## 🔴 보안 취약점 진단 (5/10 완료, #60 조치 불필요)
 
 > 전체 코드베이스 보안 분석. IDOR·인증 누락·설정 오류 중심.
 
@@ -89,13 +89,18 @@ public ApiResponse<PaymentResponse> getByPaymentKey(@PathVariable String payment
 
 ---
 
-### 60. Toss Webhook — 타임스탬프 검증 없음 (Replay Attack 가능)
+### ~~60. Toss Webhook — 타임스탬프 검증 없음 (Replay Attack 가능)~~ → 조치 불필요
 
 **위치**: `domain/payment/controller/PaymentController.java` `/webhook` 핸들러, `common/security/TossWebhookVerifier.java`
 
-**문제**: HMAC 서명 검증은 되어 있지만 요청 타임스탬프를 확인하지 않음. 공격자가 유효한 Webhook 요청을 캡처해 나중에 재전송하면 동일한 결제 확정 이벤트가 여러 번 처리될 수 있음. `PaymentIdempotencyManager`가 중복 처리를 일부 차단하지만 멱등성 키 만료 이후에는 방어되지 않음.
+**조사 결과 (2026-04-15)**: Toss 공식 문서 확인 결과, `tosspayments-webhook-signature` / `tosspayments-webhook-transmission-time` 헤더는 **`payout.changed`·`seller.changed` 이벤트 전용**이다. 우리 코드에서 처리하는 `PAYMENT_COMPLETED`, `VIRTUAL_ACCOUNT_DEPOSIT` 등 **일반 결제 웹훅에는 타임스탬프 헤더가 포함되지 않는다**. 따라서 헤더 기반 타임스탬프 검증은 적용 불가.
 
-**개선**: Toss 요청 헤더의 타임스탬프를 추출해 현재 시각과의 차이가 5분 초과 시 거부한다.
+**현황으로 충분한 이유**:
+- `PaymentIdempotencyManager` (Redis SETNX) — 동일 paymentKey 중복 처리 차단
+- `Payment.status` 상태 전이 검증 — 이미 CONFIRMED 상태인 결제는 재처리 거부
+- 멱등성 키 만료 이후 재전송 시나리오는 결제 완료 후 장기간이 지난 상태이므로 실질적 위협 낮음
+
+**참고**: [토스페이먼츠 웹훅 이벤트 문서](https://docs.tosspayments.com/reference/using-api/webhook-events)
 
 ---
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -37,21 +37,22 @@ Client
 
 ## 🔴 긴급 — 프로덕션 버그 (데이터 손실·사용자 피해)
 
-> 운영 중 발생 시 사용자 과금 또는 데이터 손실로 직결되는 항목.
+> ✅ **현재 미해결 항목 없음.** 아래 #52는 완료 처리됨.
 
 ---
 
-### 52. Toss 승인 완료 후 주문 만료 경합 — 결제됐는데 주문 취소
+### ✅ 52. Toss 승인 완료 후 주문 만료 경합 — `PAYMENT_IN_PROGRESS` 상태로 해결
 
-**위치**: `domain/payment/service/PaymentTransactionHelper.java` `applyConfirmResult()`
+**위치**: `domain/payment/service/PaymentTransactionHelper.java`, `domain/order/entity/Order.java`, `domain/order/entity/OrderStatus.java`
 
-**문제**: Toss API 승인 요청 중(`callTossConfirmApi()` 대기, 최대 30초) 만료 스케줄러가 Order를 CANCELLED로 변경 가능. Toss는 결제를 완료했으나 주문은 취소된 상태 → 사용자는 청구됨, 서버는 `log.error("[Payment] CRITICAL: …수동 환불 필요…")` 로그만 출력하고 끝.
+**문제(해결됨)**: Toss API 승인 요청 중(`callTossConfirmApi()` 대기, 최대 30초) 만료 스케줄러가 Order를 CANCELLED로 변경 가능. Toss는 결제를 완료했으나 주문은 취소된 상태 → 사용자는 청구됨, 서버는 `CRITICAL` 로그만 출력.
 
-**현황**: 실제 발생 시 운영자가 로그를 확인하고 수동 환불해야 함. 자동 감지·알림 없음.
-
-**개선 방향**:
-- 결제 승인 직전 Order 상태를 `PAYMENT_IN_PROGRESS`로 선점 → 만료 스케줄러가 건드리지 못하게 차단 (근본 해결)
-- 단기: `dead_letter_payments` 테이블에 레코드 삽입 → 대시보드에서 미처리 건 추적
+**적용된 해결책** (Stripe `processing` / Magento `payment_review` 동일 패턴):
+- `OrderStatus.PAYMENT_IN_PROGRESS` 추가 — Toss HTTP 대기 중 전용 상태
+- `loadAndValidateForConfirm()`: 검증 완료 후 `order.startPayment()` 호출 → PENDING → PAYMENT_IN_PROGRESS 커밋
+- `findExpiredPendingOrderIds()`: `status = 'PENDING'`만 조회 → PAYMENT_IN_PROGRESS 주문은 자동 스킵
+- Toss API 실패 시 catch 블록에서 `resetOrderOnPaymentError()` (`REQUIRES_NEW`) 호출 → PENDING 복원
+- `Order.confirm()`: PENDING(가상계좌 Webhook 경로) + PAYMENT_IN_PROGRESS(일반 결제 경로) 양쪽 허용
 
 ---
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4,6 +4,37 @@
 
 ---
 
+## 아키텍처 요약
+
+```
+Client
+  │
+  ├─ AuthController (JWT 발급)
+  ├─ ProductController / CategoryController / ProductImageController
+  ├─ InventoryController
+  ├─ OrderController → OrderService(God Object) → InventoryService · CouponService · PointService
+  ├─ PaymentController → PaymentService → PaymentTransactionHelper → OrderService (역방향 의존)
+  │                                                                 └─ OutboxEventStore
+  ├─ ShipmentController → ShipmentService
+  ├─ RefundController → RefundService → PaymentService
+  ├─ CartController → CartService → OrderService
+  ├─ WishlistController / ReviewController / PointController
+  └─ AdminController → AdminService
+
+공통 인프라:
+  Redis — JWT 블랙리스트 · Refresh Token · Cache · Rate Limit · 분산 락 · Outbox relay 락
+  Elasticsearch — 상품 전문 검색 (MySQL fallback)
+  MinIO(S3) — 상품 이미지 Presigned URL
+  OutboxEventStore — ORDER_CREATED/CANCELLED · PAYMENT_CONFIRMED · SHIPMENT_CREATE · POINT_EARN
+  Flyway V1~V34 — 스키마 버전 관리
+```
+
+**주요 데이터 흐름**: 주문 생성 → 재고 예약(분산 락) → PENDING → Toss 결제 승인 → Outbox 이벤트(배송·포인트) → CONFIRMED → 배송 상태 전이 → 완료
+
+**동시성 전략**: 재고 변경 `@DistributedLock(Redisson)` + `SELECT FOR UPDATE`(이중), 결제 확정 `PaymentIdempotencyManager(Redis SETNX)`, 쿠폰 발급 `findByCodeWithLock(비관적 락)`
+
+---
+
 ## ✅ 즉시 수정 완료 — 프로덕션 데이터 정합성 위험 (6/6)
 
 | # | 항목 | 파일 | 조치 |
@@ -343,3 +374,151 @@ ALTER TABLE outbox_events             CONVERT TO CHARACTER SET utf8mb4 COLLATE u
 | 배송지 관리 | 내 쿠폰 목록 / 공개 쿠폰 claim |
 | 프로필 수정 / 비밀번호 변경 | 상품 이미지 업로드 (MinIO Presigned URL) |
 | 주문 아이템 리뷰 작성 여부 | 주문 상세 통합 응답 |
+
+---
+
+## 🔴 시니어 엔지니어 코드리뷰 — 구조·성능·보안 (0/10)
+
+> 182개 Java 파일 전수 분석. 우선순위 순으로 정렬.
+
+---
+
+### 46. JWT Secret 기본값 — 로그 경고만 출력, 시작 실패 없음
+
+**위치**: `common/security/JwtTokenProvider.java` `@PostConstruct`
+
+**문제**: `JWT_SECRET` 환경변수 미설정 시 개발용 기본값으로 계속 실행됨. ERROR 로그를 출력하지만 아무도 로그를 보지 않으면 운영 배포에서 취약한 시크릿이 그대로 사용됨.
+
+**개선**: 기본값 감지 시 `IllegalStateException`으로 애플리케이션 시작 자체를 실패시킨다.
+
+```java
+if (DEV_DEFAULT_SECRET.equals(secretKeyStr)) {
+    throw new IllegalStateException(
+        "JWT_SECRET 환경변수가 설정되지 않았습니다. 운영 환경에서는 반드시 설정하세요.");
+}
+```
+
+---
+
+### 47. `X-Forwarded-For` 마지막 IP 추출 — Rate Limit 우회 가능
+
+**위치**: `common/ratelimit/RateLimitAspect.java` `extractClientIp()`
+
+**문제**: `X-Forwarded-For: client, proxy1, proxy2`에서 마지막 IP(`proxy2`)를 추출하는데, 공격자가 헤더를 `X-Forwarded-For: real_ip, attacker_ip`로 조작하면 `attacker_ip`로 Rate Limit 버킷이 생성되어 실질적인 IP 기반 제한이 무력화됨.
+
+**개선**: 프록시 수(`rate-limit.trusted-proxy-count`)를 설정하고, 헤더 끝에서 N번째 IP를 추출한다.
+
+```java
+// X-Forwarded-For에서 신뢰할 수 있는 클라이언트 IP 추출
+String[] ips = forwarded.split(",");
+int idx = Math.max(0, ips.length - 1 - trustedProxyCount);
+return ips[idx].trim();
+```
+
+---
+
+### 48. `CartService.getCart()` — Product 지연로딩 N+1
+
+**위치**: `domain/order/cart/service/CartService.java` `getCart()`
+
+**문제**: `cartRepository.findByUserId(userId)`로 CartItem을 조회한 뒤 루프에서 `item.getProduct().getId()`를 호출 → 각 CartItem마다 Product 지연로딩 쿼리 발생 (N+1). Inventory는 배치 조회되지만 Product 조회가 N번 실행됨.
+
+**개선**: CartItem 조회 시 Product를 fetch join으로 함께 로드한다.
+
+```java
+@Query("SELECT c FROM CartItem c JOIN FETCH c.product WHERE c.userId = :userId ORDER BY c.createdAt DESC")
+List<CartItem> findByUserIdWithProduct(@Param("userId") Long userId);
+```
+
+---
+
+### 49. `ShipmentService.getByOrderId()` — 소유권 검증에 Order 전체 엔티티 로드
+
+**위치**: `domain/shipment/service/ShipmentService.java` `getByOrderId()`
+
+**문제**: 배송 조회 시 소유권 검증을 위해 `orderRepository.findById(orderId)`로 Order 전체(+ 컬렉션 Lazy) 를 로드하지만 실제 필요한 건 `userId` 필드 하나뿐.
+
+**개선**: `userId`만 프로젝션으로 조회한다.
+
+```java
+// OrderRepository에 추가
+@Query("SELECT o.userId FROM Order o WHERE o.id = :orderId")
+Optional<Long> findUserIdById(@Param("orderId") Long orderId);
+```
+
+---
+
+### 50. `CouponService` — 동일 조건 중복 검증 (3곳)
+
+**위치**: `domain/coupon/service/CouponService.java`
+
+**문제**: 쿠폰 유효성 검증 로직(`active`, `validFrom`, `validUntil`, `maxUsageCount`, 사용자 중복 여부)이 `validate()`, `applyCoupon()`, `issueCoupon()` 세 곳에 분산·중복됨. 정책 변경 시 3곳을 모두 수정해야 해 누락 위험 있음.
+
+**개선**: `validateCouponConditions(Coupon, Long userId)` private 메서드로 추출하고 세 곳에서 호출한다.
+
+---
+
+### 51. `OrderService` God Object — 단일 서비스에 책임 과다
+
+**위치**: `domain/order/service/OrderService.java` (430줄)
+
+**문제**: 주문 생성·조회·취소·상태 이력·페이지네이션·쿠폰 적용·포인트 차감·재고 검증·배송지 검증을 단일 클래스가 담당. 테스트 시 Mock이 10개 이상 필요하며, 기능 추가마다 클래스가 비대해짐.
+
+**개선 방향**:
+- `OrderQueryService` — 조회 전용 (readOnly)
+- `OrderCommandService` — 생성·취소 (write)
+- `OrderValidationService` — 배송지·쿠폰·포인트 사전 검증 추출
+
+---
+
+### 52. Toss 승인 완료 후 주문 만료 경합 — 수동 환불 필요 시나리오 무처리
+
+**위치**: `domain/payment/service/PaymentTransactionHelper.java` `applyConfirmResult()` L175-187
+
+**문제**: Toss API 승인 요청 중(`callTossConfirmApi()` 대기) 만료 스케줄러가 Order를 CANCELLED로 변경 가능. Toss는 결제를 완료했으나 주문은 취소된 상태 → CRITICAL 로그만 출력하고 사용자는 청구됨.
+
+**현황**: `log.error("[Payment] CRITICAL: …수동 환불 필요…")` 에 그침.
+
+**개선 방향**:
+- CRITICAL 상황 감지 시 운영팀 알림 발송 (Slack Webhook, PagerDuty 등)
+- `dead_letter_payments` 테이블에 레코드 삽입해 대시보드에서 추적
+- 결제 승인 직전 Order 상태를 `PAYMENT_IN_PROGRESS`로 선점해 만료 스케줄러가 건드리지 못하게 차단
+
+---
+
+### 53. `ProductService` ES Fallback — MySQL LIKE 검색으로 결과 불일치
+
+**위치**: `domain/product/service/ProductService.java` `getList()` L98-116
+
+**문제**: ES 장애 시 MySQL `LIKE '%keyword%'` 검색으로 Fallback하는데, ES의 형태소 분석·관련성 점수 기반 정렬과 전혀 다른 결과를 반환함. 사용자 입장에서 검색 결과가 갑자기 바뀌는 UX 문제 발생.
+
+**개선 옵션**:
+- ES 장애 시 빈 결과 반환 + "검색 서비스 일시 장애" 메시지 표시 (결과 불일치 방지)
+- 또는 MySQL 전문 검색(`MATCH … AGAINST`)으로 대체해 품질 차이를 최소화
+
+---
+
+### 54. `DistributedLock` + Pessimistic Lock 이중 제어 — 단일 인스턴스에서 불필요한 오버헤드
+
+**위치**: `domain/inventory/service/InventoryService.java` `reserve()` / `releaseReservation()` 등
+
+**문제**: Redis 분산 락(`@DistributedLock`) + DB `SELECT FOR UPDATE`(비관적 락)을 동시에 사용. 단일 인스턴스 환경에서는 분산 락이 불필요하고, 멀티 인스턴스 환경에서는 DB 비관적 락만으로도 충분한 경우가 많음. 두 락을 모두 획득해야 하므로 레이턴시 증가.
+
+**현황**: 의도적 이중 방어선이라면 문서화 필요. 설계 판단이 필요한 항목.
+
+---
+
+### 55. `RefundService.requestRefund()` — `noRollbackFor + throw` 패턴 불명확
+
+**위치**: `domain/refund/service/RefundService.java` `requestRefund()` L58-107
+
+**문제**: `@Transactional(noRollbackFor = Exception.class)`와 `catch (Exception e) { refund.fail(); throw e; }`를 함께 사용. 예외를 던지면서도 트랜잭션을 커밋하려는 의도인데, 클라이언트는 HTTP 500을 받고 Refund 상태만 FAILED로 변경된 채로 유지됨. 의도가 불명확해 유지보수 시 오해 유발.
+
+**개선**: 예외를 던지지 않고 FAILED 상태를 반환하거나, 명시적인 주석으로 패턴 의도를 문서화한다.
+
+```java
+// 현재: throw e (클라이언트 500 수신, refund는 FAILED 커밋)
+// 개선: FAILED 상태를 정상 응답으로 반환 (클라이언트가 재시도 가능)
+refund.fail(reason);
+return RefundResponse.from(refund); // HTTP 200, status=FAILED
+```

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -105,6 +105,215 @@
 
 ---
 
+## ✅ DBA 진단 — 스키마 결함 및 누락 제약 (9/13)
+
+### ✅ 33. `refunds.user_id DEFAULT 0` — 기존 환불 소유권 검증 영구 실패 (V28 결함)
+
+**위치**: `V29__backfill_refunds_user_id.sql`
+
+**조치**: V29 마이그레이션 추가 — `orders.user_id` JOIN 백필 + `fk_refunds_user` FK 제약 추가.
+
+---
+
+### ✅ 34. `payments` 테이블 — `ENGINE` · `CHARSET` · `COLLATE` 미정의 (V4 결함)
+
+**위치**: `V4__create_payment_tables.sql`
+
+**문제**: V4의 `CREATE TABLE payments` 구문에 `ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci`가 없음. 서버 기본 collation(`utf8mb4_0900_ai_ci`)이 적용되어 다른 테이블(`utf8mb4_unicode_ci`)과 collation이 달라짐. `payments JOIN orders`, `payments JOIN users` 조인 시 `Illegal mix of collations` 에러 또는 인덱스 미사용 가능.
+
+**개선**: V29 마이그레이션:
+```sql
+ALTER TABLE payments CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+```
+
+---
+
+### ✅ 35. `orders` — `(status, created_at)` 복합 인덱스 누락
+
+**위치**: `V23__add_orders_indexes.sql`, `OrderRepository.countByStatusAndCreatedAtBetween()`
+
+**문제**: `DailyOrderStatsScheduler`가 매일 자정 `countByStatusAndCreatedAtBetween(CONFIRMED, start, end)`과 `countByStatusAndCreatedAtBetween(CANCELLED, start, end)`을 2회 실행. 쿼리: `WHERE status = ? AND created_at >= ? AND created_at < ?`. 현재 `idx_orders_status(status)` + `idx_orders_created_at(created_at)` 각각 존재하나 복합 조건에는 단일 인덱스 선택 후 나머지 필터링(filesort). 운영 주문이 누적될수록 성능 저하.
+
+**개선**: V29 마이그레이션:
+```sql
+ALTER TABLE orders ADD INDEX idx_orders_status_created (status, created_at);
+```
+
+---
+
+### ✅ 36. `coupons` — `(valid_until, active)` 복합 인덱스 누락 + 만료 처리 벌크 UPDATE 미적용
+
+**위치**: `CouponRepository.findExpiredActiveCoupons()`, `CouponExpiryScheduler`
+
+**문제**:
+- 쿼리 `WHERE valid_until < :now AND active = true` — 인덱스 없으면 전체 coupons 테이블 풀스캔 (매일 새벽 1시 실행)
+- `deactivate()` Dirty Checking으로 쿠폰 수만큼 개별 `UPDATE` 발생 — 만료 쿠폰 100건 = 100 UPDATE
+
+**개선**:
+- 인덱스: `ADD INDEX idx_coupons_expiry (valid_until, active)` (V29 마이그레이션)
+- 벌크 UPDATE: `UPDATE coupons SET active = false WHERE valid_until < :now AND active = true` 단일 쿼리로 대체
+
+---
+
+### ✅ 37. `products.status` 인덱스 누락
+
+**위치**: `V1__init_schema.sql`, `ProductRepository`
+
+**문제**: `ProductRepository`의 `findAllActiveBySpec()`, `findWithSpec()` 등이 `WHERE status = 'ACTIVE'` 조건을 항상 포함. status 인덱스가 V1~V28 어디에도 없어 전체 products 스캔 후 필터링. ES fallback 쿼리에서도 동일하게 사용.
+
+**개선**: V29 마이그레이션:
+```sql
+ALTER TABLE products ADD INDEX idx_products_status (status);
+```
+
+---
+
+### ✅ 38. `cart_items.user_id` — FK 누락, 사용자 탈퇴 시 고아 레코드
+
+**위치**: `V10__create_cart_tables.sql`
+
+**문제**: `cart_items`에 `product_id → products FK`는 있지만 `user_id → users FK`가 없음. `users.deleted_at`(소프트 삭제, V16)에도 불구하고, 사용자 삭제 시 `cart_items` 레코드는 고아(orphan)로 남아 user_id가 무효한 상태로 유지됨.
+
+**개선**: V29 마이그레이션:
+```sql
+ALTER TABLE cart_items
+    ADD CONSTRAINT fk_cart_user FOREIGN KEY (user_id) REFERENCES users (id);
+```
+
+---
+
+### ✅ 39. `point_transactions.order_id` — FK 누락, 고아 참조 가능
+
+**위치**: `V20__create_point_tables.sql`
+
+**문제**: `point_transactions.order_id BIGINT NULL`이지만 `orders(id)` FK가 없음. 주문 삭제 시 포인트 이력의 `order_id`는 유효하지 않은 ID를 참조하게 되어 데이터 조회 정합성 훼손 가능. `user_id`에는 FK가 있지만 `order_id`에는 없어 일관성 없음.
+
+**개선**: V29 마이그레이션 (ON DELETE SET NULL — 주문 삭제 시 이력 보존):
+```sql
+ALTER TABLE point_transactions
+    ADD CONSTRAINT fk_pt_order FOREIGN KEY (order_id) REFERENCES orders (id) ON DELETE SET NULL;
+```
+
+---
+
+### ✅ 40. `created_at` / `updated_at` — `DEFAULT CURRENT_TIMESTAMP` 없는 테이블 6개
+
+**위치**: V4(`payments`), V10(`cart_items`), V11(`shipments`), V12(`delivery_addresses`), V17(`product_images`), V22(`user_coupons`)
+
+**문제**: 6개 테이블의 `created_at DATETIME(6) NOT NULL`에 `DEFAULT CURRENT_TIMESTAMP(6)`이 없음. Hibernate `@CreationTimestamp`에만 의존 — bulk INSERT 또는 DB 직접 조작 시 `NULL` 삽입으로 `NOT NULL` 제약 위반 또는 묵시적 `'0000-00-00'` 저장 가능. 나머지 테이블들(V1~V3, V5, V6 등)은 모두 DEFAULT가 있어 불일치.
+
+**개선**: V29 마이그레이션으로 각 컬럼 ALTER (6개 테이블):
+```sql
+ALTER TABLE payments   MODIFY created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);
+ALTER TABLE shipments  MODIFY created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);
+-- ... (4개 더)
+```
+
+---
+
+### 41. `DECIMAL` precision 불일치 — `DECIMAL(19,2)` vs `DECIMAL(12,2)`
+
+**위치**: `V13__create_coupon_tables.sql`, `V21__create_refunds_table.sql`, `V15__create_batch_tables.sql`
+
+**문제**: 같은 비즈니스 도메인(금액) 컬럼이 두 precision으로 혼재:
+- `DECIMAL(12,2)`: `orders.total_amount`, `payments.amount`, `inventory_transactions` 스냅샷값
+- `DECIMAL(19,2)`: `coupons.discount_value`, `coupon_usages.discount_amount`, `refunds.amount`, `daily_order_stats.total_revenue`
+
+`orders.total_amount(12,2)`와 `coupons.discount_value(19,2)` 비교 시 묵시적 캐스팅 발생. 최대 12자리 금액(9,999,999.99원)으로 충분한 도메인에서 DECIMAL(19,2)는 불필요하게 큰 저장 공간 사용.
+
+**개선**: 금액 컬럼 precision을 `DECIMAL(15,2)`로 통일 (최대 999억원 지원, 일별 매출·누적 집계에 충분).
+
+---
+
+### 42. `delivery_addresses` — 기본 배송지 복수 방지 DB 제약 없음
+
+**위치**: `V12__create_delivery_address_tables.sql`, `DeliveryAddressService`
+
+**문제**: `is_default TINYINT(1)` 컬럼만 있고 "사용자별 `is_default = 1` 레코드는 최대 1개" 제약이 DB에 없음. 애플리케이션 버그 또는 직접 DB 수정 시 기본 배송지가 여러 개 생성될 수 있음. MySQL은 partial unique index를 지원하지 않으므로 트리거 또는 CHECK 제약으로 보완 필요.
+
+**개선 옵션**:
+1. `BEFORE INSERT/UPDATE` 트리거 — `is_default = 1` 설정 시 동일 user의 다른 레코드를 0으로 초기화
+2. 애플리케이션 레벨 검증 강화 + 정기 정합성 점검 쿼리 추가
+
+---
+
+### 43. `orders.findOrderStats()` — 전체 테이블 GROUP BY (대시보드 성능)
+
+**위치**: `OrderRepository.findOrderStats()`, `AdminService.getDashboard()`
+
+**문제**: `SELECT status, COUNT(*), SUM(totalAmount) FROM orders GROUP BY status` — 주문 데이터가 누적될수록 대시보드 API 응답 지연 증가. 현재 `idx_orders_status` 인덱스로 인덱스 스캔은 가능하지만 전체 행을 읽음. `daily_order_stats` 테이블이 이미 존재하지만 실시간 대시보드는 live orders 테이블 집계 사용.
+
+**개선**: 대시보드 통계를 `daily_order_stats` 캐시 + 당일 분만 live 집계로 전환. 또는 `AdminService` 응답에 Redis 캐시(5분 TTL) 적용.
+
+---
+
+### ✅ 44. 일부 테이블 `COLLATE` 미정의 — collation 불일치
+
+**위치**: `V15`(`daily_order_stats`, `daily_inventory_snapshots`), `V18`(`outbox_events`)
+
+**문제**: 3개 테이블이 `DEFAULT CHARSET=utf8mb4` 없이 생성되거나 COLLATE 없이 생성됨. 서버 기본 collation(`utf8mb4_0900_ai_ci`)이 적용되어 나머지 테이블(`utf8mb4_unicode_ci`)과 불일치. 직접 JOIN은 없지만 `SHOW CREATE TABLE`에서 혼재 확인 → 운영 이관 시 혼란.
+
+**개선**: V29 마이그레이션:
+```sql
+ALTER TABLE daily_order_stats        CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE daily_inventory_snapshots CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE outbox_events             CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+```
+
+---
+
+### 45. `refunds.payment_id UNIQUE` — `PARTIAL_CANCELLED`(부분 취소) 여러 건 이력 불가
+
+**위치**: `V21__create_refunds_table.sql`, `payments.status = PARTIAL_CANCELLED`
+
+**문제**: `payments.status`에 `PARTIAL_CANCELLED`(부분 취소) 상태가 정의되어 있어 한 결제에 대해 여러 차례 부분 환불이 가능해야 하지만, `refunds.payment_id UNIQUE` 제약이 결제당 단 1건의 환불 레코드만 허용. 부분 취소 두 번째 시도 시 DB에서 `Duplicate entry` 에러 발생.
+
+**개선**: 부분 취소 이력이 필요하면 UNIQUE 제약 제거 + `(payment_id, created_at)` 복합 인덱스 전환. 현재는 `reset()` 재사용으로 FAILED 재시도만 지원하나, 부분 취소 누적 이력은 불가.
+
+---
+
+> **요약**: #33~#40 · #44 완료(V29~V34) → 아키텍처 판단(#41~#43 · #45) 보류
+
+---
+
+## ✅ 신규 발굴 성능 병목 (4/4)
+
+### ✅ 29. ReviewService · WishlistService `findByUsername()` DB round-trip
+
+**위치**: `ReviewService.create/update/delete`, `WishlistService.add/remove/isWishlisted/getList`
+
+**문제**: 7개 메서드 전부 `userRepository.findByUsername(username)` 쿼리로 시작. JWT claim에 이미 `userId`가 포함되어 있음에도 매 요청마다 불필요한 DB round-trip 발생. `OrderService`, `ShipmentService`는 이미 `resolveUserId()` 패턴으로 전환됨.
+
+**개선**: 컨트롤러에서 `@AuthenticationPrincipal String username` → `Long userId` (`resolveUserId()` 헬퍼 패턴) 전환. 7개 write 메서드에서 `userRepository.findByUsername()` 제거.
+
+---
+
+### ✅ 30. OutboxEventRelayScheduler 지수 백오프 없음
+
+**위치**: `OutboxEventRepository.findPendingEvents()`, `OutboxEventRelayScheduler`
+
+**문제**: 실패한 이벤트(`failedAt != null`)를 5초 후 무조건 재시도. 다운스트림(ShipmentService · PointService · EmailService) 장애 시 100건 × 5초 간격으로 연속 폭격 발생. `failedAt` 컬럼이 존재하지만 relay 쿼리에서 전혀 활용되지 않음.
+
+**개선**: `findPendingEvents()` 쿼리에 `AND (e.failedAt IS NULL OR e.failedAt <= :cutoff)` 조건 추가. cutoff = `now - min(retryCount² × 5초, 300초)`. 재시도 간격: 1회→5s, 2회→20s, 3회→45s, 4회→80s, 5회→125s.
+
+---
+
+### ~~31. `outbox_events` 쿼리 인덱스 누락~~ ✅ 이미 구현됨
+
+`V18__create_outbox_events.sql`에 `INDEX idx_outbox_unpublished (published_at, retry_count, created_at)` 이미 포함. 조치 불필요.
+
+---
+
+### ✅ 32. ReviewService.create() 불필요한 `Product` 전체 엔티티 로드
+
+**위치**: `ReviewService.create()` L40-41, `ReviewService.getList()` L65-66
+
+**문제**: `productRepository.findById(productId)`로 Product + category(Lazy) 전체를 로드하지만 실제 사용 필드는 `product.getId()` 하나뿐. 1인 1리뷰 검증(`existsByProductIdAndUserId`)과 구매 이력 확인(`existsPurchaseByUserIdAndProductId`)에 productId를 직접 사용 가능.
+
+**개선**: `productRepository.findById()` → `productRepository.existsById()` 전환. 불필요한 Product 객체 생성·category JOIN 제거.
+
+---
+
 ## ✅ 완료
 
 ### 보안·버그 수정

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -35,47 +35,27 @@ Client
 
 ---
 
-## 🔴 보안 취약점 진단 (5/10 완료, #60 조치 불필요)
+## 🔴 긴급 — 프로덕션 버그 (데이터 손실·사용자 피해)
 
-> 전체 코드베이스 보안 분석. IDOR·인증 누락·설정 오류 중심.
-
----
-
-### ✅ 56. `PaymentController.getByPaymentKey()` — 인증·소유권 검증 없음 (IDOR)
-
-**위치**: `domain/payment/controller/PaymentController.java` L87-91
-
-**문제**: `GET /api/payments/{paymentKey}` 엔드포인트에 `@AuthenticationPrincipal`이 없고 결제 소유권을 검증하지 않음. 인증된 사용자라면 누구나 paymentKey를 알거나 추측해 타인의 결제 정보(금액·주문 ID·카드 정보)를 조회할 수 있음.
-
-```java
-// 현재 — 소유권 검증 없음
-@GetMapping("/{paymentKey}")
-public ApiResponse<PaymentResponse> getByPaymentKey(@PathVariable String paymentKey) {
-    return ApiResponse.ok(paymentService.getByPaymentKey(paymentKey));
-}
-```
-
-**개선**: `@AuthenticationPrincipal String username`에서 userId를 추출해 결제 소유자와 일치하는지 검증하거나, ADMIN 권한일 경우에만 허용한다.
+> 운영 중 발생 시 사용자 과금 또는 데이터 손실로 직결되는 항목.
 
 ---
 
-### ✅ 57. `TossWebhookVerifier` — `Mac` 인스턴스 `synchronized` 직렬화로 처리량 저하
+### 52. Toss 승인 완료 후 주문 만료 경합 — 결제됐는데 주문 취소
 
-**위치**: `common/security/TossWebhookVerifier.java` L34-58
+**위치**: `domain/payment/service/PaymentTransactionHelper.java` `applyConfirmResult()`
 
-**문제**: `Mac` 객체를 싱글턴으로 유지하고 `synchronized(mac)` 블록에서 사용. Webhook 트래픽이 몰릴 때 MAC 연산이 직렬화되어 병목 발생. 복잡한 동시성 관리보다 매 호출마다 새 인스턴스를 생성하는 것이 더 단순하고 안전하다.
+**문제**: Toss API 승인 요청 중(`callTossConfirmApi()` 대기, 최대 30초) 만료 스케줄러가 Order를 CANCELLED로 변경 가능. Toss는 결제를 완료했으나 주문은 취소된 상태 → 사용자는 청구됨, 서버는 `log.error("[Payment] CRITICAL: …수동 환불 필요…")` 로그만 출력하고 끝.
 
-**개선**: `@PostConstruct`에서 Mac 초기화를 제거하고, `verify()` 호출 시 `Mac.getInstance(ALGORITHM)` + `mac.init(key)`를 수행한 뒤 사용 후 버린다.
+**현황**: 실제 발생 시 운영자가 로그를 확인하고 수동 환불해야 함. 자동 감지·알림 없음.
+
+**개선 방향**:
+- 결제 승인 직전 Order 상태를 `PAYMENT_IN_PROGRESS`로 선점 → 만료 스케줄러가 건드리지 못하게 차단 (근본 해결)
+- 단기: `dead_letter_payments` 테이블에 레코드 삽입 → 대시보드에서 미처리 건 추적
 
 ---
 
-### ✅ 58. Admin 기본 자격증명 (`admin/changeme`) — 운영 배포 시 변경 누락 위험
-
-**위치**: `common/config/AdminSecurityConfig.java`, `application.properties`
-
-**문제**: `ADMIN_USERNAME` / `ADMIN_PASSWORD` 환경변수 미설정 시 `admin/changeme`로 동작. Spring Boot Admin UI(`/admin-ui`)에 로그인 가능 → 모든 actuator 엔드포인트(힙 덤프·스레드 덤프·환경변수) 접근 허용.
-
-**개선**: #46(JWT Secret)과 동일한 패턴 — `@PostConstruct`에서 기본값 사용 감지 시 `IllegalStateException`으로 시작 실패 처리.
+## 🟠 중요 — 보안·운영 안정성 (운영 전 권장)
 
 ---
 
@@ -83,178 +63,43 @@ public ApiResponse<PaymentResponse> getByPaymentKey(@PathVariable String payment
 
 **위치**: `src/main/resources/application.properties` datasource URL
 
-**문제**: `useSSL=false`로 DB 연결이 평문 전송. 같은 네트워크에서 패킷 스니핑 시 쿼리·결과·자격증명 노출 가능. `allowPublicKeyRetrieval=true`는 MITM 공격자가 MySQL 서버로 위장해 공개키를 제공하고 비밀번호를 탈취할 수 있는 추가 벡터가 됨.
+**문제**: DB 연결이 평문 전송. 같은 네트워크에서 패킷 스니핑 시 쿼리·결과·자격증명 노출 가능. `allowPublicKeyRetrieval=true`는 MITM 공격자가 MySQL 서버로 위장해 비밀번호를 탈취할 수 있는 추가 벡터.
 
-**개선**: 운영 환경에서는 `useSSL=true&requireSSL=true`로 변경하고, 환경변수(`DB_SSL_ENABLED`)로 개발/운영을 분리한다.
-
----
-
-### ~~60. Toss Webhook — 타임스탬프 검증 없음 (Replay Attack 가능)~~ → 조치 불필요
-
-**위치**: `domain/payment/controller/PaymentController.java` `/webhook` 핸들러, `common/security/TossWebhookVerifier.java`
-
-**조사 결과 (2026-04-15)**: Toss 공식 문서 확인 결과, `tosspayments-webhook-signature` / `tosspayments-webhook-transmission-time` 헤더는 **`payout.changed`·`seller.changed` 이벤트 전용**이다. 우리 코드에서 처리하는 `PAYMENT_COMPLETED`, `VIRTUAL_ACCOUNT_DEPOSIT` 등 **일반 결제 웹훅에는 타임스탬프 헤더가 포함되지 않는다**. 따라서 헤더 기반 타임스탬프 검증은 적용 불가.
-
-**현황으로 충분한 이유**:
-- `PaymentIdempotencyManager` (Redis SETNX) — 동일 paymentKey 중복 처리 차단
-- `Payment.status` 상태 전이 검증 — 이미 CONFIRMED 상태인 결제는 재처리 거부
-- 멱등성 키 만료 이후 재전송 시나리오는 결제 완료 후 장기간이 지난 상태이므로 실질적 위협 낮음
-
-**참고**: [토스페이먼츠 웹훅 이벤트 문서](https://docs.tosspayments.com/reference/using-api/webhook-events)
+**개선**: 운영 환경에서 `useSSL=true&requireSSL=true`로 변경. `DB_SSL_ENABLED` 환경변수로 개발/운영 분리.
 
 ---
 
-### ~~61. CSP `unsafe-inline` script-src — XSS 완화 효과 반감~~ → 실질 위험도 낮음, 조치 보류
-
-**위치**: `common/config/SecurityConfig.java` `contentSecurityPolicy()`
-
-**현황**: `script-src 'self' 'unsafe-inline'` — Spring Boot Admin UI(`/admin-ui`)가 인라인 스크립트를 포함하고 있어 제거 시 어드민 UI가 깨짐.
-
-**실질 위험도가 낮은 이유**:
-- 이 서버는 **순수 REST API** — 브라우저가 렌더링할 HTML을 직접 서빙하지 않음
-- XSS 공격은 "서버가 사용자 입력을 escape 없이 HTML로 출력"해야 성립하는데, JSON API 응답에는 해당 없음
-- CSP 헤더는 `/admin-ui` HTML 응답에 적용되는 것이 실질적 범위이며, 어드민은 인증된 사용자만 접근
-
-**근본 해결책**: nonce 기반 CSP — Spring MVC 인터셉터로 매 요청마다 랜덤 nonce를 생성하고 SBA 정적 HTML에 주입해야 하나, 외부 라이브러리(SBA) 내부 HTML 커스터마이징이 필요해 구현 복잡도가 높음.
-
-**결론**: 프론트엔드 SPA 서버(HTML 직접 렌더링)에서 중요한 항목. 이 API 서버 범위에서는 우선순위 낮음.
-
----
-
-### 62. DB 자격증명 — 환경변수 미설정 시 하드코딩 평문 사용
+### 62. DB 자격증명 — `root/root` 하드코딩
 
 **위치**: `src/main/resources/application.properties` `spring.datasource.username/password`
 
-**문제**: `${DB_USERNAME:root}` / `${DB_PASSWORD:root}` 형식으로 환경변수 미설정 시 `root/root` 사용. 애플리케이션 JAR 또는 설정 파일이 유출되면 DB 자격증명이 노출됨. 프로덕션 설정 검토 누락 시 root 계정으로 DB 직접 접근 가능.
+**문제**: 환경변수 없이 `root/root`가 소스코드에 그대로 존재. JAR 또는 설정 파일이 유출되면 DB 직접 접근 가능. 운영 배포 시 변경 누락 위험.
 
-**개선**: 기본값 제거(`${DB_USERNAME}` + `${DB_PASSWORD}`). 미설정 시 Spring Boot 시작 실패 → 운영 배포 전 누락 즉시 감지. Vault, AWS Secrets Manager, 또는 Kubernetes Secret 연동 권장.
-
----
-
-### ✅ 63. Actuator — `/env`, `/beans`, `/loggers` 엔드포인트 외부 노출
-
-**위치**: `src/main/resources/application.properties` `management.endpoints.web.exposure.include`
-
-**문제**: `health,info,prometheus,metrics,loggers,env,beans,mappings,threaddump,heapdump` 전체 노출. `env` 엔드포인트는 환경변수(JWT Secret, DB 비밀번호 등)를 마스킹된 형태로 표시하지만 일부 값은 노출됨. `heapdump`는 힙 메모리 덤프를 통해 평문 비밀번호·토큰을 추출 가능.
-
-**개선**:
-```properties
-# 공개 허용
-management.endpoints.web.exposure.include=health,info,prometheus,metrics
-# ADMIN 전용 (AdminSecurityConfig에서 인증 처리)
-management.endpoint.env.enabled=false
-management.endpoint.heapdump.enabled=false
-```
+**개선**: `${DB_USERNAME}` / `${DB_PASSWORD}` (기본값 없이) → 미설정 시 Spring Boot 시작 실패. `application-integration.properties`에 테스트용 H2 계정 명시.
 
 ---
 
-### ✅ 64. `CouponValidateRequest.couponCode` — `@Size` 검증 누락
-
-**위치**: `domain/coupon/dto/CouponValidateRequest.java`
-
-**문제**: `@NotBlank`만 있고 `@Size(max=50)` 가 없음. 악의적 사용자가 수백 KB의 couponCode를 전송하면 `LOWER(code) = LOWER(:code)` 쿼리 파라미터로 그대로 전달됨. 쿼리 실행 오버헤드 외에도 파라미터 바인딩 시 DB 드라이버가 대형 문자열을 처리함.
-
-**개선**: `@Size(min=8, max=50)` 추가. `CouponCreateRequest.code`의 `@Pattern`과 동일한 길이 제약을 검증에도 적용한다.
-
----
-
-### 65. `GlobalExceptionHandler` — 예외 메시지 클라이언트 노출
-
-**위치**: `common/exception/GlobalExceptionHandler.java`
-
-**문제**: `handleException(Exception e)` 폴백 핸들러가 `e.getMessage()`를 응답 본문에 포함할 경우 내부 스택 정보(클래스명, SQL 오류 등)가 외부에 노출될 수 있음. 특히 JPA `DataIntegrityViolationException`, `ConstraintViolationException` 등은 테이블명·컬럼명을 메시지에 포함함.
-
-**개선**: 폴백 핸들러는 `ErrorCode.INTERNAL_SERVER_ERROR`의 고정 메시지만 반환하고, 실제 예외 메시지는 서버 로그에만 기록한다.
-
-```java
-@ExceptionHandler(Exception.class)
-public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
-    log.error("예상치 못한 오류 발생", e);
-    return ResponseEntity.status(INTERNAL_SERVER_ERROR)
-        .body(ApiResponse.fail(ErrorCode.INTERNAL_SERVER_ERROR)); // e.getMessage() 제거
-}
-```
-
----
-
-## 🔴 코드리뷰 — 구조·성능·보안 (6/10 완료)
-
-> 182개 Java 파일 전수 분석. 우선순위 순으로 정렬.
-
----
-
-### ✅ 46. JWT Secret 기본값 — 로그 경고만 출력, 시작 실패 없음
-
-**위치**: `common/security/JwtTokenProvider.java` `@PostConstruct`
-
-**문제**: `JWT_SECRET` 환경변수 미설정 시 개발용 기본값으로 계속 실행됨. ERROR 로그를 출력하지만 아무도 로그를 보지 않으면 운영 배포에서 취약한 시크릿이 그대로 사용됨.
-
-**개선**: 기본값 감지 시 `IllegalStateException`으로 애플리케이션 시작 자체를 실패시킨다.
-
-```java
-if (DEV_DEFAULT_SECRET.equals(secretKeyStr)) {
-    throw new IllegalStateException(
-        "JWT_SECRET 환경변수가 설정되지 않았습니다. 운영 환경에서는 반드시 설정하세요.");
-}
-```
-
----
-
-### 47. `X-Forwarded-For` 마지막 IP 추출 — Rate Limit 우회 가능
+### 47. `X-Forwarded-For` IP 추출 오류 — Rate Limit 우회 가능
 
 **위치**: `common/ratelimit/RateLimitAspect.java` `extractClientIp()`
 
-**문제**: `X-Forwarded-For: client, proxy1, proxy2`에서 마지막 IP(`proxy2`)를 추출하는데, 공격자가 헤더를 `X-Forwarded-For: real_ip, attacker_ip`로 조작하면 `attacker_ip`로 Rate Limit 버킷이 생성되어 실질적인 IP 기반 제한이 무력화됨.
+**문제**: `X-Forwarded-For: client, proxy1, proxy2`에서 마지막 IP(`proxy2`)를 추출. 공격자가 헤더를 `X-Forwarded-For: real_ip, attacker_ip`로 조작하면 `attacker_ip`로 Rate Limit 버킷이 생성되어 IP 기반 제한 무력화. 현재 `trust-proxy=true/false` 설정만 있고 프록시 수 기반 추출은 미구현.
 
-**개선**: 프록시 수(`rate-limit.trusted-proxy-count`)를 설정하고, 헤더 끝에서 N번째 IP를 추출한다.
-
-```java
-// X-Forwarded-For에서 신뢰할 수 있는 클라이언트 IP 추출
-String[] ips = forwarded.split(",");
-int idx = Math.max(0, ips.length - 1 - trustedProxyCount);
-return ips[idx].trim();
-```
+**개선**: `rate-limit.trusted-proxy-count` 설정 추가, 헤더 끝에서 N번째 IP 추출.
 
 ---
 
-### ✅ 48. `CartService.getCart()` — Product 지연로딩 N+1
+### 45. `refunds.payment_id UNIQUE` — 부분취소 두 번째 시도 시 DB 에러
 
-**위치**: `domain/order/cart/service/CartService.java` `getCart()`
+**위치**: `V21__create_refunds_table.sql`, `RefundService`
 
-**문제**: `cartRepository.findByUserId(userId)`로 CartItem을 조회한 뒤 루프에서 `item.getProduct().getId()`를 호출 → 각 CartItem마다 Product 지연로딩 쿼리 발생 (N+1). Inventory는 배치 조회되지만 Product 조회가 N번 실행됨.
+**문제**: `payments.status`에 `PARTIAL_CANCELLED`(부분 취소) 상태가 있어 한 결제에 여러 번 부분 환불이 가능해야 하지만, `refunds.payment_id UNIQUE` 제약으로 결제당 1건만 허용. 부분 취소 두 번째 시도 시 `Duplicate entry` DB 에러 발생. 현재 `reset()`으로 FAILED 재시도만 지원, 부분 취소 누적 이력 불가.
 
-**개선**: CartItem 조회 시 Product를 fetch join으로 함께 로드한다.
-
-```java
-@Query("SELECT c FROM CartItem c JOIN FETCH c.product WHERE c.userId = :userId ORDER BY c.createdAt DESC")
-List<CartItem> findByUserIdWithProduct(@Param("userId") Long userId);
-```
+**개선**: 부분 취소 지원 시 UNIQUE 제약 제거 + `(payment_id, created_at)` 복합 인덱스 전환.
 
 ---
 
-### ✅ 49. `ShipmentService.getByOrderId()` — 소유권 검증에 Order 전체 엔티티 로드
-
-**위치**: `domain/shipment/service/ShipmentService.java` `getByOrderId()`
-
-**문제**: 배송 조회 시 소유권 검증을 위해 `orderRepository.findById(orderId)`로 Order 전체(+ 컬렉션 Lazy) 를 로드하지만 실제 필요한 건 `userId` 필드 하나뿐.
-
-**개선**: `userId`만 프로젝션으로 조회한다.
-
-```java
-// OrderRepository에 추가
-@Query("SELECT o.userId FROM Order o WHERE o.id = :orderId")
-Optional<Long> findUserIdById(@Param("orderId") Long orderId);
-```
-
----
-
-### ✅ 50. `CouponService` — 동일 조건 중복 검증 (3곳)
-
-**위치**: `domain/coupon/service/CouponService.java`
-
-**문제**: 쿠폰 유효성 검증 로직(`active`, `validFrom`, `validUntil`, `maxUsageCount`, 사용자 중복 여부)이 `validate()`, `applyCoupon()`, `issueCoupon()` 세 곳에 분산·중복됨. 정책 변경 시 3곳을 모두 수정해야 해 누락 위험 있음.
-
-**개선**: `validateCouponConditions(Coupon, Long userId)` private 메서드로 추출하고 세 곳에서 호출한다.
+## 🟡 중장기 개선
 
 ---
 
@@ -262,70 +107,9 @@ Optional<Long> findUserIdById(@Param("orderId") Long orderId);
 
 **위치**: `domain/order/service/OrderService.java` (430줄)
 
-**문제**: 주문 생성·조회·취소·상태 이력·페이지네이션·쿠폰 적용·포인트 차감·재고 검증·배송지 검증을 단일 클래스가 담당. 테스트 시 Mock이 10개 이상 필요하며, 기능 추가마다 클래스가 비대해짐.
+**문제**: 주문 생성·조회·취소·상태 이력·페이지네이션·쿠폰·포인트·재고·배송지 검증을 단일 클래스가 담당. 테스트 시 Mock이 10개 이상 필요.
 
-**개선 방향**:
-- `OrderQueryService` — 조회 전용 (readOnly)
-- `OrderCommandService` — 생성·취소 (write)
-- `OrderValidationService` — 배송지·쿠폰·포인트 사전 검증 추출
-
----
-
-### 52. Toss 승인 완료 후 주문 만료 경합 — 수동 환불 필요 시나리오 무처리
-
-**위치**: `domain/payment/service/PaymentTransactionHelper.java` `applyConfirmResult()` L175-187
-
-**문제**: Toss API 승인 요청 중(`callTossConfirmApi()` 대기) 만료 스케줄러가 Order를 CANCELLED로 변경 가능. Toss는 결제를 완료했으나 주문은 취소된 상태 → CRITICAL 로그만 출력하고 사용자는 청구됨.
-
-**현황**: `log.error("[Payment] CRITICAL: …수동 환불 필요…")` 에 그침.
-
-**개선 방향**:
-- CRITICAL 상황 감지 시 운영팀 알림 발송 (Slack Webhook, PagerDuty 등)
-- `dead_letter_payments` 테이블에 레코드 삽입해 대시보드에서 추적
-- 결제 승인 직전 Order 상태를 `PAYMENT_IN_PROGRESS`로 선점해 만료 스케줄러가 건드리지 못하게 차단
-
----
-
-### 53. `ProductService` ES Fallback — MySQL LIKE 검색으로 결과 불일치
-
-**위치**: `domain/product/service/ProductService.java` `getList()` L98-116
-
-**문제**: ES 장애 시 MySQL `LIKE '%keyword%'` 검색으로 Fallback하는데, ES의 형태소 분석·관련성 점수 기반 정렬과 전혀 다른 결과를 반환함. 사용자 입장에서 검색 결과가 갑자기 바뀌는 UX 문제 발생.
-
-**개선 옵션**:
-- ES 장애 시 빈 결과 반환 + "검색 서비스 일시 장애" 메시지 표시 (결과 불일치 방지)
-- 또는 MySQL 전문 검색(`MATCH … AGAINST`)으로 대체해 품질 차이를 최소화
-
----
-
-### ✅ 54. `DistributedLock` + Pessimistic Lock 이중 제어 — 단일 인스턴스에서 불필요한 오버헤드
-
-**위치**: `domain/inventory/service/InventoryService.java` `reserve()` / `releaseReservation()` 등
-
-**문제**: Redis 분산 락(`@DistributedLock`) + DB `SELECT FOR UPDATE`(비관적 락)을 동시에 사용. 단일 인스턴스 환경에서는 분산 락이 불필요하고, 멀티 인스턴스 환경에서는 DB 비관적 락만으로도 충분한 경우가 많음. 두 락을 모두 획득해야 하므로 레이턴시 증가.
-
-**현황**: 의도적 이중 방어선이라면 문서화 필요. 설계 판단이 필요한 항목.
-
----
-
-### ✅ 55. `RefundService.requestRefund()` — `noRollbackFor + throw` 패턴 불명확
-
-**위치**: `domain/refund/service/RefundService.java` `requestRefund()` L58-107
-
-**문제**: `@Transactional(noRollbackFor = Exception.class)`와 `catch (Exception e) { refund.fail(); throw e; }`를 함께 사용. 예외를 던지면서도 트랜잭션을 커밋하려는 의도인데, 클라이언트는 HTTP 500을 받고 Refund 상태만 FAILED로 변경된 채로 유지됨. 의도가 불명확해 유지보수 시 오해 유발.
-
-**개선**: 예외를 던지지 않고 FAILED 상태를 반환하거나, 명시적인 주석으로 패턴 의도를 문서화한다.
-
-```java
-// 현재: throw e (클라이언트 500 수신, refund는 FAILED 커밋)
-// 개선: FAILED 상태를 정상 응답으로 반환 (클라이언트가 재시도 가능)
-refund.fail(reason);
-return RefundResponse.from(refund); // HTTP 200, status=FAILED
-```
-
----
-
-## 🟠 미처리 — 성능·아키텍처 판단 필요
+**개선 방향**: `OrderQueryService`(조회), `OrderCommandService`(생성·취소), `OrderValidationService`(검증) 분리.
 
 ---
 
@@ -333,43 +117,29 @@ return RefundResponse.from(refund); // HTTP 200, status=FAILED
 
 **위치**: 주문 목록, 재고 이력, 리뷰 등 `Pageable` 엔드포인트
 
-**문제**: `LIMIT ? OFFSET ?`는 페이지 번호가 클수록 앞 레코드를 모두 스캔 후 버린다. 대량 이력 보유 사용자의 마지막 페이지 조회 시 풀스캔.
+**문제**: `LIMIT ? OFFSET ?`는 페이지 번호가 클수록 앞 레코드를 모두 스캔 후 버림. 대량 이력 보유 사용자의 마지막 페이지 조회 시 풀스캔.
 
-**개선**: 스크롤 조회(주문 이력, 재고 이력)는 `WHERE id < :lastId LIMIT ?` 커서 기반 페이지네이션으로 전환.
-
----
-
-### 15. AdminService.getOrders() 사용자명 조회 비효율
-
-**위치**: `domain/admin/service/AdminService.java` L108–125
-
-**문제**: 주문 페이지 조회 후 userId 목록으로 `userRepository.findAllById()` 별도 호출. 현재는 단일 `SELECT ... IN (...)` 1쿼리이므로 심각한 수준은 아님.
-
-**개선**: `"usernames"` Redis 캐시(5분 TTL) 추가 또는 Order 쿼리에 username 프로젝션 포함.
+**개선**: `WHERE id < :lastId LIMIT ?` 커서 기반 페이지네이션 전환.
 
 ---
 
-### 16. OrderExpiryScheduler 순차 취소 → 배치 처리
+### 41. `DECIMAL` precision 불일치 — `DECIMAL(19,2)` vs `DECIMAL(12,2)`
 
-**위치**: `domain/order/scheduler/OrderExpiryScheduler.java` L38–60
+**위치**: `V13`, `V21`, `V15` 마이그레이션
 
-**문제**: 만료 주문마다 개별 트랜잭션으로 `cancelBySystem()` 호출. 100건 발생 시 100회 DB 왕복.
+**문제**: 같은 금액 컬럼이 두 precision으로 혼재. `orders.total_amount(12,2)`와 `coupons.discount_value(19,2)` 비교 시 묵시적 캐스팅 발생.
 
-**개선**: 건수 ≤10이면 현행 유지, 초과 시 `UPDATE orders SET status='CANCELLED' WHERE id IN (...)` 벌크 + 재고 일괄 해제.
-
----
-
-### 20. 리드 레플리카 라우팅 미적용
-
-**위치**: 전체 `@Transactional(readOnly = true)` 쿼리
-
-**문제**: 읽기 전용 트랜잭션이 모두 MySQL Primary로 연결됨. Replica가 있어도 읽기 부하 분산 없음.
-
-**개선**: `AbstractRoutingDataSource` 또는 AWS Aurora Reader Endpoint 활용.
+**개선**: `DECIMAL(15,2)`로 통일 (최대 999억원 지원).
 
 ---
 
-## 🟡 미처리 기술 부채
+### 42. `delivery_addresses` — 기본 배송지 복수 방지 DB 제약 없음
+
+**위치**: `V12__create_delivery_address_tables.sql`
+
+**문제**: `is_default = 1` 레코드가 사용자별 최대 1개임을 DB가 보장하지 않음. 직접 DB 수정 시 데이터 정합성 깨짐.
+
+**개선**: `BEFORE INSERT/UPDATE` 트리거로 동일 user의 다른 레코드를 0으로 초기화.
 
 ---
 
@@ -383,53 +153,65 @@ return RefundResponse.from(refund); // HTTP 200, status=FAILED
 
 ---
 
-## 🟡 DBA 스키마 미처리 — 아키텍처 판단 필요
+## ⚪ 보류 — 판단 필요 또는 인프라 의존
 
 ---
 
-### 41. `DECIMAL` precision 불일치 — `DECIMAL(19,2)` vs `DECIMAL(12,2)`
-
-**위치**: `V13__create_coupon_tables.sql`, `V21__create_refunds_table.sql`, `V15__create_batch_tables.sql`
-
-**문제**: 같은 비즈니스 도메인(금액) 컬럼이 두 precision으로 혼재:
-- `DECIMAL(12,2)`: `orders.total_amount`, `payments.amount`, `inventory_transactions` 스냅샷값
-- `DECIMAL(19,2)`: `coupons.discount_value`, `coupon_usages.discount_amount`, `refunds.amount`, `daily_order_stats.total_revenue`
-
-`orders.total_amount(12,2)`와 `coupons.discount_value(19,2)` 비교 시 묵시적 캐스팅 발생. 최대 12자리 금액(9,999,999.99원)으로 충분한 도메인에서 DECIMAL(19,2)는 불필요하게 큰 저장 공간 사용.
-
-**개선**: 금액 컬럼 precision을 `DECIMAL(15,2)`로 통일 (최대 999억원 지원, 일별 매출·누적 집계에 충분).
-
----
-
-### 42. `delivery_addresses` — 기본 배송지 복수 방지 DB 제약 없음
-
-**위치**: `V12__create_delivery_address_tables.sql`, `DeliveryAddressService`
-
-**문제**: `is_default TINYINT(1)` 컬럼만 있고 "사용자별 `is_default = 1` 레코드는 최대 1개" 제약이 DB에 없음. 애플리케이션 버그 또는 직접 DB 수정 시 기본 배송지가 여러 개 생성될 수 있음. MySQL은 partial unique index를 지원하지 않으므로 트리거 또는 CHECK 제약으로 보완 필요.
-
-**개선 옵션**:
-1. `BEFORE INSERT/UPDATE` 트리거 — `is_default = 1` 설정 시 동일 user의 다른 레코드를 0으로 초기화
-2. 애플리케이션 레벨 검증 강화 + 정기 정합성 점검 쿼리 추가
-
----
-
-### 43. `orders.findOrderStats()` — 전체 테이블 GROUP BY (대시보드 성능)
+### 43. 대시보드 GROUP BY — `daily_order_stats` 미활용
 
 **위치**: `OrderRepository.findOrderStats()`, `AdminService.getDashboard()`
 
-**문제**: `SELECT status, COUNT(*), SUM(totalAmount) FROM orders GROUP BY status` — 주문 데이터가 누적될수록 대시보드 API 응답 지연 증가. 현재 `idx_orders_status` 인덱스로 인덱스 스캔은 가능하지만 전체 행을 읽음. `daily_order_stats` 테이블이 이미 존재하지만 실시간 대시보드는 live orders 테이블 집계 사용.
+**문제**: `SELECT status, COUNT(*), SUM(totalAmount) FROM orders GROUP BY status` — 이미 `daily_order_stats` 집계 테이블이 있는데 미사용. 주문 누적 시 응답 지연.
 
-**개선**: 대시보드 통계를 `daily_order_stats` 캐시 + 당일 분만 live 집계로 전환. 또는 `AdminService` 응답에 Redis 캐시(5분 TTL) 적용.
+**개선**: 대시보드 통계를 `daily_order_stats` + 당일 live 집계 조합으로 전환. 또는 Redis 캐시(5분 TTL).
+
+> **보류 이유**: 어드민 전용 기능이고 현재 데이터 규모에서 성능 문제 없음. 운영 후 모니터링으로 판단.
 
 ---
 
-### 45. `refunds.payment_id UNIQUE` — `PARTIAL_CANCELLED`(부분 취소) 여러 건 이력 불가
+### 53. `ProductService` ES Fallback — MySQL LIKE 검색으로 결과 불일치
 
-**위치**: `V21__create_refunds_table.sql`, `payments.status = PARTIAL_CANCELLED`
+**위치**: `domain/product/service/ProductService.java` `getList()`
 
-**문제**: `payments.status`에 `PARTIAL_CANCELLED`(부분 취소) 상태가 정의되어 있어 한 결제에 대해 여러 차례 부분 환불이 가능해야 하지만, `refunds.payment_id UNIQUE` 제약이 결제당 단 1건의 환불 레코드만 허용. 부분 취소 두 번째 시도 시 DB에서 `Duplicate entry` 에러 발생.
+**문제**: ES 장애 시 MySQL `LIKE '%keyword%'` fallback이 ES 형태소 분석 결과와 전혀 다른 결과를 반환. UX 불일치.
 
-**개선**: 부분 취소 이력이 필요하면 UNIQUE 제약 제거 + `(payment_id, created_at)` 복합 인덱스 전환. 현재는 `reset()` 재사용으로 FAILED 재시도만 지원하나, 부분 취소 누적 이력은 불가.
+**보류 이유**: 빈 결과 반환 vs LIKE fallback 유지 중 어느 쪽이 나은지는 제품 결정 사항.
+
+---
+
+### 20. 리드 레플리카 라우팅 미적용
+
+**위치**: 전체 `@Transactional(readOnly = true)` 쿼리
+
+**보류 이유**: Replica 인프라 없이 코드만으로 완결 불가. Aurora Reader Endpoint 또는 `AbstractRoutingDataSource` 도입 시 재검토.
+
+---
+
+### 16. `OrderExpiryScheduler` 순차 취소 → 배치 처리
+
+**위치**: `domain/order/scheduler/OrderExpiryScheduler.java`
+
+**보류 이유**: 만료 주문 건수가 적은 초기 운영 단계에서는 현행 유지. 100건 초과 시 벌크 UPDATE 전환 검토.
+
+---
+
+### 15. `AdminService.getOrders()` 사용자명 조회
+
+**위치**: `domain/admin/service/AdminService.java`
+
+**보류 이유**: 이미 `findAllById()` 단일 IN 쿼리. 현재 규모에서 심각도 낮음.
+
+---
+
+## ~~조치 불필요~~
+
+---
+
+| # | 항목 | 판단 근거 |
+|---|------|-----------|
+| ~~60~~ | Toss Webhook Replay Attack | 일반 결제 웹훅에 타임스탬프 헤더 없음. `PaymentIdempotencyManager` + 상태 전이 검증으로 충분. [Toss 문서](https://docs.tosspayments.com/reference/using-api/webhook-events) |
+| ~~61~~ | CSP `unsafe-inline` | REST API 서버 — HTML 직접 렌더링 없음. `/admin-ui`(SBA)가 인라인 스크립트 의존하여 제거 불가. 실질 XSS 위험 없음. |
+| ~~65~~ | `GlobalExceptionHandler` 예외 메시지 노출 | 코드 확인 결과 폴백 핸들러가 `ErrorCode.INTERNAL_SERVER_ERROR.getMessage()` 고정 메시지만 반환. `DataIntegrityViolationException`도 고정 문자열 사용. 이미 올바르게 구현됨. |
 
 ---
 
@@ -450,94 +232,69 @@ return RefundResponse.from(refund); // HTTP 200, status=FAILED
 
 ---
 
-### ✅ 성능 병목 완료 (3/3)
-
-| # | 항목 | 파일 | 조치 |
-|---|------|------|------|
-| 7 | InventoryRepository fetch join 누락 (N+1) | `InventoryRepository` | `findByProductId`, `findAllByProductIdIn`에 `@EntityGraph({"product"})` 추가 |
-| 8 | CategoryService.getTree() 캐시 미적용 | `CategoryService`, `CacheConfig`, `CategoryResponse` | `getList/getTree` `@Cacheable`, `create/update/delete` `@CacheEvict(allEntries=true)`, categories 30분 TTL, `@Jacksonized` + `ArrayList` 적용 |
-| 9 | InventorySnapshotScheduler 전체 로드 | `InventorySnapshotScheduler`, `InventorySnapshotProcessor` | 1,000건 페이지 루프 + 배치마다 독립 트랜잭션 커밋 (`@Component` 분리) |
-
----
-
-### ✅ 신규 발굴 성능 병목 완료 (4/4)
+### ✅ 성능 병목 완료 (7/7)
 
 | # | 항목 | 조치 |
 |---|------|------|
-| 29 | ReviewService · WishlistService `findByUsername()` DB round-trip | 컨트롤러 `resolveUserId()` 헬퍼 패턴 전환, `userRepository.findByUsername()` 제거 |
-| 30 | OutboxEventRelayScheduler 지수 백오프 없음 | `nextRetryAt` 컬럼(V34) + `findPendingEvents()` 조건 추가, 최대 1시간 백오프 |
-| ~~31~~ | `outbox_events` 쿼리 인덱스 누락 | V18에 이미 `idx_outbox_unpublished` 포함 — 조치 불필요 |
-| 32 | ReviewService.create() 불필요한 Product 전체 엔티티 로드 | `productRepository.findById()` → `existsById()` 전환 |
+| 7 | InventoryRepository N+1 | `@EntityGraph({"product"})` 추가 |
+| 8 | CategoryService.getTree() 캐시 미적용 | `@Cacheable` + 30분 TTL |
+| 9 | InventorySnapshotScheduler 전체 로드 | 1,000건 페이지 루프 + 배치 독립 트랜잭션 |
+| 29 | ReviewService·WishlistService DB round-trip | `resolveUserId()` 헬퍼 패턴, `findByUsername()` 제거 |
+| 30 | OutboxEventRelayScheduler 지수 백오프 없음 | `nextRetryAt` 컬럼(V34) + 최대 1시간 백오프 |
+| ~~31~~ | `outbox_events` 인덱스 누락 | V18에 이미 `idx_outbox_unpublished` 포함 — 조치 불필요 |
+| 32 | ReviewService.create() Product 전체 로드 | `findById()` → `existsById()` |
 
 ---
 
-### ✅ 스프린트 완료 (8/11)
-
-| # | 항목 | 파일 | 조치 |
-|---|------|------|------|
-| 10 | applyConfirmResult() 이중 DB 조회 | `PaymentTransactionHelper` | `confirm()` → `Order` 반환, 재사용 |
-| 11 | Outbox 배치 크기 하드코딩 | `OutboxEventRelayScheduler` | `@Value("${outbox.relay.batch-size:100}")` + Prometheus counter |
-| 12 | DB 인덱스 누락 | V23/V25/V27 마이그레이션 | 모든 항목 기존 마이그레이션으로 커버 |
-| 14 | RefundService 이중 쿼리 | `Refund` 엔티티 + `RefundService` | `userId` 비정규화 저장 → `validateOwnership()` orders 조회 제거, V28 마이그레이션 |
-| 17 | P6Spy 운영 오버헤드 | `build.gradle` | `implementation` → `runtimeOnly` |
-| 18 | Zipkin 샘플링 100% | `application.properties` | 1.0 → 0.1 (운영: 0.01~0.1) |
-| 19 | OrderSearchRequest mutable DTO | `OrderSpecification` + `OrderService` | `of(request, forceUserId)` 오버로드, DTO 변경 제거 |
-
----
-
-### ✅ 기술 부채 완료 (7/8)
-
-| # | 항목 | 파일 | 조치 |
-|---|------|------|------|
-| 21 | 동시성 통합 테스트 부재 | `ConcurrencyIntegrationTest`, `InventoryConcurrencyTest` | 이미 구현 완료 (ExecutorService + CountDownLatch, reserve() 재고 불변 조건 검증) |
-| 22 | Pitest targetClasses 제한적 | `build.gradle` | 6개 → 15개로 확장 (shipment·product·review·wishlist·category·user·address·cart 추가) |
-| 23 | 전체 Refresh Token 무효화 불가 | `RefreshTokenStore`, `UserService` | 이미 구현 완료 (`revokeAll()` + 비밀번호 변경 시 자동 호출) |
-| 24 | 쿠폰 코드 엔트로피 검증 없음 | `CouponCreateRequest` | 이미 구현 완료 (`@Pattern` 영문+숫자 혼합 8자 이상 강제) |
-| 26 | Dockerfile HEALTHCHECK 미정의 | `Dockerfile` | 이미 구현 완료 (`--interval=30s --retries=3`) |
-| 27 | `storage.enabled` 문서화 누락 | `application.properties` | 이미 구현 완료 (`storage.enabled=false` + 주석) |
-| 28 | Payment 도메인 주석 언어 불일치 | `PaymentService`, `PaymentTransactionHelper` | 영어 inline 주석·Javadoc·log 메시지 → 한국어(키워드 영문) 통일 |
-
----
-
-### ✅ DBA 진단 완료 (9/13)
+### ✅ 보안·버그 완료
 
 | # | 항목 | 조치 |
 |---|------|------|
-| 33 | `refunds.user_id DEFAULT 0` — 소유권 검증 영구 실패 | V29 백필 마이그레이션 + FK 제약 추가 |
-| 34 | `payments` 테이블 CHARSET/COLLATE 미정의 | V29 `ALTER TABLE ... CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci` |
-| 35 | `orders` `(status, created_at)` 복합 인덱스 누락 | V29 `ADD INDEX idx_orders_status_created` |
-| 36 | `coupons` 복합 인덱스 누락 + 만료 처리 N UPDATE | V29 인덱스 추가 + `@Modifying` 벌크 UPDATE 전환 |
-| 37 | `products.status` 인덱스 누락 | V29 `ADD INDEX idx_products_status` |
-| 38 | `cart_items.user_id` FK 누락 | V29 `fk_cart_user` FK 제약 추가 |
-| 39 | `point_transactions.order_id` FK 누락 | V29 `fk_pt_order` FK (ON DELETE SET NULL) 추가 |
-| 40 | `created_at` DEFAULT CURRENT_TIMESTAMP 없는 테이블 6개 | V33 각 컬럼 ALTER |
-| 44 | 일부 테이블 COLLATE 미정의 | V30 3개 테이블 charset/collation 통일 |
+| 46 | JWT Secret 기본값 → 시작 실패 | `JwtTokenProvider @PostConstruct` `IllegalStateException` |
+| 48 | CartService N+1 | `CartRepository.findByUserId()` 이미 `@EntityGraph(product)` 확인 |
+| 49 | ShipmentService userId 프로젝션 | `orderRepository.findUserIdById()` 스칼라 쿼리 |
+| 50 | CouponService 검증 중복 | `applyCoupon()` → `validateConditions()` 통합 |
+| 54 | InventoryService 이중 락 문서화 | `reserve()` Javadoc: Redis 장애 시 DB 락이 최후 방어선 |
+| 55 | RefundService noRollbackFor 문서화 | 코드 확인 결과 주석 이미 존재 |
+| 56 | PaymentController IDOR | 소유권 검증 + `orderRepository.findUserIdById()` |
+| 57 | TossWebhookVerifier Mac 직렬화 | 싱글턴 + `synchronized` → 호출마다 `Mac.getInstance()` |
+| 58 | Admin 기본 자격증명 → 시작 실패 | `AdminSecurityConfig @PostConstruct` `IllegalStateException` |
+| 63 | Actuator 엔드포인트 과다 노출 | `env/heapdump/threaddump/beans/mappings/loggers` 비활성화 |
+| 64 | CouponValidateRequest `@Size` 누락 | `@Size(min=8, max=50)` 추가 |
 
 ---
 
-### ✅ 보안·버그·기능 완료
+### ✅ 스프린트·기술부채·DBA 완료
 
-| 항목 | 비고 |
-|------|------|
-| #46 JWT Secret 기본값 → 시작 실패 | `JwtTokenProvider @PostConstruct` `IllegalStateException` throw |
-| #48 CartService N+1 | `CartRepository.findByUserId()` 이미 `@EntityGraph(product)` 적용 |
-| #49 ShipmentService userId 프로젝션 | `orderRepository.findUserIdById()` — Order 전체 로드 불필요 |
-| #50 CouponService 검증 중복 제거 | `applyCoupon()` → `validateConditions()` 통합 호출 |
-| #54 InventoryService 이중 락 문서화 | `reserve()` Javadoc: Redis 장애 시 DB 비관적 락이 최후 방어선 |
-| #55 RefundService noRollbackFor 문서화 | 이미 주석 존재 (confirmed) |
-| #56 PaymentController IDOR 수정 | `getByPaymentKey()` 소유권 검증 + `orderRepository.findUserIdById()` |
-| #57 TossWebhookVerifier Mac per-call | 싱글턴 + `synchronized` → 호출마다 `Mac.getInstance()` |
-| #58 Admin 기본 자격증명 → 시작 실패 | `AdminSecurityConfig @PostConstruct` `IllegalStateException` throw |
-| #63 Actuator 엔드포인트 최소화 | `env/heapdump/threaddump/beans/mappings/loggers` 비활성화 |
-| #64 CouponValidateRequest @Size 추가 | `@Size(min=8, max=50)` 입력 크기 제한 |
-| PaymentService JWT userId 적용 | DB 라운드트립 제거, `resolveUserId()` 패턴 |
-| ES 상품 동기화 | `@TransactionalEventListener(AFTER_COMMIT)` + `ProductEventListener` |
-| CSP `unsafe-eval` 제거 | `SecurityConfig` script-src 정책 강화 |
-| 가상계좌 Webhook 처리 | `applyWebhookConfirmResult()` confirm 흐름 재사용 |
-| RefundService 영구 재시도 불가 버그 | FAILED 상태 환불 `reset()` 후 재사용 |
-| LoginRateLimiter Lua 원자화 | `RAtomicLong` → Lua INCR+EXPIRE 원자적 처리 |
-| ShipmentService / PointService `REQUIRES_NEW` | `UnexpectedRollbackException` 방지 |
-| DeliveryAddressRepository `findFirstBy...` | 기본 배송지 삭제 후 1건만 조회 |
+| # | 항목 | 조치 |
+|---|------|------|
+| 10 | applyConfirmResult() 이중 DB 조회 | `confirm()` → `Order` 반환, 재사용 |
+| 11 | Outbox 배치 크기 하드코딩 | `@Value("${outbox.relay.batch-size:100}")` + Prometheus counter |
+| 12 | DB 인덱스 누락 | V23/V25/V27 마이그레이션 |
+| 14 | RefundService 이중 쿼리 | `userId` 비정규화, `validateOwnership()` orders 조회 제거 |
+| 17 | P6Spy 운영 오버헤드 | `implementation` → `runtimeOnly` |
+| 18 | Zipkin 샘플링 100% | 1.0 → 0.1 |
+| 19 | OrderSearchRequest mutable DTO | `of(request, forceUserId)` 오버로드 |
+| 21 | 동시성 통합 테스트 부재 | 이미 구현 완료 (ExecutorService + CountDownLatch) |
+| 22 | Pitest targetClasses 제한 | 6개 → 15개 확장 |
+| 23 | Refresh Token 전체 무효화 불가 | 이미 구현 완료 (`revokeAll()`) |
+| 24 | 쿠폰 코드 엔트로피 검증 없음 | 이미 구현 완료 (`@Pattern`) |
+| 26 | Dockerfile HEALTHCHECK 미정의 | 이미 구현 완료 |
+| 27 | `storage.enabled` 문서화 누락 | 이미 구현 완료 |
+| 28 | Payment 도메인 주석 언어 불일치 | 한국어(키워드 영문) 통일 |
+| 33 | `refunds.user_id DEFAULT 0` | V29 백필 + FK 제약 |
+| 34 | `payments` CHARSET/COLLATE 미정의 | V29 utf8mb4 변환 |
+| 35 | `orders` 복합 인덱스 누락 | V29 `idx_orders_status_created` |
+| 36 | `coupons` 인덱스 누락 + N UPDATE | V29 인덱스 + `@Modifying` 벌크 UPDATE |
+| 37 | `products.status` 인덱스 누락 | V29 `idx_products_status` |
+| 38 | `cart_items.user_id` FK 누락 | V29 FK 제약 |
+| 39 | `point_transactions.order_id` FK 누락 | V29 FK (ON DELETE SET NULL) |
+| 40 | `created_at` DEFAULT 없는 테이블 6개 | V33 ALTER |
+| 44 | 일부 테이블 COLLATE 미정의 | V30 charset/collation 통일 |
+
+---
+
+### ✅ 구현 완료 기능
 
 | 기능 | 기능 |
 |------|------|

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -104,13 +104,20 @@ public ApiResponse<PaymentResponse> getByPaymentKey(@PathVariable String payment
 
 ---
 
-### 61. CSP `unsafe-inline` script-src — XSS 완화 효과 반감
+### ~~61. CSP `unsafe-inline` script-src — XSS 완화 효과 반감~~ → 실질 위험도 낮음, 조치 보류
 
 **위치**: `common/config/SecurityConfig.java` `contentSecurityPolicy()`
 
-**문제**: `script-src 'self' 'unsafe-inline'` 설정으로 인라인 `<script>` 태그가 실행됨. XSS 취약점이 발견되었을 때 CSP가 실질적인 방어선 역할을 하지 못함. `unsafe-eval`은 이미 제거됐으나 `unsafe-inline`이 더 큰 위험 벡터다.
+**현황**: `script-src 'self' 'unsafe-inline'` — Spring Boot Admin UI(`/admin-ui`)가 인라인 스크립트를 포함하고 있어 제거 시 어드민 UI가 깨짐.
 
-**개선**: `unsafe-inline` 제거 후 nonce 기반 CSP(`'nonce-{random}'`) 적용. 서버에서 매 요청마다 랜덤 nonce를 생성해 헤더와 `<script nonce="...">` 태그에 주입한다.
+**실질 위험도가 낮은 이유**:
+- 이 서버는 **순수 REST API** — 브라우저가 렌더링할 HTML을 직접 서빙하지 않음
+- XSS 공격은 "서버가 사용자 입력을 escape 없이 HTML로 출력"해야 성립하는데, JSON API 응답에는 해당 없음
+- CSP 헤더는 `/admin-ui` HTML 응답에 적용되는 것이 실질적 범위이며, 어드민은 인증된 사용자만 접근
+
+**근본 해결책**: nonce 기반 CSP — Spring MVC 인터셉터로 매 요청마다 랜덤 nonce를 생성하고 SBA 정적 HTML에 주입해야 하나, 외부 라이브러리(SBA) 내부 HTML 커스터마이징이 필요해 구현 복잡도가 높음.
+
+**결론**: 프론트엔드 SPA 서버(HTML 직접 렌더링)에서 중요한 항목. 이 API 서버 범위에서는 우선순위 낮음.
 
 ---
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -522,3 +522,133 @@ Optional<Long> findUserIdById(@Param("orderId") Long orderId);
 refund.fail(reason);
 return RefundResponse.from(refund); // HTTP 200, status=FAILED
 ```
+
+---
+
+## 🔴 보안 취약점 진단 (0/10)
+
+> 전체 코드베이스 보안 분석. IDOR·인증 누락·설정 오류 중심.
+
+---
+
+### 56. `PaymentController.getByPaymentKey()` — 인증·소유권 검증 없음 (IDOR)
+
+**위치**: `domain/payment/controller/PaymentController.java` L87-91
+
+**문제**: `GET /api/payments/{paymentKey}` 엔드포인트에 `@AuthenticationPrincipal`이 없고 결제 소유권을 검증하지 않음. 인증된 사용자라면 누구나 paymentKey를 알거나 추측해 타인의 결제 정보(금액·주문 ID·카드 정보)를 조회할 수 있음.
+
+```java
+// 현재 — 소유권 검증 없음
+@GetMapping("/{paymentKey}")
+public ApiResponse<PaymentResponse> getByPaymentKey(@PathVariable String paymentKey) {
+    return ApiResponse.ok(paymentService.getByPaymentKey(paymentKey));
+}
+```
+
+**개선**: `@AuthenticationPrincipal String username`에서 userId를 추출해 결제 소유자와 일치하는지 검증하거나, ADMIN 권한일 경우에만 허용한다.
+
+---
+
+### 57. `TossWebhookVerifier` — `Mac` 인스턴스 `synchronized` 직렬화로 처리량 저하
+
+**위치**: `common/security/TossWebhookVerifier.java` L34-58
+
+**문제**: `Mac` 객체를 싱글턴으로 유지하고 `synchronized(mac)` 블록에서 사용. Webhook 트래픽이 몰릴 때 MAC 연산이 직렬화되어 병목 발생. 복잡한 동시성 관리보다 매 호출마다 새 인스턴스를 생성하는 것이 더 단순하고 안전하다.
+
+**개선**: `@PostConstruct`에서 Mac 초기화를 제거하고, `verify()` 호출 시 `Mac.getInstance(ALGORITHM)` + `mac.init(key)`를 수행한 뒤 사용 후 버린다.
+
+---
+
+### 58. Admin 기본 자격증명 (`admin/changeme`) — 운영 배포 시 변경 누락 위험
+
+**위치**: `common/config/AdminSecurityConfig.java`, `application.properties`
+
+**문제**: `ADMIN_USERNAME` / `ADMIN_PASSWORD` 환경변수 미설정 시 `admin/changeme`로 동작. Spring Boot Admin UI(`/admin-ui`)에 로그인 가능 → 모든 actuator 엔드포인트(힙 덤프·스레드 덤프·환경변수) 접근 허용.
+
+**개선**: #46(JWT Secret)과 동일한 패턴 — `@PostConstruct`에서 기본값 사용 감지 시 `IllegalStateException`으로 시작 실패 처리.
+
+---
+
+### 59. MySQL `useSSL=false` + `allowPublicKeyRetrieval=true` — 평문 DB 통신
+
+**위치**: `src/main/resources/application.properties` datasource URL
+
+**문제**: `useSSL=false`로 DB 연결이 평문 전송. 같은 네트워크에서 패킷 스니핑 시 쿼리·결과·자격증명 노출 가능. `allowPublicKeyRetrieval=true`는 MITM 공격자가 MySQL 서버로 위장해 공개키를 제공하고 비밀번호를 탈취할 수 있는 추가 벡터가 됨.
+
+**개선**: 운영 환경에서는 `useSSL=true&requireSSL=true`로 변경하고, 환경변수(`DB_SSL_ENABLED`)로 개발/운영을 분리한다.
+
+---
+
+### 60. Toss Webhook — 타임스탬프 검증 없음 (Replay Attack 가능)
+
+**위치**: `domain/payment/controller/PaymentController.java` `/webhook` 핸들러, `common/security/TossWebhookVerifier.java`
+
+**문제**: HMAC 서명 검증은 되어 있지만 요청 타임스탬프를 확인하지 않음. 공격자가 유효한 Webhook 요청을 캡처해 나중에 재전송하면 동일한 결제 확정 이벤트가 여러 번 처리될 수 있음. `PaymentIdempotencyManager`가 중복 처리를 일부 차단하지만 멱등성 키 만료 이후에는 방어되지 않음.
+
+**개선**: Toss 요청 헤더의 타임스탬프를 추출해 현재 시각과의 차이가 5분 초과 시 거부한다.
+
+---
+
+### 61. CSP `unsafe-inline` script-src — XSS 완화 효과 반감
+
+**위치**: `common/config/SecurityConfig.java` `contentSecurityPolicy()`
+
+**문제**: `script-src 'self' 'unsafe-inline'` 설정으로 인라인 `<script>` 태그가 실행됨. XSS 취약점이 발견되었을 때 CSP가 실질적인 방어선 역할을 하지 못함. `unsafe-eval`은 이미 제거됐으나 `unsafe-inline`이 더 큰 위험 벡터다.
+
+**개선**: `unsafe-inline` 제거 후 nonce 기반 CSP(`'nonce-{random}'`) 적용. 서버에서 매 요청마다 랜덤 nonce를 생성해 헤더와 `<script nonce="...">` 태그에 주입한다.
+
+---
+
+### 62. DB 자격증명 — 환경변수 미설정 시 하드코딩 평문 사용
+
+**위치**: `src/main/resources/application.properties` `spring.datasource.username/password`
+
+**문제**: `${DB_USERNAME:root}` / `${DB_PASSWORD:root}` 형식으로 환경변수 미설정 시 `root/root` 사용. 애플리케이션 JAR 또는 설정 파일이 유출되면 DB 자격증명이 노출됨. 프로덕션 설정 검토 누락 시 root 계정으로 DB 직접 접근 가능.
+
+**개선**: 기본값 제거(`${DB_USERNAME}` + `${DB_PASSWORD}`). 미설정 시 Spring Boot 시작 실패 → 운영 배포 전 누락 즉시 감지. Vault, AWS Secrets Manager, 또는 Kubernetes Secret 연동 권장.
+
+---
+
+### 63. Actuator — `/env`, `/beans`, `/loggers` 엔드포인트 외부 노출
+
+**위치**: `src/main/resources/application.properties` `management.endpoints.web.exposure.include`
+
+**문제**: `health,info,prometheus,metrics,loggers,env,beans,mappings,threaddump,heapdump` 전체 노출. `env` 엔드포인트는 환경변수(JWT Secret, DB 비밀번호 등)를 마스킹된 형태로 표시하지만 일부 값은 노출됨. `heapdump`는 힙 메모리 덤프를 통해 평문 비밀번호·토큰을 추출 가능.
+
+**개선**:
+```properties
+# 공개 허용
+management.endpoints.web.exposure.include=health,info,prometheus,metrics
+# ADMIN 전용 (AdminSecurityConfig에서 인증 처리)
+management.endpoint.env.enabled=false
+management.endpoint.heapdump.enabled=false
+```
+
+---
+
+### 64. `CouponValidateRequest.couponCode` — `@Size` 검증 누락
+
+**위치**: `domain/coupon/dto/CouponValidateRequest.java`
+
+**문제**: `@NotBlank`만 있고 `@Size(max=50)` 가 없음. 악의적 사용자가 수백 KB의 couponCode를 전송하면 `LOWER(code) = LOWER(:code)` 쿼리 파라미터로 그대로 전달됨. 쿼리 실행 오버헤드 외에도 파라미터 바인딩 시 DB 드라이버가 대형 문자열을 처리함.
+
+**개선**: `@Size(min=8, max=50)` 추가. `CouponCreateRequest.code`의 `@Pattern`과 동일한 길이 제약을 검증에도 적용한다.
+
+---
+
+### 65. `GlobalExceptionHandler` — 예외 메시지 클라이언트 노출
+
+**위치**: `common/exception/GlobalExceptionHandler.java`
+
+**문제**: `handleException(Exception e)` 폴백 핸들러가 `e.getMessage()`를 응답 본문에 포함할 경우 내부 스택 정보(클래스명, SQL 오류 등)가 외부에 노출될 수 있음. 특히 JPA `DataIntegrityViolationException`, `ConstraintViolationException` 등은 테이블명·컬럼명을 메시지에 포함함.
+
+**개선**: 폴백 핸들러는 `ErrorCode.INTERNAL_SERVER_ERROR`의 고정 메시지만 반환하고, 실제 예외 메시지는 서버 로그에만 기록한다.
+
+```java
+@ExceptionHandler(Exception.class)
+public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+    log.error("예상치 못한 오류 발생", e);
+    return ResponseEntity.status(INTERNAL_SERVER_ERROR)
+        .body(ApiResponse.fail(ErrorCode.INTERNAL_SERVER_ERROR)); // e.getMessage() 제거
+}
+```

--- a/src/main/java/com/stockmanagement/common/config/AdminSecurityConfig.java
+++ b/src/main/java/com/stockmanagement/common/config/AdminSecurityConfig.java
@@ -1,5 +1,6 @@
 package com.stockmanagement.common.config;
 
+import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -36,6 +37,22 @@ public class AdminSecurityConfig {
 
     @Value("${admin.password:changeme}")
     private String adminPassword;
+
+    /**
+     * 운영 배포 시 기본 자격증명 사용 방지.
+     *
+     * <p>ADMIN_USERNAME / ADMIN_PASSWORD 환경변수가 모두 기본값인 경우 시작을 즉시 실패시킨다.
+     *
+     * @throws IllegalStateException 기본 자격증명이 그대로 사용되는 경우
+     */
+    @PostConstruct
+    public void validateCredentials() {
+        if ("admin".equals(adminUsername) && "changeme".equals(adminPassword)) {
+            throw new IllegalStateException(
+                    "[SECURITY] ADMIN_USERNAME / ADMIN_PASSWORD가 기본값(admin/changeme)입니다. " +
+                    "운영 환경에서는 환경변수를 반드시 설정하세요.");
+        }
+    }
 
     @Bean
     @Order(1)

--- a/src/main/java/com/stockmanagement/common/outbox/OutboxEvent.java
+++ b/src/main/java/com/stockmanagement/common/outbox/OutboxEvent.java
@@ -49,6 +49,16 @@ public class OutboxEvent {
     @Column
     private LocalDateTime failedAt;
 
+    /**
+     * 지수 백오프 다음 재시도 가능 시각.
+     * NULL이면 즉시 재시도 가능 (최초 시도 또는 기존 레코드 하위 호환).
+     */
+    @Column
+    private LocalDateTime nextRetryAt;
+
+    /** 지수 백오프 최대 대기 시간 (초). */
+    private static final long MAX_BACKOFF_SECONDS = 3600L;
+
     @Builder
     public OutboxEvent(OutboxEventType eventType, String payload) {
         this.eventType = eventType;
@@ -60,9 +70,16 @@ public class OutboxEvent {
         this.publishedAt = LocalDateTime.now();
     }
 
-    /** 발행 실패 기록 — retryCount 증가, failedAt 갱신. */
+    /**
+     * 발행 실패 기록 — retryCount 증가, failedAt 갱신, 지수 백오프 nextRetryAt 산출.
+     *
+     * <p>대기 시간: {@code min(30 × 2^retryCount, 3600)} 초.
+     * (retryCount=0→30s, 1→60s, 2→120s, 3→240s, 4→480s, ...)
+     */
     public void recordFailure() {
         this.retryCount++;
         this.failedAt = LocalDateTime.now();
+        long backoffSeconds = Math.min(30L * (1L << (retryCount - 1)), MAX_BACKOFF_SECONDS);
+        this.nextRetryAt = this.failedAt.plusSeconds(backoffSeconds);
     }
 }

--- a/src/main/java/com/stockmanagement/common/outbox/OutboxEventRelayScheduler.java
+++ b/src/main/java/com/stockmanagement/common/outbox/OutboxEventRelayScheduler.java
@@ -13,6 +13,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 /**
@@ -65,7 +66,7 @@ public class OutboxEventRelayScheduler {
     @Scheduled(fixedDelayString = "${outbox.relay.interval-ms:5000}")
     public void relay() {
         List<OutboxEvent> pending = repository
-                .findPendingEvents(MAX_RETRY, PageRequest.of(0, batchSize));
+                .findPendingEvents(MAX_RETRY, LocalDateTime.now(), PageRequest.of(0, batchSize));
 
         if (pending.isEmpty()) return;
 

--- a/src/main/java/com/stockmanagement/common/outbox/OutboxEventRepository.java
+++ b/src/main/java/com/stockmanagement/common/outbox/OutboxEventRepository.java
@@ -12,12 +12,26 @@ import java.util.List;
 public interface OutboxEventRepository extends JpaRepository<OutboxEvent, Long> {
 
     /**
-     * 미발행 이벤트 중 재시도 횟수 상한 미만인 레코드를 최대 {@code pageable.pageSize}건 조회한다.
+     * 미발행 이벤트 중 재시도 가능한 레코드를 최대 {@code pageable.pageSize}건 조회한다.
+     *
+     * <p>조건:
+     * <ul>
+     *   <li>{@code publishedAt IS NULL} — 미발행</li>
+     *   <li>{@code retryCount < maxRetry} — dead letter 제외</li>
+     *   <li>{@code nextRetryAt IS NULL OR nextRetryAt <= :now} — 지수 백오프 대기 이벤트 제외</li>
+     * </ul>
      * 생성 순서대로 처리하여 이벤트 순서를 보장한다.
-     * 배치 크기는 {@code outbox.relay.batch-size} 프로퍼티로 제어된다.
      */
-    @Query("SELECT e FROM OutboxEvent e WHERE e.publishedAt IS NULL AND e.retryCount < :maxRetry ORDER BY e.createdAt ASC")
-    List<OutboxEvent> findPendingEvents(@Param("maxRetry") int maxRetry, Pageable pageable);
+    @Query("""
+            SELECT e FROM OutboxEvent e
+            WHERE e.publishedAt IS NULL
+              AND e.retryCount < :maxRetry
+              AND (e.nextRetryAt IS NULL OR e.nextRetryAt <= :now)
+            ORDER BY e.createdAt ASC
+            """)
+    List<OutboxEvent> findPendingEvents(@Param("maxRetry") int maxRetry,
+                                        @Param("now") LocalDateTime now,
+                                        Pageable pageable);
 
     /**
      * 발행 완료된 레코드 중 기준 시각 이전 것을 일괄 삭제한다 (purge용).

--- a/src/main/java/com/stockmanagement/common/security/JwtTokenProvider.java
+++ b/src/main/java/com/stockmanagement/common/security/JwtTokenProvider.java
@@ -31,20 +31,19 @@ public class JwtTokenProvider {
     /**
      * 시작 시 JWT 시크릿을 초기화하고 보안 검사를 수행한다.
      *
-     * <p>JWT_SECRET 환경변수 미설정으로 개발용 기본값이 사용되는 경우 ERROR 로그를 출력한다.
+     * <p>JWT_SECRET 환경변수 미설정으로 개발용 기본값이 사용되는 경우 애플리케이션 시작을 즉시 실패시킨다.
      * 공격자가 기본값을 알고 있으므로 운영 배포 전 반드시 교체해야 한다.
+     *
+     * @throws IllegalStateException JWT_SECRET이 개발용 기본값일 때
      */
     @PostConstruct
     public void init() {
-        this.secretKey = Keys.hmacShaKeyFor(secretKeyStr.getBytes(StandardCharsets.UTF_8));
-
         if (DEV_DEFAULT_SECRET.equals(secretKeyStr)) {
-            log.error("╔══════════════════════════════════════════════════╗");
-            log.error("║ [SECURITY WARNING] JWT 개발용 기본 시크릿 사용 중  ║");
-            log.error("║ JWT_SECRET 환경변수를 설정하지 않으면               ║");
-            log.error("║ 공격자가 임의 토큰을 위조할 수 있습니다.            ║");
-            log.error("╚══════════════════════════════════════════════════╝");
+            throw new IllegalStateException(
+                    "[SECURITY] JWT_SECRET 환경변수가 개발용 기본값입니다. " +
+                    "운영 환경에서는 JWT_SECRET을 반드시 설정하세요.");
         }
+        this.secretKey = Keys.hmacShaKeyFor(secretKeyStr.getBytes(StandardCharsets.UTF_8));
     }
 
     /**

--- a/src/main/java/com/stockmanagement/domain/coupon/dto/CouponValidateRequest.java
+++ b/src/main/java/com/stockmanagement/domain/coupon/dto/CouponValidateRequest.java
@@ -3,6 +3,7 @@ package com.stockmanagement.domain.coupon.dto;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,6 +17,7 @@ import java.math.BigDecimal;
 public class CouponValidateRequest {
 
     @NotBlank
+    @Size(min = 8, max = 50)
     private String couponCode;
 
     @NotNull

--- a/src/main/java/com/stockmanagement/domain/coupon/repository/CouponRepository.java
+++ b/src/main/java/com/stockmanagement/domain/coupon/repository/CouponRepository.java
@@ -4,18 +4,27 @@ import com.stockmanagement.domain.coupon.entity.Coupon;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Optional;
 
 public interface CouponRepository extends JpaRepository<Coupon, Long> {
 
-    /** 만료됐지만 아직 활성 상태인 쿠폰 목록 (CouponExpiryScheduler 사용) */
-    @Query("SELECT c FROM Coupon c WHERE c.validUntil < :now AND c.active = true")
-    List<Coupon> findExpiredActiveCoupons(@Param("now") LocalDateTime now);
+    /**
+     * 만료된 활성 쿠폰을 단일 벌크 UPDATE로 비활성화한다.
+     *
+     * <p>기존 findExpiredActiveCoupons() + 건별 Dirty Checking 방식은
+     * 만료 쿠폰 수만큼 개별 UPDATE 쿼리가 발생했음.
+     * 단일 UPDATE 문으로 대체해 DB 왕복을 1회로 줄인다.
+     *
+     * @return 비활성화된 쿠폰 수
+     */
+    @Modifying
+    @Query("UPDATE Coupon c SET c.active = false WHERE c.validUntil < :now AND c.active = true")
+    int deactivateExpiredCoupons(@Param("now") LocalDateTime now);
 
     Optional<Coupon> findByCode(String code);
 

--- a/src/main/java/com/stockmanagement/domain/coupon/scheduler/CouponExpiryScheduler.java
+++ b/src/main/java/com/stockmanagement/domain/coupon/scheduler/CouponExpiryScheduler.java
@@ -1,6 +1,5 @@
 package com.stockmanagement.domain.coupon.scheduler;
 
-import com.stockmanagement.domain.coupon.entity.Coupon;
 import com.stockmanagement.domain.coupon.repository.CouponRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -10,13 +9,12 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 /**
  * 만료 쿠폰 자동 비활성화 스케줄러.
  *
  * <p>매일 새벽 1시에 {@code validUntil < now}인 활성 쿠폰을 {@code active=false}로 전환한다.
- * Dirty Checking에 의해 별도 save() 없이 트랜잭션 종료 시 자동 반영된다.
+ * 단일 벌크 UPDATE 쿼리로 처리하여 만료 쿠폰 수에 관계없이 DB 왕복 1회로 완료된다.
  */
 @Slf4j
 @Component
@@ -30,19 +28,7 @@ public class CouponExpiryScheduler {
     @Transactional
     public void deactivateExpiredCoupons() {
         LocalDateTime now = LocalDateTime.now();
-        List<Coupon> expired = couponRepository.findExpiredActiveCoupons(now);
-        log.info("[CouponExpiryScheduler] 만료 쿠폰 비활성화 시작 — 대상: {}건", expired.size());
-
-        int success = 0;
-        for (Coupon coupon : expired) {
-            try {
-                coupon.deactivate(); // Dirty Checking → 트랜잭션 종료 시 자동 UPDATE
-                success++;
-            } catch (Exception e) {
-                log.error("[CouponExpiryScheduler] 쿠폰 비활성화 실패 — couponId={}, error={}",
-                        coupon.getId(), e.getMessage());
-            }
-        }
-        log.info("[CouponExpiryScheduler] 완료 — 성공: {}건 / 전체: {}건", success, expired.size());
+        int count = couponRepository.deactivateExpiredCoupons(now);
+        log.info("[CouponExpiryScheduler] 만료 쿠폰 비활성화 완료 — {}건", count);
     }
 }

--- a/src/main/java/com/stockmanagement/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/stockmanagement/domain/coupon/service/CouponService.java
@@ -193,10 +193,7 @@ public class CouponService {
 
         // 비관적 락 획득 후 재검증 (TOCTOU 방지)
         validateActive(coupon);
-        validatePeriod(coupon);
-        validateUsageCount(coupon);
-        validateMinimumOrderAmount(coupon, orderAmount);
-        validateUserUsage(coupon, userId);
+        validateConditions(coupon, userId, orderAmount);
 
         // 발급 전용 쿠폰은 user_coupons 등록 여부 확인
         if (!coupon.isPublic()

--- a/src/main/java/com/stockmanagement/domain/inventory/service/InventoryService.java
+++ b/src/main/java/com/stockmanagement/domain/inventory/service/InventoryService.java
@@ -165,6 +165,14 @@ public class InventoryService {
     /**
      * 주문 생성 시 재고를 예약한다.
      * 가용 재고가 부족하면 {@link com.stockmanagement.common.exception.InsufficientStockException}이 발생한다.
+     *
+     * <p>동시성 이중 방어:
+     * <ul>
+     *   <li>@DistributedLock(Redisson) — 멀티 인스턴스 간 상호 배제 (외부 락)
+     *   <li>findByProductIdWithLock(SELECT FOR UPDATE) — 단일 DB 트랜잭션 내 비관적 락 (내부 락)
+     * </ul>
+     * Redis 장애 시 Redisson 락이 누락되더라도 DB 비관적 락이 최후 방어선으로 동작한다.
+     * releaseReservation(), allocate(), releaseAllocation()도 동일한 이중 락 구조를 따른다.
      */
     @DistributedLock(key = "'inventory:' + #productId")
     @Transactional

--- a/src/main/java/com/stockmanagement/domain/order/entity/Order.java
+++ b/src/main/java/com/stockmanagement/domain/order/entity/Order.java
@@ -112,7 +112,7 @@ public class Order {
      * 주문을 취소한다.
      *
      * <p>PENDING 상태인 경우에만 취소 가능하다.
-     * CONFIRMED·CANCELLED 상태에서 호출 시 {@link BusinessException}이 발생한다.
+     * PAYMENT_IN_PROGRESS 상태에서는 Toss API 호출이 진행 중이므로 취소 불가.
      *
      * @throws BusinessException 취소 불가 상태일 경우
      */
@@ -124,15 +124,42 @@ public class Order {
     }
 
     /**
-     * Confirms the order after successful payment.
-     * Called by the Payment domain upon payment approval.
+     * Toss API 호출 직전 결제 진행 중 상태로 전환한다.
      *
-     * <p>Only a PENDING order can be confirmed.
+     * <p>PENDING → PAYMENT_IN_PROGRESS. 만료 스케줄러({@code findExpiredPendingOrderIds})가
+     * PENDING만 조회하므로 이 상태로 전환된 주문은 자동 취소 대상에서 제외된다.
      *
-     * @throws BusinessException if the current status is not PENDING
+     * @throws BusinessException PENDING이 아닌 상태에서 호출 시
+     */
+    public void startPayment() {
+        if (this.status != OrderStatus.PENDING) {
+            throw new BusinessException(ErrorCode.INVALID_ORDER_STATUS);
+        }
+        this.status = OrderStatus.PAYMENT_IN_PROGRESS;
+    }
+
+    /**
+     * 결제 실패·오류 시 PAYMENT_IN_PROGRESS → PENDING 으로 복원한다.
+     *
+     * <p>복원 후 만료 스케줄러가 다시 이 주문을 정리할 수 있다.
+     * Toss API 오류 또는 비-DONE 응답 수신 시 {@link com.stockmanagement.domain.payment.service.PaymentTransactionHelper}가 호출한다.
+     */
+    public void resetPaymentFailed() {
+        if (this.status != OrderStatus.PAYMENT_IN_PROGRESS) {
+            throw new BusinessException(ErrorCode.INVALID_ORDER_STATUS);
+        }
+        this.status = OrderStatus.PENDING;
+    }
+
+    /**
+     * 결제 성공 후 주문을 확정한다 — Payment 도메인에서 호출.
+     *
+     * <p>PAYMENT_IN_PROGRESS(일반 결제) 또는 PENDING(가상계좌 Webhook) 상태에서 CONFIRMED로 전환.
+     *
+     * @throws BusinessException 전환 가능한 상태가 아닌 경우
      */
     public void confirm() {
-        if (this.status != OrderStatus.PENDING) {
+        if (this.status != OrderStatus.PAYMENT_IN_PROGRESS && this.status != OrderStatus.PENDING) {
             throw new BusinessException(ErrorCode.INVALID_ORDER_STATUS);
         }
         this.status = OrderStatus.CONFIRMED;

--- a/src/main/java/com/stockmanagement/domain/order/entity/OrderStatus.java
+++ b/src/main/java/com/stockmanagement/domain/order/entity/OrderStatus.java
@@ -4,22 +4,37 @@ package com.stockmanagement.domain.order.entity;
  * 주문 상태 열거형.
  *
  * <pre>
- * PENDING   → 주문 생성 완료, 재고 예약 완료, 결제 대기 중
- * CONFIRMED → 결제 성공 (Payment 도메인에서 전환)
- * CANCELLED → 주문 취소, 재고 예약 해제 완료
+ * PENDING              → 주문 생성 완료, 재고 예약 완료, 결제 대기 중
+ * PAYMENT_IN_PROGRESS  → Toss API 승인 요청 중 (만료 스케줄러 접근 불가)
+ * CONFIRMED            → 결제 성공 (Payment 도메인에서 전환)
+ * CANCELLED            → 주문 취소, 재고 예약 해제 완료
  * </pre>
  *
  * <p>상태 전이:
  * <ul>
- *   <li>PENDING → CONFIRMED (결제 성공)
- *   <li>PENDING → CANCELLED (주문 취소)
+ *   <li>PENDING → PAYMENT_IN_PROGRESS (Toss API 호출 직전 선점)
+ *   <li>PAYMENT_IN_PROGRESS → CONFIRMED (결제 성공)
+ *   <li>PAYMENT_IN_PROGRESS → PENDING (결제 실패/오류 시 복원)
+ *   <li>PENDING → CONFIRMED (가상계좌 Webhook 경로)
+ *   <li>PENDING → CANCELLED (주문 취소 / 만료 스케줄러)
  * </ul>
- * CONFIRMED·CANCELLED 상태에서는 더 이상 전이가 발생하지 않는다.
+ * PAYMENT_IN_PROGRESS 상태는 만료 스케줄러({@code findExpiredPendingOrderIds})가
+ * PENDING만 조회하므로 자동 취소 대상에서 제외된다.
  */
 public enum OrderStatus {
 
     /** 주문 생성, 재고 예약 완료 — 결제 대기 상태 */
     PENDING,
+
+    /**
+     * Toss API 결제 승인 요청 중.
+     *
+     * <p>외부 HTTP 호출(최대 30초) 동안 만료 스케줄러가 주문을 취소하지 못하도록
+     * {@link com.stockmanagement.domain.payment.service.PaymentTransactionHelper}가
+     * Toss API 호출 직전에 이 상태로 전환한다. Stripe의 {@code processing},
+     * Magento의 {@code payment_review}와 동일한 역할.
+     */
+    PAYMENT_IN_PROGRESS,
 
     /** 결제 완료 — 출고 확정 상태 */
     CONFIRMED,

--- a/src/main/java/com/stockmanagement/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/stockmanagement/domain/order/repository/OrderRepository.java
@@ -87,6 +87,15 @@ public interface OrderRepository extends JpaRepository<Order, Long>, JpaSpecific
     List<Long> findExpiredPendingOrderIds(@Param("threshold") LocalDateTime threshold);
 
     /**
+     * 주문 소유자의 userId만 조회한다 (소유권 검증 전용 — Order 전체 로드 불필요).
+     *
+     * @param id 주문 ID
+     * @return 주문 소유자 userId (주문 없으면 Optional.empty())
+     */
+    @Query("SELECT o.userId FROM Order o WHERE o.id = :id")
+    Optional<Long> findUserIdById(@Param("id") Long id);
+
+    /**
      * 사용자가 특정 상품을 구매(CONFIRMED 주문 보유)했는지 확인한다 (리뷰 작성 자격 검증).
      */
     @Query("SELECT COUNT(o) > 0 FROM Order o JOIN o.items i " +

--- a/src/main/java/com/stockmanagement/domain/order/service/OrderService.java
+++ b/src/main/java/com/stockmanagement/domain/order/service/OrderService.java
@@ -382,13 +382,15 @@ public class OrderService {
         Order order = orderRepository.findByIdWithItemsForUpdate(id)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
 
+        // 전환 전 상태를 캡처 — PAYMENT_IN_PROGRESS(일반 결제) 또는 PENDING(가상계좌 Webhook)
+        OrderStatus previousStatus = order.getStatus();
         order.confirm();
 
         for (OrderItem item : order.getItems()) {
             inventoryService.confirmAllocation(item.getProduct().getId(), item.getQuantity());
         }
 
-        recordHistory(order.getId(), OrderStatus.PENDING, OrderStatus.CONFIRMED, null);
+        recordHistory(order.getId(), previousStatus, OrderStatus.CONFIRMED, null);
         return order;
     }
 

--- a/src/main/java/com/stockmanagement/domain/payment/controller/PaymentController.java
+++ b/src/main/java/com/stockmanagement/domain/payment/controller/PaymentController.java
@@ -83,11 +83,14 @@ public class PaymentController {
         paymentService.handleWebhook(event);
     }
 
-    @Operation(summary = "결제 조회", description = "paymentKey로 결제 상세 조회.")
+    @Operation(summary = "결제 조회", description = "paymentKey로 결제 상세 조회. 본인 결제만 가능 (ADMIN은 전체 조회).")
     @GetMapping("/{paymentKey}")
     public ApiResponse<PaymentResponse> getByPaymentKey(
-            @PathVariable String paymentKey) {
-        return ApiResponse.ok(paymentService.getByPaymentKey(paymentKey));
+            @PathVariable String paymentKey,
+            @AuthenticationPrincipal String username,
+            Authentication authentication) {
+        boolean isAdmin = SecurityUtils.isAdmin(authentication);
+        return ApiResponse.ok(paymentService.getByPaymentKey(paymentKey, resolveUserId(authentication, username), isAdmin));
     }
 
     @Operation(summary = "주문별 결제 조회", description = "주문 ID로 결제 정보 조회. 결제 전이면 data: null 반환. 본인 주문만 가능.")

--- a/src/main/java/com/stockmanagement/domain/payment/infrastructure/TossWebhookVerifier.java
+++ b/src/main/java/com/stockmanagement/domain/payment/infrastructure/TossWebhookVerifier.java
@@ -31,16 +31,22 @@ public class TossWebhookVerifier {
     @Value("${toss.secret-key}")
     private String secretKeyStr;
 
-    private Mac mac;
+    /** 서명 키 — 불변(immutable)이므로 thread-safe하게 공유 가능. */
+    private SecretKeySpec secretKeySpec;
 
     @PostConstruct
-    public void init() throws NoSuchAlgorithmException, InvalidKeyException {
-        mac = Mac.getInstance(ALGORITHM);
-        mac.init(new SecretKeySpec(secretKeyStr.getBytes(StandardCharsets.UTF_8), ALGORITHM));
+    public void init() {
+        // SecretKeySpec은 불변 객체 → 스레드 안전하게 재사용 가능
+        this.secretKeySpec = new SecretKeySpec(
+                secretKeyStr.getBytes(StandardCharsets.UTF_8), ALGORITHM);
     }
 
     /**
      * 웹훅 서명을 검증한다.
+     *
+     * <p>Mac 인스턴스는 호출마다 새로 생성한다. Mac은 thread-safe하지 않으므로
+     * 싱글턴 공유 대신 per-call 생성 방식을 사용한다 (synchronized 병목 제거).
+     * SecretKeySpec은 불변이므로 재사용한다.
      *
      * @param rawBody   요청 본문 원문 (String)
      * @param signature {@code Toss-Signature} 헤더 값 (Base64 인코딩)
@@ -52,17 +58,19 @@ public class TossWebhookVerifier {
             throw new BusinessException(ErrorCode.WEBHOOK_SIGNATURE_INVALID);
         }
         try {
-            // Mac 인스턴스는 상태를 가지므로 synchronized로 보호
-            byte[] expected;
-            synchronized (mac) {
-                expected = mac.doFinal(rawBody.getBytes(StandardCharsets.UTF_8));
-            }
+            // Mac 인스턴스 per-call 생성 — synchronized 직렬화 병목 제거
+            Mac mac = Mac.getInstance(ALGORITHM);
+            mac.init(secretKeySpec);
+            byte[] expected = mac.doFinal(rawBody.getBytes(StandardCharsets.UTF_8));
             byte[] actual = Base64.getDecoder().decode(signature);
 
             if (!MessageDigest.isEqual(expected, actual)) {
                 log.warn("웹훅 서명 불일치");
                 throw new BusinessException(ErrorCode.WEBHOOK_SIGNATURE_INVALID);
             }
+        } catch (NoSuchAlgorithmException | InvalidKeyException e) {
+            // HmacSHA256은 JDK 표준 — 실질적으로 발생하지 않음
+            throw new IllegalStateException("HMAC 초기화 실패", e);
         } catch (IllegalArgumentException e) {
             // Base64 디코딩 실패
             log.warn("웹훅 서명 Base64 디코딩 실패: {}", e.getMessage());

--- a/src/main/java/com/stockmanagement/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/stockmanagement/domain/payment/service/PaymentService.java
@@ -164,6 +164,8 @@ public class PaymentService {
             return response;
 
         } catch (Exception e) {
+            // PAYMENT_IN_PROGRESS → PENDING 복원: 재시도 시 스케줄러가 다시 접근 가능하도록 되돌린다
+            transactionHelper.resetOrderOnPaymentError(request.getTossOrderId());
             // 실패 시 Redis 키 삭제 → 클라이언트 재시도 허용
             idempotencyManager.release(idempotencyKey);
             throw e;

--- a/src/main/java/com/stockmanagement/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/stockmanagement/domain/payment/service/PaymentService.java
@@ -269,13 +269,26 @@ public class PaymentService {
     /**
      * Toss paymentKey로 결제 상세 정보를 조회한다.
      *
+     * <p>ADMIN은 전체 조회 가능. USER는 자신의 주문에 대한 결제만 조회 가능.
+     * Payment 엔티티에 userId 필드가 없으므로 orderId → Order.userId 경유로 소유권을 검증한다.
+     *
      * @param paymentKey Toss 결제 키
+     * @param userId     요청자 userId (JWT claim)
+     * @param isAdmin    ADMIN 여부
      * @return 결제 상세 정보
+     * @throws BusinessException 결제 없음(PAYMENT_NOT_FOUND) 또는 소유권 불일치(ORDER_ACCESS_DENIED)
      */
-    public PaymentResponse getByPaymentKey(String paymentKey) {
-        return paymentRepository.findByPaymentKey(paymentKey)
-                .map(PaymentResponse::from)
+    public PaymentResponse getByPaymentKey(String paymentKey, Long userId, boolean isAdmin) {
+        Payment payment = paymentRepository.findByPaymentKey(paymentKey)
                 .orElseThrow(() -> new BusinessException(ErrorCode.PAYMENT_NOT_FOUND));
+        if (!isAdmin) {
+            Long orderUserId = orderRepository.findUserIdById(payment.getOrderId())
+                    .orElseThrow(() -> new BusinessException(ErrorCode.PAYMENT_NOT_FOUND));
+            if (!orderUserId.equals(userId)) {
+                throw new BusinessException(ErrorCode.ORDER_ACCESS_DENIED);
+            }
+        }
+        return PaymentResponse.from(payment);
     }
 
     /**

--- a/src/main/java/com/stockmanagement/domain/payment/service/PaymentTransactionHelper.java
+++ b/src/main/java/com/stockmanagement/domain/payment/service/PaymentTransactionHelper.java
@@ -18,6 +18,7 @@ import com.stockmanagement.domain.payment.repository.PaymentRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
@@ -85,7 +86,40 @@ class PaymentTransactionHelper {
             throw new BusinessException(ErrorCode.PAYMENT_AMOUNT_MISMATCH);
         }
 
+        // PENDING → PAYMENT_IN_PROGRESS: Toss HTTP 대기(최대 30초) 중
+        // 만료 스케줄러가 이 주문을 취소하지 못하도록 상태를 선점한다.
+        // Dirty Checking: 트랜잭션 종료 시 자동 flush.
+        order.startPayment();
+
         return Optional.empty();
+    }
+
+    /**
+     * 결제 실패·오류 시 PAYMENT_IN_PROGRESS → PENDING 복원 트랜잭션.
+     *
+     * <p>Toss API 호출 실패(네트워크 오류, HTTP 5xx) 또는 비-DONE 응답 수신 시
+     * {@link PaymentService#confirm}의 catch 블록에서 호출된다.
+     *
+     * <p>{@code REQUIRES_NEW}를 사용하여 호출 컨텍스트가 롤백되더라도
+     * 이 트랜잭션은 독립적으로 커밋된다. 복원 후 만료 스케줄러가 다시 이 주문을 정리할 수 있다.
+     *
+     * @param tossOrderId Toss 주문 ID
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    void resetOrderOnPaymentError(String tossOrderId) {
+        paymentRepository.findByTossOrderId(tossOrderId).ifPresent(payment ->
+            orderRepository.findById(payment.getOrderId()).ifPresent(order -> {
+                try {
+                    order.resetPaymentFailed();
+                    log.info("[Payment] 결제 오류 — 주문 상태 복원: orderId={}, PAYMENT_IN_PROGRESS → PENDING",
+                            order.getId());
+                } catch (BusinessException e) {
+                    // PAYMENT_IN_PROGRESS가 아닌 상태 — Webhook 등 다른 경로로 이미 처리됨, 무시
+                    log.warn("[Payment] 주문 상태 복원 생략 — 이미 상태 변경됨: orderId={}, currentStatus={}",
+                            order.getId(), order.getStatus());
+                }
+            })
+        );
     }
 
     /**

--- a/src/main/java/com/stockmanagement/domain/product/review/controller/ReviewController.java
+++ b/src/main/java/com/stockmanagement/domain/product/review/controller/ReviewController.java
@@ -5,6 +5,7 @@ import com.stockmanagement.domain.product.review.dto.ReviewCreateRequest;
 import com.stockmanagement.domain.product.review.dto.ReviewResponse;
 import com.stockmanagement.domain.product.review.dto.ReviewUpdateRequest;
 import com.stockmanagement.domain.product.review.service.ReviewService;
+import com.stockmanagement.domain.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -13,6 +14,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -23,6 +25,7 @@ import org.springframework.web.bind.annotation.*;
 public class ReviewController {
 
     private final ReviewService reviewService;
+    private final UserService userService;
 
     @Operation(summary = "리뷰 작성 (실구매자 한정, 상품당 1회)")
     @PostMapping
@@ -30,8 +33,9 @@ public class ReviewController {
     public ApiResponse<ReviewResponse> create(
             @PathVariable Long productId,
             @AuthenticationPrincipal String username,
+            Authentication authentication,
             @Valid @RequestBody ReviewCreateRequest request) {
-        return ApiResponse.ok(reviewService.create(productId, username, request));
+        return ApiResponse.ok(reviewService.create(productId, resolveUserId(authentication, username), request));
     }
 
     @Operation(summary = "상품 리뷰 목록 조회 (최신순)")
@@ -48,8 +52,9 @@ public class ReviewController {
             @PathVariable Long productId,
             @PathVariable Long reviewId,
             @AuthenticationPrincipal String username,
+            Authentication authentication,
             @Valid @RequestBody ReviewUpdateRequest request) {
-        return ApiResponse.ok(reviewService.update(productId, reviewId, username, request));
+        return ApiResponse.ok(reviewService.update(productId, reviewId, resolveUserId(authentication, username), request));
     }
 
     @Operation(summary = "리뷰 삭제 (작성자 본인)")
@@ -58,7 +63,16 @@ public class ReviewController {
     public void delete(
             @PathVariable Long productId,
             @PathVariable Long reviewId,
-            @AuthenticationPrincipal String username) {
-        reviewService.delete(productId, reviewId, username);
+            @AuthenticationPrincipal String username,
+            Authentication authentication) {
+        reviewService.delete(productId, reviewId, resolveUserId(authentication, username));
+    }
+
+    /** JWT claim details에서 userId 추출. 구 토큰이면 DB fallback. */
+    private Long resolveUserId(Authentication auth, String username) {
+        if (auth != null && auth.getDetails() instanceof Long userId) {
+            return userId;
+        }
+        return userService.resolveUserId(username);
     }
 }

--- a/src/main/java/com/stockmanagement/domain/product/review/service/ReviewService.java
+++ b/src/main/java/com/stockmanagement/domain/product/review/service/ReviewService.java
@@ -3,15 +3,12 @@ package com.stockmanagement.domain.product.review.service;
 import com.stockmanagement.common.exception.BusinessException;
 import com.stockmanagement.common.exception.ErrorCode;
 import com.stockmanagement.domain.order.repository.OrderRepository;
-import com.stockmanagement.domain.product.entity.Product;
 import com.stockmanagement.domain.product.repository.ProductRepository;
 import com.stockmanagement.domain.product.review.dto.ReviewCreateRequest;
 import com.stockmanagement.domain.product.review.dto.ReviewResponse;
 import com.stockmanagement.domain.product.review.dto.ReviewUpdateRequest;
 import com.stockmanagement.domain.product.review.entity.Review;
 import com.stockmanagement.domain.product.review.repository.ReviewRepository;
-import com.stockmanagement.domain.user.entity.User;
-import com.stockmanagement.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.data.domain.Page;
@@ -26,32 +23,30 @@ public class ReviewService {
 
     private final ReviewRepository reviewRepository;
     private final ProductRepository productRepository;
-    private final UserRepository userRepository;
     private final OrderRepository orderRepository;
 
     /**
      * 리뷰를 작성한다.
      *
      * <p>실구매자(CONFIRMED 주문 보유) + 상품당 1인 1리뷰 제약을 검증한다.
+     * userId는 JWT claim에서 추출한 값을 컨트롤러에서 전달받아 DB users 조회를 생략한다.
      */
     @Transactional
     @CacheEvict(cacheNames = "products", key = "#productId")
-    public ReviewResponse create(Long productId, String username, ReviewCreateRequest request) {
-        Product product = productRepository.findById(productId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND));
-        User user = userRepository.findByUsername(username)
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
-
-        if (!orderRepository.existsPurchaseByUserIdAndProductId(user.getId(), product.getId())) {
+    public ReviewResponse create(Long productId, Long userId, ReviewCreateRequest request) {
+        if (!productRepository.existsById(productId)) {
+            throw new BusinessException(ErrorCode.PRODUCT_NOT_FOUND);
+        }
+        if (!orderRepository.existsPurchaseByUserIdAndProductId(userId, productId)) {
             throw new BusinessException(ErrorCode.REVIEW_NOT_PURCHASED);
         }
-        if (reviewRepository.existsByProductIdAndUserId(product.getId(), user.getId())) {
+        if (reviewRepository.existsByProductIdAndUserId(productId, userId)) {
             throw new BusinessException(ErrorCode.REVIEW_ALREADY_EXISTS);
         }
 
         Review review = Review.builder()
-                .productId(product.getId())
-                .userId(user.getId())
+                .productId(productId)
+                .userId(userId)
                 .rating(request.getRating())
                 .title(request.getTitle())
                 .content(request.getContent())
@@ -62,26 +57,28 @@ public class ReviewService {
 
     /** 상품의 리뷰 목록을 최신순 페이징 조회한다. */
     public Page<ReviewResponse> getList(Long productId, Pageable pageable) {
-        productRepository.findById(productId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND));
+        if (!productRepository.existsById(productId)) {
+            throw new BusinessException(ErrorCode.PRODUCT_NOT_FOUND);
+        }
         return reviewRepository.findByProductIdOrderByCreatedAtDesc(productId, pageable)
                 .map(ReviewResponse::from);
     }
 
-    /** 리뷰를 수정한다. 작성자 본인만 가능하다. */
+    /**
+     * 리뷰를 수정한다. 작성자 본인만 가능하다.
+     *
+     * <p>userId는 JWT claim에서 추출한 값을 컨트롤러에서 전달받아 DB users 조회를 생략한다.
+     */
     @Transactional
     @CacheEvict(cacheNames = "products", key = "#productId")
-    public ReviewResponse update(Long productId, Long reviewId, String username, ReviewUpdateRequest request) {
-        User user = userRepository.findByUsername(username)
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
-
+    public ReviewResponse update(Long productId, Long reviewId, Long userId, ReviewUpdateRequest request) {
         Review review = reviewRepository.findById(reviewId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.REVIEW_NOT_FOUND));
 
         if (!review.getProductId().equals(productId)) {
             throw new BusinessException(ErrorCode.REVIEW_NOT_FOUND);
         }
-        if (!review.getUserId().equals(user.getId())) {
+        if (!review.getUserId().equals(userId)) {
             throw new BusinessException(ErrorCode.REVIEW_ACCESS_DENIED);
         }
 
@@ -89,20 +86,21 @@ public class ReviewService {
         return ReviewResponse.from(review);
     }
 
-    /** 리뷰를 삭제한다. 작성자 본인만 가능하다. */
+    /**
+     * 리뷰를 삭제한다. 작성자 본인만 가능하다.
+     *
+     * <p>userId는 JWT claim에서 추출한 값을 컨트롤러에서 전달받아 DB users 조회를 생략한다.
+     */
     @Transactional
     @CacheEvict(cacheNames = "products", key = "#productId")
-    public void delete(Long productId, Long reviewId, String username) {
-        User user = userRepository.findByUsername(username)
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
-
+    public void delete(Long productId, Long reviewId, Long userId) {
         Review review = reviewRepository.findById(reviewId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.REVIEW_NOT_FOUND));
 
         if (!review.getProductId().equals(productId)) {
             throw new BusinessException(ErrorCode.REVIEW_NOT_FOUND);
         }
-        if (!review.getUserId().equals(user.getId())) {
+        if (!review.getUserId().equals(userId)) {
             throw new BusinessException(ErrorCode.REVIEW_ACCESS_DENIED);
         }
 

--- a/src/main/java/com/stockmanagement/domain/product/wishlist/controller/WishlistController.java
+++ b/src/main/java/com/stockmanagement/domain/product/wishlist/controller/WishlistController.java
@@ -3,10 +3,12 @@ package com.stockmanagement.domain.product.wishlist.controller;
 import com.stockmanagement.common.dto.ApiResponse;
 import com.stockmanagement.domain.product.wishlist.dto.WishlistResponse;
 import com.stockmanagement.domain.product.wishlist.service.WishlistService;
+import com.stockmanagement.domain.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,14 +21,16 @@ import java.util.List;
 public class WishlistController {
 
     private final WishlistService wishlistService;
+    private final UserService userService;
 
     @Operation(summary = "위시리스트에 상품 추가")
     @PostMapping("/{productId}")
     @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<WishlistResponse> add(
             @PathVariable Long productId,
-            @AuthenticationPrincipal String username) {
-        return ApiResponse.ok(wishlistService.add(productId, username));
+            @AuthenticationPrincipal String username,
+            Authentication authentication) {
+        return ApiResponse.ok(wishlistService.add(productId, resolveUserId(authentication, username)));
     }
 
     @Operation(summary = "위시리스트에서 상품 제거")
@@ -34,8 +38,9 @@ public class WishlistController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void remove(
             @PathVariable Long productId,
-            @AuthenticationPrincipal String username) {
-        wishlistService.remove(productId, username);
+            @AuthenticationPrincipal String username,
+            Authentication authentication) {
+        wishlistService.remove(productId, resolveUserId(authentication, username));
     }
 
     @Operation(summary = "특정 상품의 위시리스트 추가 여부 조회",
@@ -43,15 +48,25 @@ public class WishlistController {
     @GetMapping("/{productId}")
     public ApiResponse<java.util.Map<String, Boolean>> isWishlisted(
             @PathVariable Long productId,
-            @AuthenticationPrincipal String username) {
-        boolean wishlisted = wishlistService.isWishlisted(productId, username);
+            @AuthenticationPrincipal String username,
+            Authentication authentication) {
+        boolean wishlisted = wishlistService.isWishlisted(productId, resolveUserId(authentication, username));
         return ApiResponse.ok(java.util.Map.of("wishlisted", wishlisted));
     }
 
     @Operation(summary = "내 위시리스트 목록 조회")
     @GetMapping
     public ApiResponse<List<WishlistResponse>> getList(
-            @AuthenticationPrincipal String username) {
-        return ApiResponse.ok(wishlistService.getList(username));
+            @AuthenticationPrincipal String username,
+            Authentication authentication) {
+        return ApiResponse.ok(wishlistService.getList(resolveUserId(authentication, username)));
+    }
+
+    /** JWT details에서 userId를 추출하고, 없으면 DB fallback. */
+    private Long resolveUserId(Authentication auth, String username) {
+        if (auth != null && auth.getDetails() instanceof Long userId) {
+            return userId;
+        }
+        return userService.resolveUserId(username);
     }
 }

--- a/src/main/java/com/stockmanagement/domain/product/wishlist/service/WishlistService.java
+++ b/src/main/java/com/stockmanagement/domain/product/wishlist/service/WishlistService.java
@@ -7,8 +7,6 @@ import com.stockmanagement.domain.product.repository.ProductRepository;
 import com.stockmanagement.domain.product.wishlist.dto.WishlistResponse;
 import com.stockmanagement.domain.product.wishlist.entity.WishlistItem;
 import com.stockmanagement.domain.product.wishlist.repository.WishlistRepository;
-import com.stockmanagement.domain.user.entity.User;
-import com.stockmanagement.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,46 +23,57 @@ public class WishlistService {
 
     private final WishlistRepository wishlistRepository;
     private final ProductRepository productRepository;
-    private final UserRepository userRepository;
 
-    /** 위시리스트에 상품을 추가한다. */
+    /**
+     * 위시리스트에 상품을 추가한다.
+     *
+     * <p>userId는 JWT claim에서 추출한 값을 컨트롤러에서 전달받아 DB users 조회를 생략한다.
+     */
     @Transactional
-    public WishlistResponse add(Long productId, String username) {
-        User user = findUser(username);
+    public WishlistResponse add(Long productId, Long userId) {
         Product product = productRepository.findById(productId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND));
 
-        if (wishlistRepository.existsByUserIdAndProductId(user.getId(), productId)) {
+        if (wishlistRepository.existsByUserIdAndProductId(userId, productId)) {
             throw new BusinessException(ErrorCode.WISHLIST_ALREADY_EXISTS);
         }
 
         WishlistItem item = WishlistItem.builder()
-                .userId(user.getId())
+                .userId(userId)
                 .productId(productId)
                 .build();
 
         return toResponse(wishlistRepository.save(item), product);
     }
 
-    /** 위시리스트에서 상품을 제거한다. */
+    /**
+     * 위시리스트에서 상품을 제거한다.
+     *
+     * <p>userId는 JWT claim에서 추출한 값을 컨트롤러에서 전달받아 DB users 조회를 생략한다.
+     */
     @Transactional
-    public void remove(Long productId, String username) {
-        User user = findUser(username);
-        WishlistItem item = wishlistRepository.findByUserIdAndProductId(user.getId(), productId)
+    public void remove(Long productId, Long userId) {
+        WishlistItem item = wishlistRepository.findByUserIdAndProductId(userId, productId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.WISHLIST_ITEM_NOT_FOUND));
         wishlistRepository.delete(item);
     }
 
-    /** 특정 상품의 위시리스트 추가 여부를 반환한다 (상품 상세 페이지 하트 아이콘용). */
-    public boolean isWishlisted(Long productId, String username) {
-        User user = findUser(username);
-        return wishlistRepository.existsByUserIdAndProductId(user.getId(), productId);
+    /**
+     * 특정 상품의 위시리스트 추가 여부를 반환한다 (상품 상세 페이지 하트 아이콘용).
+     *
+     * <p>userId는 JWT claim에서 추출한 값을 컨트롤러에서 전달받아 DB users 조회를 생략한다.
+     */
+    public boolean isWishlisted(Long productId, Long userId) {
+        return wishlistRepository.existsByUserIdAndProductId(userId, productId);
     }
 
-    /** 사용자의 위시리스트 목록을 조회한다. */
-    public List<WishlistResponse> getList(String username) {
-        User user = findUser(username);
-        List<WishlistItem> items = wishlistRepository.findByUserIdOrderByCreatedAtDesc(user.getId());
+    /**
+     * 사용자의 위시리스트 목록을 조회한다.
+     *
+     * <p>userId는 JWT claim에서 추출한 값을 컨트롤러에서 전달받아 DB users 조회를 생략한다.
+     */
+    public List<WishlistResponse> getList(Long userId) {
+        List<WishlistItem> items = wishlistRepository.findByUserIdOrderByCreatedAtDesc(userId);
         if (items.isEmpty()) {
             return List.of();
         }
@@ -79,11 +88,6 @@ public class WishlistService {
                 .filter(item -> productMap.containsKey(item.getProductId()))
                 .map(item -> toResponse(item, productMap.get(item.getProductId())))
                 .toList();
-    }
-
-    private User findUser(String username) {
-        return userRepository.findByUsername(username)
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
     }
 
     private WishlistResponse toResponse(WishlistItem item, Product product) {

--- a/src/main/java/com/stockmanagement/domain/shipment/service/ShipmentService.java
+++ b/src/main/java/com/stockmanagement/domain/shipment/service/ShipmentService.java
@@ -77,9 +77,10 @@ public class ShipmentService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.SHIPMENT_NOT_FOUND));
 
         if (!isAdmin) {
-            Order order = orderRepository.findById(orderId)
+            // userId 스칼라 프로젝션 — Order 전체 엔티티 로드 불필요
+            Long orderUserId = orderRepository.findUserIdById(orderId)
                     .orElseThrow(() -> new BusinessException(ErrorCode.SHIPMENT_NOT_FOUND));
-            if (!order.getUserId().equals(resolveUserId(username))) {
+            if (!orderUserId.equals(resolveUserId(username))) {
                 // 타인 배송 존재 여부 노출 방지 — ACCESS_DENIED 대신 NOT_FOUND 반환
                 throw new BusinessException(ErrorCode.SHIPMENT_NOT_FOUND);
             }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -63,11 +63,18 @@ server.shutdown=graceful
 spring.lifecycle.timeout-per-shutdown-phase=30s
 
 # ===== Actuator =====
-# prometheus는 SecurityConfig에서 ADMIN 전용으로 제한
-management.endpoints.web.exposure.include=health,info,metrics,loggers,env,beans,prometheus
+# 공개 허용 최소 엔드포인트 — prometheus는 SecurityConfig에서 ADMIN 전용으로 제한
+management.endpoints.web.exposure.include=health,info,prometheus,metrics
 management.endpoint.health.show-details=when-authorized
 management.endpoint.health.probes.enabled=true
 management.info.env.enabled=true
+# 민감 정보 노출 방지: env(환경변수) / heapdump(힙 덤프) / threaddump / beans / mappings / loggers 비활성화
+management.endpoint.env.enabled=false
+management.endpoint.heapdump.enabled=false
+management.endpoint.threaddump.enabled=false
+management.endpoint.beans.enabled=false
+management.endpoint.mappings.enabled=false
+management.endpoint.loggers.enabled=false
 
 # ===== Micrometer 메트릭 =====
 management.metrics.tags.application=${spring.application.name}

--- a/src/main/resources/db/migration/V29__backfill_refunds_user_id.sql
+++ b/src/main/resources/db/migration/V29__backfill_refunds_user_id.sql
@@ -1,0 +1,20 @@
+-- =====================================================================
+-- V29: refunds.user_id 백필 + FK 제약 추가
+-- =====================================================================
+-- V28에서 ADD COLUMN user_id BIGINT NOT NULL DEFAULT 0 으로 컬럼을 추가했으나
+-- 기존 환불 레코드의 user_id가 0으로 채워진 상태.
+-- user_id=0은 존재하지 않는 사용자 ID이므로 소유권 검증이 항상 실패함.
+-- 이 마이그레이션은 orders 테이블에서 실제 user_id를 조회해 백필한 뒤,
+-- 참조 무결성을 보장하는 FK 제약을 추가한다.
+-- =====================================================================
+
+-- 1단계: 기존 레코드 백필 — orders.user_id 를 refunds.user_id 로 채움
+UPDATE refunds r
+    JOIN orders o ON r.order_id = o.id
+SET r.user_id = o.user_id
+WHERE r.user_id = 0;
+
+-- 2단계: FK 제약 추가 — users 테이블 참조 무결성 보장
+--   ON DELETE RESTRICT: 사용자 삭제 전 환불 이력 정리 필요 (소프트 삭제이므로 실제로는 발생 안 함)
+ALTER TABLE refunds
+    ADD CONSTRAINT fk_refunds_user FOREIGN KEY (user_id) REFERENCES users (id);

--- a/src/main/resources/db/migration/V30__fix_charset_collation.sql
+++ b/src/main/resources/db/migration/V30__fix_charset_collation.sql
@@ -1,0 +1,28 @@
+-- =====================================================================
+-- V30: charset · collation 통일
+-- =====================================================================
+-- 대상 테이블:
+--   payments              (V4)  — ENGINE/CHARSET/COLLATE 모두 미정의
+--   daily_order_stats     (V15) — ENGINE/CHARSET/COLLATE 모두 미정의
+--   daily_inventory_snapshots (V15) — ENGINE/CHARSET/COLLATE 모두 미정의
+--   outbox_events         (V18) — CHARSET=utf8mb4이나 COLLATE 미정의
+--
+-- 다른 모든 테이블은 utf8mb4_unicode_ci 로 통일되어 있음.
+-- collation 불일치 상태에서 JOIN 시 "Illegal mix of collations" 에러 또는
+-- 인덱스 미사용(payments JOIN orders 등)이 발생할 수 있음.
+-- =====================================================================
+
+ALTER TABLE payments
+    ENGINE = InnoDB,
+    CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+ALTER TABLE daily_order_stats
+    ENGINE = InnoDB,
+    CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+ALTER TABLE daily_inventory_snapshots
+    ENGINE = InnoDB,
+    CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+ALTER TABLE outbox_events
+    CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/src/main/resources/db/migration/V31__add_missing_indexes2.sql
+++ b/src/main/resources/db/migration/V31__add_missing_indexes2.sql
@@ -1,0 +1,31 @@
+-- =====================================================================
+-- V31: 누락 인덱스 추가
+-- =====================================================================
+-- orders (status, created_at):
+--   DailyOrderStatsScheduler가 매일 자정 countByStatusAndCreatedAtBetween()을
+--   CONFIRMED·CANCELLED 각 1회씩 실행.
+--   쿼리: WHERE status = ? AND created_at >= ? AND created_at < ?
+--   기존 idx_orders_status(status) + idx_orders_created_at(created_at) 단일 인덱스로는
+--   옵티마이저가 한쪽만 택해 나머지 조건을 post-filter 처리 → filesort 발생.
+--   (status, created_at) 복합 인덱스로 커버링 인덱스 스캔 가능.
+--
+-- products (status):
+--   ProductRepository 전 조회 쿼리에 WHERE status = 'ACTIVE' 조건 포함.
+--   V1~V29 어디에도 status 인덱스 없어 products 풀스캔 발생.
+--
+-- coupons (valid_until, active):
+--   CouponExpiryScheduler: WHERE valid_until < :now AND active = true
+--   매일 새벽 1시 실행. 인덱스 없으면 coupons 풀스캔.
+-- =====================================================================
+
+-- #35: 통계 쿼리 커버링 인덱스
+ALTER TABLE orders
+    ADD INDEX idx_orders_status_created (status, created_at);
+
+-- #37: 상품 상태 필터 인덱스
+ALTER TABLE products
+    ADD INDEX idx_products_status (status);
+
+-- #36: 만료 쿠폰 조회 인덱스
+ALTER TABLE coupons
+    ADD INDEX idx_coupons_expiry (valid_until, active);

--- a/src/main/resources/db/migration/V32__add_missing_fk_constraints.sql
+++ b/src/main/resources/db/migration/V32__add_missing_fk_constraints.sql
@@ -1,0 +1,25 @@
+-- =====================================================================
+-- V32: 누락 FK 제약 추가
+-- =====================================================================
+-- cart_items.user_id:
+--   product_id → products FK는 있지만 user_id → users FK가 없음.
+--   사용자 탈퇴(소프트 삭제) 후 cart_items 레코드가 고아로 남아
+--   user_id가 무효한 상태로 유지됨.
+--   ON DELETE CASCADE: 사용자 hard delete 시 장바구니 자동 정리.
+--   (소프트 삭제 운영이므로 실질적 CASCADE 발동은 없지만 무결성 보장)
+--
+-- point_transactions.order_id:
+--   user_id → users FK는 있지만 order_id → orders FK가 없음.
+--   주문 삭제 시 포인트 이력의 order_id가 고아 참조 상태가 됨.
+--   ON DELETE SET NULL: 주문 삭제 후에도 포인트 이력 자체는 보존.
+-- =====================================================================
+
+-- #38: 장바구니 사용자 참조 무결성
+ALTER TABLE cart_items
+    ADD CONSTRAINT fk_cart_user
+        FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE;
+
+-- #39: 포인트 이력 주문 참조 무결성
+ALTER TABLE point_transactions
+    ADD CONSTRAINT fk_pt_order
+        FOREIGN KEY (order_id) REFERENCES orders (id) ON DELETE SET NULL;

--- a/src/main/resources/db/migration/V33__fix_timestamp_defaults.sql
+++ b/src/main/resources/db/migration/V33__fix_timestamp_defaults.sql
@@ -1,0 +1,35 @@
+-- =====================================================================
+-- V33: created_at / updated_at DEFAULT CURRENT_TIMESTAMP 누락 수정
+-- =====================================================================
+-- 아래 6개 테이블이 Hibernate @CreationTimestamp/@UpdateTimestamp에만 의존하고
+-- DDL 레벨 DEFAULT가 없어, bulk INSERT 또는 DB 직접 조작 시 NOT NULL 위반 가능.
+-- 다른 모든 테이블(V1~V6 등)은 DEFAULT CURRENT_TIMESTAMP(6)가 정의되어 있음.
+-- =====================================================================
+
+-- payments (V4)
+ALTER TABLE payments
+    MODIFY created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    MODIFY updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6);
+
+-- shipments (V11)
+ALTER TABLE shipments
+    MODIFY created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    MODIFY updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6);
+
+-- delivery_addresses (V12)
+ALTER TABLE delivery_addresses
+    MODIFY created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    MODIFY updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6);
+
+-- cart_items (V10)
+ALTER TABLE cart_items
+    MODIFY created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    MODIFY updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6);
+
+-- product_images (V17)
+ALTER TABLE product_images
+    MODIFY created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);
+
+-- user_coupons (V22)
+ALTER TABLE user_coupons
+    MODIFY issued_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);

--- a/src/main/resources/db/migration/V34__outbox_next_retry_at.sql
+++ b/src/main/resources/db/migration/V34__outbox_next_retry_at.sql
@@ -1,0 +1,14 @@
+-- =====================================================================
+-- V34: outbox_events 지수 백오프 지원
+-- =====================================================================
+-- 기존 relay 쿼리는 failedAt 컬럼이 있음에도 미발행 이벤트를
+-- 5초 간격으로 무조건 재시도 → 다운스트림 장애 시 연속 폭격 발생.
+-- next_retry_at(NULL = 즉시 재시도 가능)을 추가하고
+-- recordFailure() 호출 시 지수 백오프로 산출: 30s × 2^retryCount (최대 1h).
+-- relay 쿼리에서 next_retry_at <= NOW() 조건으로 대기 중인 이벤트만 선택.
+-- 기존 레코드는 NULL → 즉시 재시도 대상 유지(하위 호환).
+-- =====================================================================
+
+ALTER TABLE outbox_events
+    ADD COLUMN next_retry_at DATETIME(6) NULL AFTER failed_at,
+    ADD INDEX idx_outbox_next_retry (published_at, retry_count, next_retry_at);

--- a/src/test/java/com/stockmanagement/common/outbox/OutboxEventRelaySchedulerTest.java
+++ b/src/test/java/com/stockmanagement/common/outbox/OutboxEventRelaySchedulerTest.java
@@ -44,7 +44,7 @@ class OutboxEventRelaySchedulerTest {
         @Test
         @DisplayName("미발행 이벤트 없음 → processor 미호출")
         void doesNothingWhenNoPending() {
-            given(repository.findPendingEvents(anyInt(), any()))
+            given(repository.findPendingEvents(anyInt(), any(), any()))
                     .willReturn(List.of());
 
             scheduler.relay();
@@ -60,7 +60,7 @@ class OutboxEventRelaySchedulerTest {
             ReflectionTestUtils.setField(e1, "id", 1L);
             ReflectionTestUtils.setField(e2, "id", 2L);
 
-            given(repository.findPendingEvents(anyInt(), any()))
+            given(repository.findPendingEvents(anyInt(), any(), any()))
                     .willReturn(List.of(e1, e2));
 
             scheduler.relay();

--- a/src/test/java/com/stockmanagement/domain/coupon/scheduler/CouponExpirySchedulerTest.java
+++ b/src/test/java/com/stockmanagement/domain/coupon/scheduler/CouponExpirySchedulerTest.java
@@ -1,6 +1,5 @@
 package com.stockmanagement.domain.coupon.scheduler;
 
-import com.stockmanagement.domain.coupon.entity.Coupon;
 import com.stockmanagement.domain.coupon.repository.CouponRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -8,15 +7,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
-
-import java.math.BigDecimal;
-import java.time.LocalDateTime;
-import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("CouponExpiryScheduler 단위 테스트")
@@ -26,41 +20,22 @@ class CouponExpirySchedulerTest {
     @InjectMocks CouponExpiryScheduler scheduler;
 
     @Test
-    @DisplayName("만료 쿠폰이 있으면 deactivate() 호출")
+    @DisplayName("만료 쿠폰이 있으면 벌크 UPDATE 호출 및 건수 반환")
     void deactivatesExpiredCoupons() {
-        Coupon expired = buildActiveCoupon("EXPIRED");
-        given(couponRepository.findExpiredActiveCoupons(any())).willReturn(List.of(expired));
+        given(couponRepository.deactivateExpiredCoupons(any())).willReturn(3);
 
         scheduler.deactivateExpiredCoupons();
 
-        // deactivate() → active=false 확인
-        assert !expired.isActive();
+        verify(couponRepository).deactivateExpiredCoupons(any());
     }
 
     @Test
-    @DisplayName("만료 쿠폰이 없으면 deactivate() 미호출")
+    @DisplayName("만료 쿠폰이 없으면 0건 반환 (정상 종료)")
     void doesNothingWhenNoExpiredCoupons() {
-        given(couponRepository.findExpiredActiveCoupons(any())).willReturn(List.of());
+        given(couponRepository.deactivateExpiredCoupons(any())).willReturn(0);
 
         scheduler.deactivateExpiredCoupons();
 
-        // 빈 목록이므로 쿠폰 관련 추가 호출 없음
-        verify(couponRepository, only()).findExpiredActiveCoupons(any());
-    }
-
-    // ===== 헬퍼 =====
-
-    private Coupon buildActiveCoupon(String code) {
-        Coupon coupon = Coupon.builder()
-                .code(code)
-                .name("테스트 쿠폰")
-                .discountType(com.stockmanagement.domain.coupon.entity.DiscountType.FIXED_AMOUNT)
-                .discountValue(BigDecimal.valueOf(1000))
-                .validFrom(LocalDateTime.now().minusDays(30))
-                .validUntil(LocalDateTime.now().minusDays(1))
-                .maxUsageCount(100)
-                .build();
-        ReflectionTestUtils.setField(coupon, "id", 1L);
-        return coupon;
+        verify(couponRepository).deactivateExpiredCoupons(any());
     }
 }

--- a/src/test/java/com/stockmanagement/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/order/service/OrderServiceTest.java
@@ -374,6 +374,18 @@ class OrderServiceTest {
         }
 
         @Test
+        @DisplayName("PAYMENT_IN_PROGRESS 주문 확정 — 일반 Toss 결제 경로 (CONFIRMED 전환)")
+        void confirmsPaymentInProgressOrder() {
+            order.startPayment(); // PENDING → PAYMENT_IN_PROGRESS
+            given(orderRepository.findByIdWithItemsForUpdate(1L)).willReturn(Optional.of(order));
+
+            orderService.confirm(1L);
+
+            assertThat(order.getStatus()).isEqualTo(OrderStatus.CONFIRMED);
+            verify(inventoryService).confirmAllocation(any(), eq(1));
+        }
+
+        @Test
         @DisplayName("주문이 존재하지 않으면 ORDER_NOT_FOUND 예외를 발생시킨다")
         void throwsWhenNotFound() {
             given(orderRepository.findByIdWithItemsForUpdate(99L)).willReturn(Optional.empty());

--- a/src/test/java/com/stockmanagement/domain/payment/controller/PaymentControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/payment/controller/PaymentControllerTest.java
@@ -250,7 +250,8 @@ class PaymentControllerTest {
         @WithMockUser
         @DisplayName("인증된 사용자 — 결제 내역 조회 → 200")
         void returnsPayment() throws Exception {
-            given(paymentService.getByPaymentKey("pk-test")).willReturn(mock(PaymentResponse.class));
+            given(paymentService.getByPaymentKey(eq("pk-test"), any(), anyBoolean()))
+                    .willReturn(mock(PaymentResponse.class));
 
             mockMvc.perform(get("/api/payments/pk-test"))
                     .andExpect(status().isOk())
@@ -268,11 +269,23 @@ class PaymentControllerTest {
         @WithMockUser
         @DisplayName("존재하지 않는 결제 → 404")
         void returnsNotFound() throws Exception {
-            given(paymentService.getByPaymentKey("unknown"))
+            given(paymentService.getByPaymentKey(eq("unknown"), any(), anyBoolean()))
                     .willThrow(new BusinessException(ErrorCode.PAYMENT_NOT_FOUND));
 
             mockMvc.perform(get("/api/payments/unknown"))
                     .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false));
+        }
+
+        @Test
+        @WithMockUser
+        @DisplayName("타인 결제 조회 시도 → 403")
+        void deniesAccessForNonOwner() throws Exception {
+            given(paymentService.getByPaymentKey(eq("pk-test"), any(), anyBoolean()))
+                    .willThrow(new BusinessException(ErrorCode.ORDER_ACCESS_DENIED));
+
+            mockMvc.perform(get("/api/payments/pk-test"))
+                    .andExpect(status().isForbidden())
                     .andExpect(jsonPath("$.success").value(false));
         }
     }

--- a/src/test/java/com/stockmanagement/domain/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/payment/service/PaymentServiceTest.java
@@ -433,14 +433,37 @@ class PaymentServiceTest {
     class GetByPaymentKey {
 
         @Test
-        @DisplayName("결제가 존재하면 PaymentResponse를 반환한다")
-        void returnsPaymentResponse() {
+        @DisplayName("ADMIN은 소유권 검증 없이 결제 조회 가능")
+        void returnsPaymentResponseForAdmin() {
             given(paymentRepository.findByPaymentKey("pk-001")).willReturn(Optional.of(pendingPayment));
 
-            PaymentResponse response = paymentService.getByPaymentKey("pk-001");
+            PaymentResponse response = paymentService.getByPaymentKey("pk-001", 99L, true);
 
             assertThat(response.getTossOrderId()).isEqualTo("toss-order-001");
             assertThat(response.getStatus()).isEqualTo(PaymentStatus.PENDING);
+        }
+
+        @Test
+        @DisplayName("본인 결제 조회 → 성공")
+        void returnsPaymentResponseForOwner() {
+            given(paymentRepository.findByPaymentKey("pk-001")).willReturn(Optional.of(pendingPayment));
+            given(orderRepository.findUserIdById(1L)).willReturn(Optional.of(1L));
+
+            PaymentResponse response = paymentService.getByPaymentKey("pk-001", 1L, false);
+
+            assertThat(response.getTossOrderId()).isEqualTo("toss-order-001");
+        }
+
+        @Test
+        @DisplayName("타인 결제 조회 → ORDER_ACCESS_DENIED")
+        void throwsWhenNonOwnerAccesses() {
+            given(paymentRepository.findByPaymentKey("pk-001")).willReturn(Optional.of(pendingPayment));
+            given(orderRepository.findUserIdById(1L)).willReturn(Optional.of(1L));
+
+            assertThatThrownBy(() -> paymentService.getByPaymentKey("pk-001", 99L, false))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.ORDER_ACCESS_DENIED));
         }
 
         @Test
@@ -448,7 +471,7 @@ class PaymentServiceTest {
         void throwsWhenNotFound() {
             given(paymentRepository.findByPaymentKey("unknown")).willReturn(Optional.empty());
 
-            assertThatThrownBy(() -> paymentService.getByPaymentKey("unknown"))
+            assertThatThrownBy(() -> paymentService.getByPaymentKey("unknown", 1L, false))
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                             .isEqualTo(ErrorCode.PAYMENT_NOT_FOUND));

--- a/src/test/java/com/stockmanagement/domain/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/payment/service/PaymentServiceTest.java
@@ -297,7 +297,7 @@ class PaymentServiceTest {
         }
 
         @Test
-        @DisplayName("Toss API가 DONE이 아닌 상태 반환 시 applyConfirmResult가 TOSS_PAYMENTS_ERROR를 던진다")
+        @DisplayName("Toss API가 DONE이 아닌 상태 반환 시 주문 상태를 복원하고 TOSS_PAYMENTS_ERROR를 던진다")
         void failsWhenTossReturnsNonDoneStatus() {
             PaymentConfirmRequest request = mock(PaymentConfirmRequest.class);
             given(request.getTossOrderId()).willReturn("toss-order-001");
@@ -316,6 +316,29 @@ class PaymentServiceTest {
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                             .isEqualTo(ErrorCode.TOSS_PAYMENTS_ERROR));
+
+            // PAYMENT_IN_PROGRESS → PENDING 복원 호출 검증
+            verify(transactionHelper).resetOrderOnPaymentError("toss-order-001");
+        }
+
+        @Test
+        @DisplayName("Toss API 예외 발생 시 주문 상태를 PENDING으로 복원한다")
+        void resetsOrderStatusWhenTossApiThrows() {
+            PaymentConfirmRequest request = mock(PaymentConfirmRequest.class);
+            given(request.getTossOrderId()).willReturn("toss-order-001");
+            given(request.getAmount()).willReturn(new BigDecimal("10000"));
+            given(request.getPaymentKey()).willReturn("pk-001");
+
+            given(transactionHelper.loadAndValidateForConfirm(anyString(), any(), anyLong()))
+                    .willReturn(Optional.empty());
+            given(tossPaymentsClient.confirm(any()))
+                    .willThrow(new RuntimeException("Toss API 네트워크 오류"));
+
+            assertThatThrownBy(() -> paymentService.confirm(request, 1L))
+                    .isInstanceOf(RuntimeException.class);
+
+            verify(transactionHelper).resetOrderOnPaymentError("toss-order-001");
+            verify(idempotencyManager).release("confirm:toss-order-001");
         }
     }
 

--- a/src/test/java/com/stockmanagement/domain/product/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/product/review/controller/ReviewControllerTest.java
@@ -6,7 +6,9 @@ import com.stockmanagement.common.exception.ErrorCode;
 import com.stockmanagement.common.security.JwtBlacklist;
 import com.stockmanagement.domain.product.review.dto.ReviewResponse;
 import com.stockmanagement.domain.product.review.service.ReviewService;
+import com.stockmanagement.domain.user.service.UserService;
 import com.stockmanagement.common.security.JwtTokenProvider;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -41,6 +43,7 @@ class ReviewControllerTest {
     private MockMvc mockMvc;
 
     @MockBean private ReviewService reviewService;
+    @MockBean private UserService userService;
     @MockBean private JwtTokenProvider jwtTokenProvider;
     @MockBean private JwtBlacklist jwtBlacklist;
 
@@ -49,6 +52,11 @@ class ReviewControllerTest {
                     List.of(new SimpleGrantedAuthority("ROLE_USER")));
 
     private static final String REVIEW_JSON = "{\"rating\":5,\"title\":\"좋아요\",\"content\":\"매우 만족합니다.\"}";
+
+    @BeforeEach
+    void setUp() {
+        given(userService.resolveUserId(anyString())).willReturn(1L);
+    }
 
     // ===== POST /api/products/{id}/reviews =====
 
@@ -59,7 +67,7 @@ class ReviewControllerTest {
         @Test
         @DisplayName("인증된 사용자 — 리뷰 작성 → 201")
         void createsReview() throws Exception {
-            given(reviewService.create(anyLong(), anyString(), any())).willReturn(mock(ReviewResponse.class));
+            given(reviewService.create(anyLong(), anyLong(), any())).willReturn(mock(ReviewResponse.class));
 
             mockMvc.perform(post("/api/products/1/reviews")
                             .with(authentication(USER_AUTH))
@@ -81,7 +89,7 @@ class ReviewControllerTest {
         @Test
         @DisplayName("미구매 상품 리뷰 → 400")
         void notPurchased() throws Exception {
-            given(reviewService.create(anyLong(), anyString(), any()))
+            given(reviewService.create(anyLong(), anyLong(), any()))
                     .willThrow(new BusinessException(ErrorCode.REVIEW_NOT_PURCHASED));
 
             mockMvc.perform(post("/api/products/1/reviews")
@@ -95,7 +103,7 @@ class ReviewControllerTest {
         @Test
         @DisplayName("중복 리뷰 → 409")
         void duplicateReview() throws Exception {
-            given(reviewService.create(anyLong(), anyString(), any()))
+            given(reviewService.create(anyLong(), anyLong(), any()))
                     .willThrow(new BusinessException(ErrorCode.REVIEW_ALREADY_EXISTS));
 
             mockMvc.perform(post("/api/products/1/reviews")

--- a/src/test/java/com/stockmanagement/domain/product/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/product/review/service/ReviewServiceTest.java
@@ -9,8 +9,6 @@ import com.stockmanagement.domain.product.review.dto.ReviewCreateRequest;
 import com.stockmanagement.domain.product.review.dto.ReviewResponse;
 import com.stockmanagement.domain.product.review.entity.Review;
 import com.stockmanagement.domain.product.review.repository.ReviewRepository;
-import com.stockmanagement.domain.user.entity.User;
-import com.stockmanagement.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -38,7 +36,6 @@ class ReviewServiceTest {
 
     @Mock private ReviewRepository reviewRepository;
     @Mock private ProductRepository productRepository;
-    @Mock private UserRepository userRepository;
     @Mock private OrderRepository orderRepository;
 
     @InjectMocks private ReviewService reviewService;
@@ -47,12 +44,6 @@ class ReviewServiceTest {
         Product p = Product.builder().name("테스트상품").price(java.math.BigDecimal.valueOf(10000)).sku("SKU-001").build();
         ReflectionTestUtils.setField(p, "id", id);
         return p;
-    }
-
-    private User mockUser(Long id, String username) {
-        User u = User.builder().username(username).password("pw").email("e@e.com").build();
-        ReflectionTestUtils.setField(u, "id", id);
-        return u;
     }
 
     private ReviewCreateRequest request() {
@@ -70,10 +61,7 @@ class ReviewServiceTest {
         @Test
         @DisplayName("정상 작성 → 저장 호출")
         void success() {
-            Product product = mockProduct(1L);
-            User user = mockUser(2L, "user1");
-            given(productRepository.findById(1L)).willReturn(Optional.of(product));
-            given(userRepository.findByUsername("user1")).willReturn(Optional.of(user));
+            given(productRepository.existsById(1L)).willReturn(true);
             given(orderRepository.existsPurchaseByUserIdAndProductId(2L, 1L)).willReturn(true);
             given(reviewRepository.existsByProductIdAndUserId(1L, 2L)).willReturn(false);
 
@@ -81,7 +69,7 @@ class ReviewServiceTest {
             ReflectionTestUtils.setField(saved, "id", 10L);
             given(reviewRepository.save(any())).willReturn(saved);
 
-            ReviewResponse response = reviewService.create(1L, "user1", request());
+            ReviewResponse response = reviewService.create(1L, 2L, request());
 
             assertThat(response.getRating()).isEqualTo(5);
             verify(reviewRepository).save(any());
@@ -90,11 +78,10 @@ class ReviewServiceTest {
         @Test
         @DisplayName("미구매 상품 → REVIEW_NOT_PURCHASED")
         void notPurchased() {
-            given(productRepository.findById(1L)).willReturn(Optional.of(mockProduct(1L)));
-            given(userRepository.findByUsername("user1")).willReturn(Optional.of(mockUser(2L, "user1")));
+            given(productRepository.existsById(1L)).willReturn(true);
             given(orderRepository.existsPurchaseByUserIdAndProductId(2L, 1L)).willReturn(false);
 
-            assertThatThrownBy(() -> reviewService.create(1L, "user1", request()))
+            assertThatThrownBy(() -> reviewService.create(1L, 2L, request()))
                     .isInstanceOf(BusinessException.class)
                     .hasFieldOrPropertyWithValue("errorCode", ErrorCode.REVIEW_NOT_PURCHASED);
         }
@@ -102,12 +89,11 @@ class ReviewServiceTest {
         @Test
         @DisplayName("이미 리뷰 존재 → REVIEW_ALREADY_EXISTS")
         void alreadyExists() {
-            given(productRepository.findById(1L)).willReturn(Optional.of(mockProduct(1L)));
-            given(userRepository.findByUsername("user1")).willReturn(Optional.of(mockUser(2L, "user1")));
+            given(productRepository.existsById(1L)).willReturn(true);
             given(orderRepository.existsPurchaseByUserIdAndProductId(2L, 1L)).willReturn(true);
             given(reviewRepository.existsByProductIdAndUserId(1L, 2L)).willReturn(true);
 
-            assertThatThrownBy(() -> reviewService.create(1L, "user1", request()))
+            assertThatThrownBy(() -> reviewService.create(1L, 2L, request()))
                     .isInstanceOf(BusinessException.class)
                     .hasFieldOrPropertyWithValue("errorCode", ErrorCode.REVIEW_ALREADY_EXISTS);
         }
@@ -120,7 +106,7 @@ class ReviewServiceTest {
         @Test
         @DisplayName("정상 조회 → 페이지 반환")
         void success() {
-            given(productRepository.findById(1L)).willReturn(Optional.of(mockProduct(1L)));
+            given(productRepository.existsById(1L)).willReturn(true);
             Review r = Review.builder().productId(1L).userId(2L).rating(4).title("보통").content("그냥 그래요").build();
             ReflectionTestUtils.setField(r, "id", 5L);
             given(reviewRepository.findByProductIdOrderByCreatedAtDesc(any(), any(Pageable.class)))
@@ -140,13 +126,11 @@ class ReviewServiceTest {
         @Test
         @DisplayName("작성자 삭제 성공")
         void success() {
-            User user = mockUser(2L, "user1");
-            given(userRepository.findByUsername("user1")).willReturn(Optional.of(user));
             Review r = Review.builder().productId(1L).userId(2L).rating(5).title("좋아요").content("최고").build();
             ReflectionTestUtils.setField(r, "id", 10L);
             given(reviewRepository.findById(10L)).willReturn(Optional.of(r));
 
-            reviewService.delete(1L, 10L, "user1");
+            reviewService.delete(1L, 10L, 2L);
 
             verify(reviewRepository).delete(r);
         }
@@ -154,13 +138,11 @@ class ReviewServiceTest {
         @Test
         @DisplayName("타인 리뷰 삭제 시도 → REVIEW_ACCESS_DENIED")
         void accessDenied() {
-            User other = mockUser(99L, "other");
-            given(userRepository.findByUsername("other")).willReturn(Optional.of(other));
             Review r = Review.builder().productId(1L).userId(2L).rating(5).title("좋아요").content("최고").build();
             ReflectionTestUtils.setField(r, "id", 10L);
             given(reviewRepository.findById(10L)).willReturn(Optional.of(r));
 
-            assertThatThrownBy(() -> reviewService.delete(1L, 10L, "other"))
+            assertThatThrownBy(() -> reviewService.delete(1L, 10L, 99L))
                     .isInstanceOf(BusinessException.class)
                     .hasFieldOrPropertyWithValue("errorCode", ErrorCode.REVIEW_ACCESS_DENIED);
         }

--- a/src/test/java/com/stockmanagement/domain/product/wishlist/controller/WishlistControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/product/wishlist/controller/WishlistControllerTest.java
@@ -6,7 +6,9 @@ import com.stockmanagement.common.exception.ErrorCode;
 import com.stockmanagement.common.security.JwtBlacklist;
 import com.stockmanagement.domain.product.wishlist.dto.WishlistResponse;
 import com.stockmanagement.domain.product.wishlist.service.WishlistService;
+import com.stockmanagement.domain.user.service.UserService;
 import com.stockmanagement.common.security.JwtTokenProvider;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -37,12 +39,18 @@ class WishlistControllerTest {
     private MockMvc mockMvc;
 
     @MockBean private WishlistService wishlistService;
+    @MockBean private UserService userService;
     @MockBean private JwtTokenProvider jwtTokenProvider;
     @MockBean private JwtBlacklist jwtBlacklist;
 
     private static final UsernamePasswordAuthenticationToken USER_AUTH =
             new UsernamePasswordAuthenticationToken("user1", null,
                     List.of(new SimpleGrantedAuthority("ROLE_USER")));
+
+    @BeforeEach
+    void setUp() {
+        given(userService.resolveUserId(anyString())).willReturn(1L);
+    }
 
     // ===== POST /api/wishlist/{productId} =====
 
@@ -53,7 +61,7 @@ class WishlistControllerTest {
         @Test
         @DisplayName("인증된 사용자 — 위시리스트 추가 → 201")
         void addsToWishlist() throws Exception {
-            given(wishlistService.add(anyLong(), anyString())).willReturn(mock(WishlistResponse.class));
+            given(wishlistService.add(anyLong(), anyLong())).willReturn(mock(WishlistResponse.class));
 
             mockMvc.perform(post("/api/wishlist/1").with(authentication(USER_AUTH)))
                     .andExpect(status().isCreated())
@@ -70,7 +78,7 @@ class WishlistControllerTest {
         @Test
         @DisplayName("이미 추가된 상품 → 409")
         void alreadyExists() throws Exception {
-            given(wishlistService.add(anyLong(), anyString()))
+            given(wishlistService.add(anyLong(), anyLong()))
                     .willThrow(new BusinessException(ErrorCode.WISHLIST_ALREADY_EXISTS));
 
             mockMvc.perform(post("/api/wishlist/1").with(authentication(USER_AUTH)))
@@ -109,7 +117,7 @@ class WishlistControllerTest {
         @Test
         @DisplayName("인증된 사용자 — 위시리스트 조회 → 200")
         void returnsList() throws Exception {
-            given(wishlistService.getList(anyString()))
+            given(wishlistService.getList(anyLong()))
                     .willReturn(List.of(mock(WishlistResponse.class)));
 
             mockMvc.perform(get("/api/wishlist").with(authentication(USER_AUTH)))

--- a/src/test/java/com/stockmanagement/domain/product/wishlist/service/WishlistServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/product/wishlist/service/WishlistServiceTest.java
@@ -7,8 +7,6 @@ import com.stockmanagement.domain.product.repository.ProductRepository;
 import com.stockmanagement.domain.product.wishlist.dto.WishlistResponse;
 import com.stockmanagement.domain.product.wishlist.entity.WishlistItem;
 import com.stockmanagement.domain.product.wishlist.repository.WishlistRepository;
-import com.stockmanagement.domain.user.entity.User;
-import com.stockmanagement.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -34,15 +32,8 @@ class WishlistServiceTest {
 
     @Mock private WishlistRepository wishlistRepository;
     @Mock private ProductRepository productRepository;
-    @Mock private UserRepository userRepository;
 
     @InjectMocks private WishlistService wishlistService;
-
-    private User mockUser(Long id) {
-        User u = User.builder().username("user1").password("pw").email("e@e.com").build();
-        ReflectionTestUtils.setField(u, "id", id);
-        return u;
-    }
 
     private Product mockProduct(Long id) {
         Product p = Product.builder().name("상품A").price(BigDecimal.valueOf(15000)).sku("SKU-A").build();
@@ -63,13 +54,12 @@ class WishlistServiceTest {
         @Test
         @DisplayName("정상 추가 → 저장 호출")
         void success() {
-            given(userRepository.findByUsername("user1")).willReturn(Optional.of(mockUser(1L)));
             given(productRepository.findById(10L)).willReturn(Optional.of(mockProduct(10L)));
             given(wishlistRepository.existsByUserIdAndProductId(1L, 10L)).willReturn(false);
             WishlistItem saved = mockItem(5L, 1L, 10L);
             given(wishlistRepository.save(any())).willReturn(saved);
 
-            WishlistResponse response = wishlistService.add(10L, "user1");
+            WishlistResponse response = wishlistService.add(10L, 1L);
 
             assertThat(response.getProductId()).isEqualTo(10L);
             verify(wishlistRepository).save(any());
@@ -78,11 +68,10 @@ class WishlistServiceTest {
         @Test
         @DisplayName("이미 추가된 상품 → WISHLIST_ALREADY_EXISTS")
         void alreadyExists() {
-            given(userRepository.findByUsername("user1")).willReturn(Optional.of(mockUser(1L)));
             given(productRepository.findById(10L)).willReturn(Optional.of(mockProduct(10L)));
             given(wishlistRepository.existsByUserIdAndProductId(1L, 10L)).willReturn(true);
 
-            assertThatThrownBy(() -> wishlistService.add(10L, "user1"))
+            assertThatThrownBy(() -> wishlistService.add(10L, 1L))
                     .isInstanceOf(BusinessException.class)
                     .hasFieldOrPropertyWithValue("errorCode", ErrorCode.WISHLIST_ALREADY_EXISTS);
         }
@@ -95,11 +84,10 @@ class WishlistServiceTest {
         @Test
         @DisplayName("정상 제거 → delete 호출")
         void success() {
-            given(userRepository.findByUsername("user1")).willReturn(Optional.of(mockUser(1L)));
             WishlistItem item = mockItem(5L, 1L, 10L);
             given(wishlistRepository.findByUserIdAndProductId(1L, 10L)).willReturn(Optional.of(item));
 
-            wishlistService.remove(10L, "user1");
+            wishlistService.remove(10L, 1L);
 
             verify(wishlistRepository).delete(item);
         }
@@ -107,10 +95,9 @@ class WishlistServiceTest {
         @Test
         @DisplayName("존재하지 않는 항목 → WISHLIST_ITEM_NOT_FOUND")
         void notFound() {
-            given(userRepository.findByUsername("user1")).willReturn(Optional.of(mockUser(1L)));
             given(wishlistRepository.findByUserIdAndProductId(1L, 10L)).willReturn(Optional.empty());
 
-            assertThatThrownBy(() -> wishlistService.remove(10L, "user1"))
+            assertThatThrownBy(() -> wishlistService.remove(10L, 1L))
                     .isInstanceOf(BusinessException.class)
                     .hasFieldOrPropertyWithValue("errorCode", ErrorCode.WISHLIST_ITEM_NOT_FOUND);
         }
@@ -123,13 +110,12 @@ class WishlistServiceTest {
         @Test
         @DisplayName("목록 반환")
         void success() {
-            given(userRepository.findByUsername("user1")).willReturn(Optional.of(mockUser(1L)));
             WishlistItem item = mockItem(5L, 1L, 10L);
             Product product = mockProduct(10L);
             given(wishlistRepository.findByUserIdOrderByCreatedAtDesc(1L)).willReturn(List.of(item));
             given(productRepository.findAllById(List.of(10L))).willReturn(List.of(product));
 
-            List<WishlistResponse> list = wishlistService.getList("user1");
+            List<WishlistResponse> list = wishlistService.getList(1L);
 
             assertThat(list).hasSize(1);
             assertThat(list.get(0).getProductName()).isEqualTo("상품A");

--- a/src/test/resources/application-integration.properties
+++ b/src/test/resources/application-integration.properties
@@ -49,3 +49,9 @@ mail.enabled=false
 # Outbox Relay/Purge: 통합 테스트 중 스케줄러 간섭 방지
 outbox.relay.enabled=false
 outbox.purge.enabled=false
+
+# ===== 보안 기본값 체크 우회 (테스트 전용) =====
+# JwtTokenProvider / AdminSecurityConfig의 기본값 감지 시 시작 실패 → 테스트용 고유 값으로 교체
+jwt.secret=integration-test-only-secret-key-not-for-production-use-32chars
+admin.username=test-admin
+admin.password=test-admin-password-integration-only


### PR DESCRIPTION
## Summary

- **#52 [핵심]** Toss 결제 승인 중 만료 스케줄러 경합 — `PAYMENT_IN_PROGRESS` 상태 도입으로 근본 해결  
  Stripe `processing` / Magento `payment_review`와 동일한 업계 표준 패턴
- **#56** `PaymentController.getByPaymentKey()` IDOR 소유권 검증 추가
- **#46/#58** JWT/Admin 기본 자격증명 사용 시 애플리케이션 시작 실패
- **#63** Actuator 민감 엔드포인트(`env/heapdump/threaddump/beans`) 비활성화
- **#49/#57/#50/#64** ShipmentService 프로젝션, TossWebhookVerifier per-call Mac, CouponService 검증 통합, 입력 검증
- 성능: InventoryRepository N+1, CategoryService 캐시, InventorySnapshotScheduler 배치
- 스키마: V29~V34 마이그레이션 (인덱스, FK, charset, Outbox backoff)
- 문서: API·DB·결제·TODO 전면 최신화

## PAYMENT_IN_PROGRESS 상태 전이

```
PENDING
  → [loadAndValidateForConfirm() 커밋]
    PAYMENT_IN_PROGRESS   ← 만료 스케줄러 접근 불가(PENDING만 조회)
      → [Toss API 성공] → CONFIRMED
      → [Toss API 실패] → resetOrderOnPaymentError(REQUIRES_NEW) → PENDING 복원
PENDING → [가상계좌 Webhook] → CONFIRMED   (Order.confirm()이 양쪽 허용)
```

## Test plan

- [x] `./gradlew test` — 610개 전체 통과 (+2: PAYMENT_IN_PROGRESS 확정, Toss 오류 reset 검증)
- [x] `OrderServiceTest.confirmsPendingOrder` / `confirmsPaymentInProgressOrder`
- [x] `PaymentServiceTest.failsWhenTossReturnsNonDoneStatus` — `resetOrderOnPaymentError` 호출 검증
- [x] `PaymentServiceTest.resetsOrderStatusWhenTossApiThrows` — 네트워크 오류 시 PENDING 복원
- [x] `PaymentIntegrationTest.confirmSuccess` — 실제 상태 전이 통합 검증