### PR TITLE
fix: 긴급 버그 수정 — Payment 금액 누락 및 중복 상품 500 에러 (#80, #81)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,62 @@
 # CLAUDE.md
 
+Behavioral guidelines to reduce common LLM coding mistakes. Merge with project-specific instructions as needed.
+
+Tradeoff: These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+1. Think Before Coding
+   Don't assume. Don't hide confusion. Surface tradeoffs.
+
+Before implementing:
+
+State your assumptions explicitly. If uncertain, ask.
+If multiple interpretations exist, present them - don't pick silently.
+If a simpler approach exists, say so. Push back when warranted.
+If something is unclear, stop. Name what's confusing. Ask.
+2. Simplicity First
+   Minimum code that solves the problem. Nothing speculative.
+
+No features beyond what was asked.
+No abstractions for single-use code.
+No "flexibility" or "configurability" that wasn't requested.
+No error handling for impossible scenarios.
+If you write 200 lines and it could be 50, rewrite it.
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+3. Surgical Changes
+   Touch only what you must. Clean up only your own mess.
+
+When editing existing code:
+
+Don't "improve" adjacent code, comments, or formatting.
+Don't refactor things that aren't broken.
+Match existing style, even if you'd do it differently.
+If you notice unrelated dead code, mention it - don't delete it.
+When your changes create orphans:
+
+Remove imports/variables/functions that YOUR changes made unused.
+Don't remove pre-existing dead code unless asked.
+The test: Every changed line should trace directly to the user's request.
+
+4. Goal-Driven Execution
+   Define success criteria. Loop until verified.
+
+Transform tasks into verifiable goals:
+
+"Add validation" → "Write tests for invalid inputs, then make them pass"
+"Fix the bug" → "Write a test that reproduces it, then make it pass"
+"Refactor X" → "Ensure tests pass before and after"
+For multi-step tasks, state a brief plan:
+
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+   Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+---
+
+
+
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ## Project Overview

--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -1,7 +1,7 @@
 # 개선 작업 내역
 
 > Spring Boot 3.5.11 + Java 17 기반 쇼핑몰 재고 관리 API에서 발견·해결한 기술적 문제 목록.
-> 각 항목은 **문제 인식 → 해결 방법 → Trade-off → 결과** 순으로 기술한다.
+> 각 항목은 **배경 및 문제정의 → 솔루션 → 기능 구현 → Trade-off → 결과** 순으로 기술한다.
 
 ---
 
@@ -96,10 +96,10 @@ ALB가 요청을 두 인스턴스에 분산하므로 동일 상품 주문이 Ser
 
 ## 1. 재고 동시성 제어
 
-### 문제 인식
+### 배경 및 문제정의
 
-쇼핑몰 특성상 인기 상품에는 동시에 수백 건의 주문 요청이 발생한다.
-단순 조회→차감 패턴은 다음 시나리오에서 무너진다.
+* **상황:** 인기 상품에 동시에 수백 건의 주문 요청이 발생하는 쇼핑몰 특성
+* **문제:** 단순 조회→차감 패턴은 동시 접근 시 재고 초과 예약(oversell)을 유발함
 
 ```
 재고: 1개 남음
@@ -110,20 +110,24 @@ Thread A: UPDATE reserved += 1  → available = 0
 Thread B: UPDATE reserved += 1  → available = -1  ← 초과 예약 발생
 ```
 
-`@Transactional`만으로는 부족하다. REPEATABLE READ 격리 수준에서는 각 트랜잭션이 시작 시점의 스냅샷을 읽기 때문에 Thread B도 여전히 `available = 1`을 본다. SERIALIZABLE은 데드락 위험과 처리량 저하가 크다.
+* `@Transactional`만으로는 부족함 — REPEATABLE READ 격리 수준에서 각 트랜잭션은 시작 시점의 스냅샷을 읽어 Thread B도 `available = 1`을 봄. SERIALIZABLE은 데드락 위험과 처리량 저하가 큼
+* 멀티 인스턴스(수평 확장) 환경에서 JVM `synchronized`는 의미 없음 — 두 JVM은 메모리가 완전히 분리되어 있어 인스턴스 간 동시성을 제어할 수 없음
 
-멀티 인스턴스(수평 확장) 환경이라면 JVM 수준의 `synchronized`는 아무 의미가 없다. 인스턴스 A와 인스턴스 B가 각자의 메모리에서 동시 처리하기 때문이다.
+### 솔루션: 2중 락 전략
 
-### 해결 방법
-
-**2중 락 전략** 적용:
+* 단일 레이어로는 멀티 인스턴스 환경과 DB 레벨 동시성을 동시에 제어할 수 없음
+* 분산 락(인스턴스 간 직렬화)과 DB 비관적 락(분산 락 누락 경로 차단)을 조합하여 각 레이어가 독립적으로 방어
 
 | 레이어 | 기술 | 역할 |
 |--------|------|------|
 | 분산 락 | Redisson `@DistributedLock` | 멀티 인스턴스 환경에서 동일 상품 요청 직렬화 |
 | DB 락 | `@Lock(PESSIMISTIC_WRITE)` | DB 레벨 보조, 분산 락 누락 경로 차단 |
 
-재고 상태를 3가지로 분리해 의미를 명확히 한다.
+### 기능 구현
+
+**1. 재고 상태 3분리**
+
+주문·결제·취소 각 단계의 재고 의미를 명확히 구분한다.
 
 ```
 available = onHand - reserved - allocated
@@ -133,6 +137,8 @@ available = onHand - reserved - allocated
 주문 취소  → reserved--
 결제 취소  → allocated--
 ```
+
+**2. 분산 락 + 비관적 락 적용**
 
 ```java
 @DistributedLock(key = "'lock:inventory:' + #productId", waitTime = 3, leaseTime = 5)
@@ -145,20 +151,21 @@ public void reserve(Long productId, int quantity) {
 
 ### Trade-off
 
-비관적 락과 분산 락을 동시에 사용하면 처리량(Throughput)이 저하된다. 이를 감안해 재고 차감·반환 핵심 경로에만 선별 적용하고, 단순 조회 API에는 락을 사용하지 않았다.
+비관적 락과 분산 락을 동시에 사용하면 처리량(Throughput)이 저하된다. 재고 차감·반환 핵심 경로에만 선별 적용하고, 단순 조회 API에는 락을 사용하지 않았다.
 
 ### 결과
 
-- 동시 100건 주문 시나리오(k6)에서 재고 초과 예약 0건
-- 분산 락 획득 실패 시 `LOCK_ACQUISITION_FAILED` 즉시 반환 (무한 대기 없음)
+* 동시 100건 주문 시나리오(k6)에서 재고 초과 예약 0건
+* 분산 락 획득 실패 시 `LOCK_ACQUISITION_FAILED` 즉시 반환 (무한 대기 없음)
 
 ---
 
 ## 2. 결제 취소 이중 처리 경쟁 조건
 
-### 문제 인식
+### 배경 및 문제정의
 
-사용자가 취소 버튼을 빠르게 두 번 클릭하거나, 네트워크 재시도로 동일 요청이 두 번 도달하면:
+* **상황:** 사용자가 취소 버튼을 빠르게 두 번 클릭하거나, 네트워크 재시도로 동일 요청이 두 번 도달하는 상황
+* **문제:** TOCTOU(Time-of-Check to Time-of-Use) 취약점 — 상태 확인 시점과 변경 시점 사이에 다른 스레드가 끼어들 수 있음
 
 ```
 결제 status = CONFIRMED
@@ -170,21 +177,26 @@ Thread 2: PG사 취소 API 호출 → ??? (이미 취소된 결제에 재요청)
 Thread 2: UPDATE status = CANCELLED  ← 중복 기록
 ```
 
-이 패턴은 TOCTOU(Time-of-Check to Time-of-Use) 취약점의 전형적인 사례다. 상태 확인 시점과 상태 변경 시점 사이에 다른 스레드가 끼어들 수 있다.
+* 프로덕션에서 발생 시 결제는 1번 취소됐는데 환불이 2번 지급되는 **금전적 손실**로 이어짐
+* PG사 API 특성에 따라 중복 취소 자체가 에러 없이 성공하는 경우도 있어 감지가 어려움
 
-프로덕션에서 이 버그가 발생했다면, 결제는 1번 취소됐는데 환불이 2번 지급되는 **금전적 손실**로 이어진다. PG사 API 특성에 따라 중복 취소 자체가 에러 없이 성공하는 경우도 있어 감지가 어렵다.
+### 솔루션: 조회-변경을 단일 락 범위로 통합
 
-### 해결 방법
+* 상태 확인과 변경을 별도의 연산으로 수행하면 두 연산 사이에 다른 스레드가 개입할 수 있음
+* 조회 시점에 비관적 락으로 결제 행을 잠가 상태 확인과 변경이 하나의 락 범위 안에서 이루어지도록 함
 
-`findByPaymentKeyWithLock()` — 조회 시점에 비관적 락으로 결제 행을 잠금.
-상태 확인과 변경이 하나의 락 범위 안에서 이루어진다.
+### 기능 구현
+
+**1. 비관적 락 조회 메서드 추가**
 
 ```java
 @Lock(LockModeType.PESSIMISTIC_WRITE)
 Optional<Payment> findByPaymentKeyWithLock(String paymentKey);
 ```
 
-- `loadAndValidateForCancel()`: `readOnly=true` → `@Transactional` + locked query로 변경
+**2. 취소 검증 메서드 트랜잭션 변경**
+
+`loadAndValidateForCancel()`을 `readOnly=true`에서 `@Transactional` + locked query로 변경하여 조회와 검증이 동일 트랜잭션 내에서 이루어지게 한다.
 
 ### Trade-off
 
@@ -192,16 +204,17 @@ Optional<Payment> findByPaymentKeyWithLock(String paymentKey);
 
 ### 결과
 
-- 취소 요청이 동시에 들어와도 먼저 락을 획득한 스레드만 PG사 API를 호출
-- 이후 스레드는 DB에서 이미 `CANCELLED` 상태를 읽어 즉시 반환 — 환불 이중 지급 차단
+* 취소 요청이 동시에 들어와도 먼저 락을 획득한 스레드만 PG사 API를 호출
+* 이후 스레드는 DB에서 이미 `CANCELLED` 상태를 읽어 즉시 반환 — 환불 이중 지급 차단
 
 ---
 
 ## 3. Redis Rate Limit 원자성 결함
 
-### 문제 인식
+### 배경 및 문제정의
 
-로그인 실패 횟수 제한을 Redis의 `RAtomicLong`으로 구현했으나 두 연산이 비원자적으로 실행됐다.
+* **상황:** 로그인 실패 횟수 제한을 Redis `RAtomicLong`으로 구현
+* **문제:** INCR + EXPIRE 두 연산이 비원자적으로 실행되어, 두 연산 사이에 크래시 발생 시 TTL 없는 키가 Redis에 남음
 
 ```java
 // 기존 코드
@@ -211,15 +224,17 @@ if (count == 1) {
 }
 ```
 
-두 연산 사이에 애플리케이션이 크래시(OOM, 강제 종료)되면 연산 1만 실행된다.
-TTL 없는 키가 Redis에 남아 **해당 계정이 영구 잠금** 상태가 된다.
-사용자 지원팀이 직접 Redis에서 키를 삭제하거나 Redis를 재시작하기 전까지 로그인 불가 상태가 지속된다.
+* 앱 크래시(OOM, 강제 종료) 시 연산 1만 실행되어 **해당 계정이 영구 잠금** 상태가 됨 — 사용자 지원팀이 직접 Redis 키를 삭제하기 전까지 로그인 불가
+* 멀티 인스턴스 환경에서 두 인스턴스가 거의 동시에 `incrementAndGet()`을 호출하면 둘 다 `count=1`로 읽어 TTL을 누락할 수도 있음
 
-멀티 인스턴스 환경에서는 두 인스턴스가 거의 동시에 `incrementAndGet()`을 호출하면 둘 다 `count=1`로 읽어 TTL을 누락할 수도 있다.
+### 솔루션: Lua 스크립트로 원자화
 
-### 해결 방법
+* Redis는 단일 스레드로 Lua 스크립트를 실행하므로 두 명령 사이에 다른 명령이 끼어들 수 없음
+* INCR + EXPIRE를 단일 Lua 스크립트로 합쳐 원자성을 보장
 
-INCR + EXPIRE를 **Lua 스크립트로 원자화**하여 단일 연산으로 처리한다.
+### 기능 구현
+
+**1. INCR + EXPIRE Lua 스크립트 작성**
 
 ```lua
 local count = redis.call('INCR', KEYS[1])
@@ -229,25 +244,23 @@ end
 return count
 ```
 
-Redis는 단일 스레드로 Lua 스크립트를 실행하므로 두 명령 사이에 다른 명령이 끼어들 수 없다.
-
 ### Trade-off
 
-Lua 스크립트 실행 중에는 Redis가 다른 명령을 처리하지 않는다. 다만 이 스크립트는 2개 명령으로 구성되어 실행 시간이 수 μs에 불과해 실질적 영향은 없다. Redis Cluster 환경에서는 `KEYS[1]`이 단일 슬롯에 속해야 하는 제약이 있다.
+Lua 스크립트 실행 중에는 Redis가 다른 명령을 처리하지 않는다. 이 스크립트는 2개 명령으로 구성되어 실행 시간이 수 μs에 불과해 실질적 영향은 없다. Redis Cluster 환경에서는 `KEYS[1]`이 단일 슬롯에 속해야 하는 제약이 있다.
 
 ### 결과
 
-- 앱 크래시 시에도 TTL이 보장되어 영구 잠금 버그 제거
-- 멀티 인스턴스 환경에서도 INCR과 EXPIRE가 항상 함께 실행
+* 앱 크래시 시에도 TTL이 보장되어 영구 잠금 버그 제거
+* 멀티 인스턴스 환경에서도 INCR과 EXPIRE가 항상 함께 실행
 
 ---
 
 ## 4. 결제 트랜잭션 정합성
 
-### 문제 인식
+### 배경 및 문제정의
 
-결제 확정 후에는 배송 생성, 포인트 적립 같은 부수 효과가 연쇄 실행된다.
-초기 구조는 이 모든 로직이 하나의 트랜잭션 안에 묶여 있었다.
+* **상황:** 결제 확정 후 배송 생성, 포인트 적립 같은 부수 효과가 연쇄 실행되는 구조
+* **문제:** 모든 로직이 단일 트랜잭션에 묶여 있어, 부수 효과 실패가 결제 자체를 롤백시킴
 
 ```java
 // 기존 구조 (문제)
@@ -262,118 +275,114 @@ public void applyConfirmResult(Payment payment) {
 }
 ```
 
-`createForOrder()`가 예외를 던지면 Spring이 공유 트랜잭션을 **rollback-only**로 표시한다.
-catch로 잡아도 이미 늦었다. 바깥 트랜잭션이 commit을 시도하는 순간 `UnexpectedRollbackException`이 터진다.
+* `createForOrder()`가 예외를 던지면 Spring이 공유 트랜잭션을 **rollback-only**로 표시함 — catch로 잡아도 이미 늦어 바깥 트랜잭션 commit 시 `UnexpectedRollbackException` 발생
+* **Toss는 결제 완료(돈 빠져나감)인데 DB는 `payment.status = PENDING` 유지** — 사용자가 재시도해도 idempotency key로 차단 → 결제 유실 상태 지속
 
-이 버그가 프로덕션에서 발생했다면:
+### 솔루션: 부수 효과를 독립 트랜잭션으로 분리
 
-- **Toss Payments**: 결제 완료 처리됨 (돈 빠져나감)
-- **DB**: `payment.status = PENDING` 유지 (rollback됨)
-- 사용자가 재시도해도 idempotency key로 차단 → **결제 유실, 지불 후 주문 미처리 상태 지속**
+* 결제 확정과 배송·포인트 생성은 비즈니스적으로 독립적인 작업임
+* 부수 효과는 `REQUIRES_NEW`로 별도 트랜잭션에서 처리하여 실패해도 결제 확정에 영향을 주지 않게 함
 
-### 해결 방법
+| 메서드 | 전파 레벨 | 이유 |
+|--------|-----------|------|
+| `ShipmentService.createForOrder()` | `REQUIRES_NEW` | 결제 트랜잭션과 독립 커밋·롤백 |
+| `PointService.earn()` | `REQUIRES_NEW` | 동일 |
+| `PointService.use()` / `refundByOrder()` | `REQUIRED` | 주문·취소와 원자성 보장 필요 |
+
+### 기능 구현
+
+**1. 부수 효과 REQUIRES_NEW 적용**
 
 ```java
-// 변경 후: 부수 효과를 독립 트랜잭션으로 분리
 @Transactional(propagation = Propagation.REQUIRES_NEW)
 public void createForOrder(Long orderId) {
     // 결제 트랜잭션과 별개로 커밋/롤백 — 실패해도 결제 확정에 영향 없음
 }
 ```
 
-- `PointService.use()` / `refundByOrder()`는 주문과 원자성이 필요하므로 `REQUIRED` 유지
+**2. 불일치 감지 및 보상 처리**
+
+Dead Letter 알람(`outbox.dead_letters`)으로 실패 건을 감지하여 다음 두 가지 방식으로 보상한다.
+
+* 운영 툴에서 `POST /api/admin/orders/{orderId}/retry-side-effects` 수동 재시도
+* 매 시간 `payment.status = CONFIRMED AND shipment IS NULL` 조건으로 누락 건 자동 감지 후 재처리
 
 ### Trade-off
 
-`REQUIRES_NEW`는 부모 트랜잭션과 별개로 새 DB 커넥션을 획득하므로 커넥션 풀 사용량이 증가한다. 또한 배송·포인트 실패 시 결제만 성공하는 불일치 상태가 발생하므로, 이를 감지하고 보상 처리하는 운영 프로세스가 별도로 필요하다.
-
-보상 처리 흐름은 다음 두 가지를 고려할 수 있다:
-
-- **수동 재시도 API**: 운영 툴에서 `POST /api/admin/orders/{orderId}/retry-side-effects` 호출 → 배송·포인트를 개별 재시도
-- **미처리 건 배치 스캔**: 매 시간 `payment.status = CONFIRMED AND shipment IS NULL` 조건으로 누락 건 자동 감지 후 재처리
+`REQUIRES_NEW`는 새 DB 커넥션을 획득하므로 커넥션 풀 사용량이 증가한다. 배송·포인트 실패 시 결제만 성공하는 불일치 상태가 발생하므로 운영 보상 처리 프로세스가 필요하다.
 
 ### 결과
 
-- 배송 생성이 실패해도 결제 확정 커밋은 보장됨
-- Dead Letter 알람(`outbox.dead_letters`) → 운영 툴 재시도 또는 배치 자동 보상으로 불일치 해소
-- 사용자 관점에서 "돈은 나갔는데 주문이 없다"는 상황 차단
+* 배송 생성이 실패해도 결제 확정 커밋은 보장됨
+* Dead Letter 알람 → 운영 툴 재시도 또는 배치 자동 보상으로 불일치 해소
+* 사용자 관점에서 "돈은 나갔는데 주문이 없다"는 상황 차단
 
 ---
 
 ## 5. 결제 멱등성
 
-### 문제 인식
+### 배경 및 문제정의
 
-네트워크 타임아웃이나 클라이언트 재시도로 동일한 결제 확정 요청이 두 번 도달하면:
-- 동일 `orderId`로 두 번의 결제가 생성될 수 있었다.
-- Toss Payments에도 중복 API 호출이 발생해 이중 청구 위험이 있었다.
+* **상황:** 네트워크 타임아웃이나 클라이언트 재시도로 동일한 결제 확정 요청이 두 번 도달할 수 있음 ("3초 응답 없음 → 자동 재시도" 설정 하나로 운영 환경에서 실제로 발생)
+* **문제:** 동일 `orderId`로 두 번의 결제가 생성되고 Toss Payments에 중복 API 호출 → 이중 청구 위험
 
-서버 응답이 반환되기 전에 클라이언트가 타임아웃으로 재시도하는 상황은 운영 환경에서 빈번하게 발생한다. "3초 응답 없음 → 자동 재시도" 설정 하나로 이 문제가 실제로 터진다.
+단일 방어선만으로는 부족하다.
 
-단일 방어선만으로는 부족하다:
-- Redis만 있으면: Redis 장애 시 완전 무방비
-- DB UNIQUE만 있으면: 두 요청이 동시에 도달해 트랜잭션이 커밋 전이면 두 번 모두 PG사 API를 호출하게 됨
+* Redis만 있으면: Redis 장애 시 완전 무방비
+* DB UNIQUE만 있으면: 두 요청이 동시에 도달해 트랜잭션 커밋 전이면 두 번 모두 PG사 API를 호출하게 됨
 
-### 해결 방법
+### 솔루션: 3중 독립 방어
 
-3중 방어를 적용해 각 레이어가 독립적으로 기능하도록 한다.
+* 각 레이어가 서로 다른 장애 시나리오를 담당하여 단일 장애 지점 없이 방어
 
 ```
 1. Redis SETNX (PaymentIdempotencyManager)
-   — 동일 orderId 최초 요청만 통과, 이미 처리 중이면 즉시 차단
-   — 빠른 선제 차단, DB 부하 없음
+   — 동일 orderId 최초 요청만 통과, 빠른 선제 차단, DB 부하 없음
 
 2. Toss Payments Idempotency-Key 헤더
    — PG사 레벨에서 중복 API 호출 차단
-   — 서버 내부 처리 결과와 관계없이 이중 청구 자체를 PG사가 막음
 
 3. payments.order_id UNIQUE 제약 (V8 migration)
    — DB 레벨 최후 방어선
-   — Redis 장애, 코드 버그, 예상치 못한 경로 모두 차단
 ```
 
-**레이어 간 장애 상호작용:**
+| 장애 상황 | 동작 |
+|-----------|------|
+| Redis 장애 | SETNX 우회 → Toss Idempotency-Key로 이중 청구 차단 → DB UNIQUE로 중복 INSERT 차단 |
+| DB 부하·느린 응답 | Redis SETNX가 첫 요청만 통과 → PG사 API 호출 1회로 제한 |
 
-```
-[Redis 장애 시]
-  SETNX 실패 → 두 요청 모두 진행
-  → PG사 Idempotency-Key 헤더로 이중 청구 차단 (PG사 레벨)
-  → DB INSERT 시 order_id UNIQUE 제약으로 두 번째 INSERT 실패 (DB 레벨)
+### 기능 구현
 
-[DB 부하 / 느린 응답 시]
-  Redis SETNX가 첫 요청만 통과 → PG사 API 호출 1회로 제한
-  → DB 응답 지연과 무관하게 이중 호출 자체를 선제 차단 (Redis 레벨)
-```
+**1. Redis SETNX — 선제 차단**
+
+`PaymentIdempotencyManager`: `orderId`를 키로 SETNX, TTL은 결제 처리 예상 시간보다 충분히 길게 설정.
+
+**2. Toss Payments Idempotency-Key 헤더**
+
+`TossPaymentsClient` 요청 헤더에 `Idempotency-Key` 추가하여 PG사가 자체적으로 중복 요청을 차단하게 함.
+
+**3. DB UNIQUE 제약 — 최후 방어선**
+
+`V8 migration`: `payments.order_id UNIQUE` 제약 추가. Redis 장애·코드 버그·예상치 못한 경로 모두 차단.
 
 ### Trade-off
 
-3중 방어는 구현·운영 복잡도를 높인다. 특히 Redis SETNX의 TTL 설계에 주의가 필요하다 — TTL이 결제 처리 시간보다 짧으면 키가 만료된 사이에 재시도 요청이 통과될 수 있다.
-
-**Redis SPOF 문제**: 현재 구성은 ElastiCache 단일 인스턴스이므로 Redis 자체가 단일 장애 지점(SPOF)이다. Redis가 죽으면 SETNX 레이어가 통째로 무력화되어 모든 중복 요청이 DB까지 도달한다. 피크 TPS 1,000 환경에서 이 상황이 발생하면 `payments` 테이블에 중복 INSERT 시도가 집중되어 RDS 부하가 급증할 수 있다.
-
-대응 전략으로 고려할 수 있는 옵션:
-
-| 전략 | 내용 | 비고 |
-|------|------|------|
-| ElastiCache Multi-AZ | 스탠바이 노드 + 자동 failover | Redis SPOF 제거, 비용 증가 |
-| Circuit Breaker (Resilience4j) | Redis 연결 실패율 임계치 초과 시 SETNX 건너뜀 → DB UNIQUE에만 의존하는 Degraded Mode로 전환 | 장애 전파 차단, 이미 프로젝트에 Resilience4j 적용됨 |
-| ALB 요청 제한 | Redis 장애와 무관하게 ALB 수준에서 초당 요청 수 cap | 근본 해결은 아님 |
-
-현재 구현은 Circuit Breaker 없이 3중 방어 레이어 설계에 의존하며, 운영 환경이라면 **ElastiCache Multi-AZ 또는 Circuit Breaker** 도입이 권장된다.
+3중 방어는 구현·운영 복잡도를 높인다. Redis SETNX의 TTL이 결제 처리 시간보다 짧으면 키 만료 사이에 재시도 요청이 통과될 수 있다. Redis SPOF 문제는 ElastiCache Multi-AZ 또는 Resilience4j Circuit Breaker(이미 프로젝트에 적용됨)로 완화 가능하다.
 
 ### 결과
 
-- 네트워크 재시도로 인한 이중 결제 차단
-- Redis 장애·코드 결함·PG사 오동작 각각의 시나리오에서 독립적으로 방어
-- Redis SPOF 리스크는 인지하고 있으며 Multi-AZ 또는 Circuit Breaker로 완화 가능
+* 네트워크 재시도로 인한 이중 결제 차단
+* Redis 장애·코드 결함·PG사 오동작 각각의 시나리오에서 독립적으로 방어
+* Redis SPOF 리스크는 인지하고 있으며 Multi-AZ 또는 Circuit Breaker로 완화 가능
 
 ---
 
 ## 6. 이벤트 유실 — Transactional Outbox
 
-### 문제 인식
+### 배경 및 문제정의
 
-`ApplicationEventPublisher`로 도메인 이벤트를 발행하는 구조의 치명적 약점이 있다.
+* **상황:** `ApplicationEventPublisher`로 도메인 이벤트를 발행하는 구조 사용 중
+* **문제:** 커밋 직후, 이벤트 발행 직전 JVM 크래시 발생 시 이벤트가 영구 유실됨
 
 ```
 1. 주문 생성 트랜잭션 커밋
@@ -382,24 +391,16 @@ public void createForOrder(Long orderId) {
 3. 이메일 발송 / 재고 알림
 ```
 
-커밋 이후 이벤트 발행 전에 크래시가 발생하면 이벤트는 흔적 없이 사라진다.
-`@TransactionalEventListener(AFTER_COMMIT)`을 사용해도 동일하다. AFTER_COMMIT 단계에서 실패한 이벤트는 재시도나 보상 트랜잭션이 불가능하다.
+* `@TransactionalEventListener(AFTER_COMMIT)` 사용 시도 동일 — AFTER_COMMIT 단계에서 실패한 이벤트는 재시도나 보상 트랜잭션이 불가능함
 
-### 해결 방법
+### 솔루션: Transactional Outbox 패턴
 
-**Transactional Outbox 패턴** 적용. 비즈니스 로직과 이벤트 저장을 **동일 트랜잭션**으로 묶는다.
+* 이벤트 발행과 비즈니스 로직을 **동일 트랜잭션으로 묶어** 커밋되면 반드시 저장되도록 보장
+* 별도 스케줄러가 저장된 이벤트를 폴링하여 발행 — JVM 재기동 시 PENDING 이벤트 자동 재처리
 
-```
-[주문 생성 트랜잭션]
-  OrderService.create()
-  OutboxEventStore.save(OrderCreatedEvent)  ← 같은 트랜잭션, 커밋되면 반드시 저장됨
+### 기능 구현
 
-[OutboxEventRelayScheduler — 5초 폴링]
-  PENDING 이벤트 조회 → 발행 → PROCESSED 표시
-
-[OutboxEventPurgeScheduler — 매일 새벽 3시]
-  7일 이상 처리 완료 이벤트 정리
-```
+**1. 비즈니스 트랜잭션과 이벤트 저장 원자화**
 
 ```java
 @Transactional(propagation = Propagation.MANDATORY)
@@ -409,80 +410,37 @@ public void save(DomainEvent event) {
 }
 ```
 
-Prometheus 게이지 `outbox.dead_letters`로 재시도 한계를 넘긴 이벤트 수를 실시간 모니터링.
+**2. OutboxEventRelayScheduler — 5초 폴링**
+
+PENDING 이벤트 조회 → 발행 → PROCESSED 표시. JVM 재기동 시 미처리 이벤트 자동 재처리.
+
+**3. OutboxEventPurgeScheduler + 모니터링**
+
+매일 새벽 3시 7일 이상 처리 완료 이벤트 정리. Prometheus 게이지 `outbox.dead_letters`로 재시도 한계 초과 이벤트 실시간 모니터링.
 
 ### Trade-off
 
-폴링 방식은 이벤트 처리에 최대 5초의 지연을 허용한다. 실시간성보다 발행 보장을 택한 트레이드오프로, 이메일·알림처럼 수 초 지연이 허용되는 용도에 적합하다. 재고 부족 즉시 경보처럼 실시간성이 중요한 경우라면 Kafka 등 메시지 브로커 도입이 더 적합하다.
+폴링 방식은 이벤트 처리에 최대 5초의 지연을 허용한다. 이메일·알림처럼 수 초 지연이 허용되는 용도에 적합하다. 재고 부족 즉시 경보처럼 실시간성이 중요한 경우라면 Kafka 등 메시지 브로커 도입이 더 적합하다.
 
 ### 결과
 
-- DB에 저장된 이벤트는 반드시 발행됨 (JVM 크래시 후 재기동 시 PENDING 이벤트 자동 재처리)
-- Dead letter 알람으로 처리 실패 이벤트 즉시 감지 가능
+* DB에 저장된 이벤트는 반드시 발행됨 (JVM 크래시 후 재기동 시 PENDING 이벤트 자동 재처리)
+* Dead letter 알람으로 처리 실패 이벤트 즉시 감지 가능
 
 ---
 
 ## 7. N+1 쿼리 및 배치 처리 최적화
 
-### 문제 인식
+### 배경 및 문제정의
 
-여러 곳에서 N+1 패턴이 발생하고 있었다.
+* **`getMyCoupons()` — 2중 N+1:** 쿠폰 50개 보유 시 쿼리 101번 발생 (user_coupons SELECT 1 + coupons SELECT N + coupon_usages COUNT N)
+* **`InventorySnapshotScheduler` — 개별 save():** 재고 1,000건 기준 INSERT 1,000번 실행 → DB connection 장시간 점유, 슬로우 쿼리 알람 발생 가능
+* **`ReviewRepository` — 분리 집계:** 상품별 avgRating + reviewCount를 각각 조회 → 상품 20개 기준 쿼리 40번
+* **`@ManyToOne` 전반 — 배치 미적용:** `OrderItem → Product`, `CartItem → Product` 등 개별 접근 시 SELECT 1건씩 추가. 기본 설정에서는 배치 없이 1건씩만 로딩
+* **`InventoryRepository` — product fetch join 누락:** `findByProductId()`, `findAllByProductIdIn()`이 `@EntityGraph` 없이 Lazy 로딩 → 상품 목록 20건 조회 시 product SELECT 20번 추가 발생
+* **`InventorySnapshotScheduler` — 단일 트랜잭션 전체 로드:** `findAll()`로 재고 10,000건을 한 번에 힙에 적재 → GC 압박 + 트랜잭션 유지 중 `inventory` 테이블 shared lock 장시간 점유
 
-**`getMyCoupons()` — 2중 N+1**
-
-```
-SELECT * FROM user_coupons WHERE user_id = ?                             → 1번
-SELECT * FROM coupons WHERE id = ?                                       → N번 (Lazy)
-SELECT COUNT(*) FROM coupon_usages WHERE coupon_id = ? AND user_id = ?  → N번
-합계: 2N + 1번  →  쿠폰 50개 보유 시 쿼리 101번 발생
-```
-
-**`InventorySnapshotScheduler`**
-
-```java
-// 기존: 재고 1000건이면 1000번 INSERT
-inventories.forEach(inv -> snapshotRepository.save(new DailyInventorySnapshot(...)));
-```
-
-자정 스케줄러 실행 시 DB connection을 길게 점유하고 슬로우 쿼리 알람 발생 가능.
-
-**`ReviewRepository`**
-
-```java
-// 기존: 상품별 2번의 별도 집계 쿼리 → 상품 20개 기준 40번
-double avgRating   = reviewRepository.avgRatingByProductId(productId);
-long   reviewCount = reviewRepository.countByProductId(productId);
-
-// 변경 후: 단일 JPQL로 통합
-@Query("SELECT AVG(r.rating), COUNT(r) FROM Review r WHERE r.productId = :id")
-ReviewStats findReviewStatsByProductId(Long id);
-```
-
-**`@ManyToOne` Lazy Loading 전반**
-
-`OrderItem → Product`, `CartItem → Product` 등 연관 엔티티를 개별 접근할 때마다 SELECT 1건씩 추가.
-기본 설정에서는 배치 없이 1건씩만 로딩.
-
-**`InventoryRepository` — product fetch join 누락 (N+1)**
-
-`findByProductId()`, `findAllByProductIdIn()`이 `@EntityGraph` 없이 `Inventory`를 Lazy 로딩한다.
-`ProductService.enrichPage()`가 페이지 20건을 처리하며 각 `inventory.product`에 접근하면 product SELECT가 20번 추가 발생한다.
-
-```
-상품 목록 20건 조회 시:
-  SELECT * FROM inventory WHERE product_id = ?   →  20번 (N+1)
-  (Inventory 20개 × product Lazy 로딩)
-```
-
-**`InventorySnapshotScheduler` — 단일 트랜잭션 전체 로드**
-
-자정 스케줄러가 `inventoryRepository.findAll()`로 전체 재고를 한 번에 메모리에 올린다.
-재고 10,000건 기준:
-- JVM 힙에 수백 MB 객체 적재 → GC 압박
-- `findAll()` 부터 `saveAll()` 완료까지 트랜잭션이 유지되어 `inventory` 테이블 shared lock이 장시간 점유됨
-- 단일 커밋 실패 시 전체 스냅샷이 롤백되어 재시도 비용이 크다
-
-### 해결 방법
+### 솔루션
 
 | 위치 | 변경 전 | 변경 후 |
 |------|---------|---------|
@@ -492,19 +450,40 @@ ReviewStats findReviewStatsByProductId(Long id);
 | `ReviewRepository` | 집계 쿼리 2번 | avgRating + reviewCount 통합 단일 JPQL |
 | 전체 `@ManyToOne` | 1건씩 Lazy | `hibernate.default_batch_fetch_size=50` |
 | `inventory_transactions` | `inventory_id` 단일 인덱스 | `(inventory_id, created_at)` 복합 인덱스 |
-| `InventoryRepository` | `product` Lazy 로딩 (N+1) | `@EntityGraph({"product"})` — `findByProductId`, `findAllByProductIdIn` |
-| `InventorySnapshotScheduler` | `findAll()` 단일 트랜잭션 전체 로드 | `findAll(PageRequest.of(page, 1000))` 페이지 루프 + `InventorySnapshotProcessor`(@Component 분리)로 배치마다 독립 트랜잭션 커밋 |
+| `InventoryRepository` | product Lazy 로딩 (N+1) | `@EntityGraph({"product"})` — `findByProductId`, `findAllByProductIdIn` |
+| `InventorySnapshotScheduler` | `findAll()` 단일 트랜잭션 전체 로드 | `findAll(PageRequest.of(page, 1000))` 페이지 루프 + 배치마다 독립 트랜잭션 커밋 |
 
-> **주의**: `@BatchSize`는 `@OneToMany`/`@ManyToMany` 컬렉션에만 적용 가능.
-> `@ManyToOne`에 붙이면 `AnnotationException` 발생 → `default_batch_fetch_size` 사용.
+### 기능 구현
+
+**1. @EntityGraph + IN 절 배치로 getMyCoupons() 최적화**
+
+```java
+@EntityGraph(attributePaths = {"coupon"})
+List<UserCoupon> findByUserId(Long userId);
+```
+
+`CouponUsageRepository.countByCouponIdsAndUserId()`: 쿠폰 ID 목록을 IN 절로 한 번에 집계.
+
+**2. default_batch_fetch_size 전역 적용**
+
+```properties
+# application.properties
+spring.jpa.properties.hibernate.default_batch_fetch_size=50
+```
+
+> **주의**: `@BatchSize`는 `@OneToMany`/`@ManyToMany` 컬렉션에만 적용 가능. `@ManyToOne`에 붙이면 `AnnotationException` 발생 → `default_batch_fetch_size` 사용.
+
+**3. InventorySnapshotScheduler 페이지 단위 처리**
+
+`InventorySnapshotProcessor(@Component)`를 별도 빈으로 분리하여 Spring AOP 프록시를 통해 배치마다 독립 `@Transactional` 커밋.
+
+> **이유**: 동일 클래스 내 self-call은 프록시를 거치지 않아 `@Transactional`이 적용되지 않으므로 외부 빈으로 분리해 호출해야 한다.
+
+페이지 단위 처리는 부분 실패 시 롤백 범위를 1페이지(1,000건)로 제한하는 장점도 있다. 첫 페이지 조회 후 다른 인스턴스가 동일 날짜 스냅샷을 삽입하는 레이스 컨디션은 `DataIntegrityViolationException` catch로 방어하며 해당 배치를 스킵한다.
 
 ### Trade-off
 
-`default_batch_fetch_size`는 전역 설정이므로 배치 로딩이 불필요한 단건 조회에도 적용되어 미세한 메모리 오버헤드가 발생한다. `@EntityGraph` fetch join은 페이징(`Pageable`)과 함께 사용 시 `HibernateJpaDialect` 경고가 발생하므로, 컬렉션이 아닌 단일 연관 엔티티(`@ManyToOne`)에만 적용했다.
-
-`InventorySnapshotProcessor`를 별도 `@Component`로 분리한 이유: Spring AOP는 프록시 기반으로 동작하므로 동일 클래스 내 self-call은 프록시를 거치지 않아 `@Transactional`이 적용되지 않는다. 스케줄러 내부에 `@Transactional processBatch()` 메서드를 두어도 배치마다 독립 커밋이 되지 않기 때문에 외부 빈으로 분리해 호출해야 한다. 클래스가 하나 늘어나지만 `@Transactional` 전파 범위를 명시적으로 제어하기 위한 불가피한 설계다.
-
-페이지 단위 처리는 `findAll()` 한 번으로 전체를 보는 것보다 부분 실패 시 롤백 범위가 1페이지(1,000건)로 제한되는 장점도 있다. 단, 첫 페이지 조회 후 다른 인스턴스가 동일 날짜 스냅샷을 삽입하는 레이스 컨디션은 `DataIntegrityViolationException` catch로 방어하며 해당 배치를 스킵한다.
+`default_batch_fetch_size`는 전역 설정으로 배치 로딩이 불필요한 단건 조회에도 적용되어 미세한 메모리 오버헤드가 있다. `@EntityGraph` fetch join은 컬렉션이 아닌 단일 `@ManyToOne`에만 적용했다 (페이징과 컬렉션 fetch join 조합 시 `HibernateJpaDialect` 경고 발생).
 
 ### 결과
 
@@ -521,46 +500,33 @@ ReviewStats findReviewStatsByProductId(Long id);
 
 ## 8. 보안 취약점
 
-### 문제 인식
+### 배경 및 문제정의
 
-**IDOR (Insecure Direct Object Reference)**
+* **IDOR (Insecure Direct Object Reference):** `orderId=999`가 사용자 B의 주문이어도 소유권 검증 없이 취소 가능. 배송 조회, 결제 조회에서도 동일한 문제
+* **가격 조작:** 클라이언트가 `unitPrice`를 1원으로 보내면 그대로 주문 생성 — 정가 100,000원짜리 상품을 1원에 구매 가능
+* **JWT userId DB round-trip:** 모든 인증 요청마다 `username → userId` 변환을 위해 DB SELECT 발생 — 초당 1,000 req 기준 인증 처리만으로 `users` 테이블 초당 1,000번 조회 (req:select = 1:1)
+* **TossPayments Webhook 위조:** 서명 검증 없이 수신 — 외부 공격자가 임의 결제 완료 이벤트를 위조해 보낼 수 있음
 
-```http
-DELETE /api/orders/999/cancel
-Authorization: Bearer <사용자 A의 토큰>
-```
+### 솔루션
 
-`orderId=999`가 사용자 B의 주문이어도 취소가 가능했다.
-서비스 레이어에서 소유권 검증 없이 `orderId`만으로 처리했기 때문이다.
-배송 조회, 결제 조회에서도 동일한 문제가 있었다.
-
-**가격 조작**
-
-```json
-POST /api/orders
-{ "items": [{"productId": 1, "quantity": 1, "unitPrice": 1}] }
-```
-
-`unitPrice`를 클라이언트가 1원으로 보내면 그대로 주문이 생성됐다.
-DB의 실제 가격을 검증하지 않았기 때문이다. 정가 100,000원짜리 상품을 1원에 구매할 수 있는 상태였다.
-
-**JWT userId DB round-trip**
-
-모든 인증 요청마다 `username → userId` 변환을 위해 DB SELECT가 1회씩 발생했다.
-초당 1,000 req 기준, 비즈니스 로직과 무관한 인증 처리만으로 초당 1,000번의 `users` 테이블 조회가 발생한다 (req:select = 1:1).
-
-**TossPayments Webhook 위조**
-
-Webhook 수신 시 서명 검증이 없어 외부 공격자가 임의 결제 완료 이벤트를 위조해 보낼 수 있었다.
-
-### 해결 방법
-
-| 취약점 | 해결 |
-|--------|------|
-| IDOR | `validateOwnership()` 소유권 검증 4개 엔드포인트 추가 |
-| 가격 조작 | `OrderService.create()`에서 DB canonical price 강제 적용, 클라이언트 `unitPrice` 무시 |
-| JWT round-trip | JWT 생성 시 `userId` 클레임 포함, SecurityContext에서 바로 추출 (DB fallback 유지) |
+| 취약점 | 해결 전략 |
+|--------|-----------|
+| IDOR | 서비스 레이어에서 소유권 검증 — 인증된 userId와 리소스 소유자 일치 여부 확인 |
+| 가격 조작 | 클라이언트 `unitPrice` 무시, 주문 생성 시 DB에서 canonical price 강제 적용 |
+| JWT round-trip | JWT 생성 시 `userId` 클레임 포함 — SecurityContext에서 직접 추출 (DB fallback 유지) |
 | Webhook 위조 | HMAC-SHA256 서명 검증 추가 |
+
+### 기능 구현
+
+**1. IDOR 소유권 검증**
+
+`validateOwnership()` 소유권 검증을 4개 엔드포인트(주문 취소, 배송 조회, 결제 prepare, 결제 조회)에 추가.
+
+**2. 주문 생성 시 DB canonical price 강제 적용**
+
+`OrderService.create()`에서 클라이언트 전달 `unitPrice`를 무시하고 `productRepository`에서 조회한 실제 가격을 강제 적용.
+
+**3. JWT userId 클레임으로 DB round-trip 제거**
 
 ```java
 // JwtAuthenticationFilter: userId를 details에 저장
@@ -574,45 +540,50 @@ if (details instanceof Long id) return id;  // DB 조회 불필요
 return userRepository.findByUsername(username).getId();  // fallback
 ```
 
+**4. Toss Webhook HMAC-SHA256 서명 검증**
+
+`TossWebhookVerifier`: 요청 헤더의 서명 값과 HMAC-SHA256으로 직접 계산한 값을 비교.
+
 ### Trade-off
 
-JWT에 `userId`를 포함하면 토큰 크기가 소폭 증가한다. 또한 `userId`는 변경되지 않는 값이지만, 기존 발급 토큰이 만료되기 전까지 새 클레임이 반영되지 않으므로 DB fallback 경로를 유지했다. 이 fallback은 JWT 파싱 실패나 레거시 토큰 호환을 위한 안전망이기도 하다.
+JWT에 `userId`를 포함하면 토큰 크기가 소폭 증가한다. `userId`는 변경되지 않는 값이지만 기존 발급 토큰 만료 전까지 새 클레임이 반영되지 않으므로 DB fallback 경로를 유지했다.
 
 ### 결과
 
-- 가격 조작: 클라이언트가 어떤 값을 보내도 DB 가격이 강제 적용됨
-- JWT round-trip: 초당 1,000 req 기준 인증 단계 `users` SELECT 1,000회 → 0회 (req:select = 1:1 → 1:0)
-- IDOR: 타인 주문·결제·배송 접근 차단
+* 가격 조작: 클라이언트가 어떤 값을 보내도 DB 가격이 강제 적용됨
+* JWT round-trip: 초당 1,000 req 기준 `users` SELECT 1,000회 → 0회 (req:select = 1:1 → 1:0)
+* IDOR: 타인 주문·결제·배송 접근 차단
 
 ---
 
 ## 9. CategoryService Redis 캐시
 
-### 문제 인식
+### 배경 및 문제정의
 
-`CategoryService.getList()`와 `getTree()`는 호출할 때마다 `categoryRepository.findAll()`을 실행하고, `getTree()`는 추가로 전체 카테고리를 순회해 부모-자식 트리를 in-memory에서 조립한다.
-
-카테고리는 관리자가 생성·수정·삭제할 때만 변경되는 **거의 정적인 데이터**다. 그런데 상품 목록 API(`GET /api/products`)는 카테고리 정보를 참조하기 위해 매 요청마다 이 메서드를 호출한다.
+* **상황:** `CategoryService.getList()` / `getTree()`는 호출마다 `categoryRepository.findAll()`을 실행하고, `getTree()`는 추가로 전체 카테고리를 순회해 부모-자식 트리를 in-memory에서 조립
+* **문제:** 카테고리는 관리자가 생성·수정·삭제할 때만 변경되는 **거의 정적인 데이터**인데 상품 목록 API가 매 요청마다 이를 호출
 
 ```
 피크 TPS 1,000 기준:
   상품 목록 API 1,000회/s
   → CategoryService.getList() 1,000회/s
-  → SELECT * FROM categories 1,000회/s  (비즈니스 로직 없이 인증 오버헤드와 동급)
+  → SELECT * FROM categories 1,000회/s
 ```
 
-`getTree()`는 조립 과정에서 카테고리 수에 비례하는 O(n) 연산이 매 호출마다 반복된다. 카테고리가 수백 개 규모로 증가하면 CPU 부하로 이어진다.
+* `getTree()`는 카테고리 수에 비례하는 O(n) 연산이 매 호출마다 반복되어 카테고리 규모가 늘어날수록 CPU 부하가 증가
 
-### 해결 방법
+### 솔루션: @Cacheable 적용 + Redis 직렬화 호환성 확보
 
-`getList()`, `getTree()`에 `@Cacheable`, 모든 write 메서드에 `@CacheEvict(allEntries = true)` 적용.
+* 거의 변하지 않는 카테고리 데이터를 Redis에 캐싱하여 불필요한 DB 조회와 in-memory 조립 연산을 제거
+* write 메서드에 `@CacheEvict` 적용으로 캐시 무효화 보장
+
+### 기능 구현
+
+**1. @Cacheable / @CacheEvict 적용 + TTL 설정**
 
 ```java
 @Cacheable(cacheNames = "categories", key = "'list'")
 public List<CategoryResponse> getList() { ... }
-
-@Cacheable(cacheNames = "categories", key = "'tree'")
-public List<CategoryResponse> getTree() { ... }
 
 @CacheEvict(cacheNames = "categories", allEntries = true)
 @Transactional
@@ -620,31 +591,29 @@ public CategoryResponse create(CategoryCreateRequest request) { ... }
 // update(), delete() 동일
 ```
 
-`CacheConfig`에 `categories` 전용 TTL(30분) 추가:
+`CacheConfig`에 `categories` 전용 TTL 30분 추가.
 
-```java
-"categories", base.entryTtl(Duration.ofMinutes(30))
-```
+**2. Redis 직렬화 호환성 문제 해결**
 
-**구현 과정에서 Redis 직렬화 호환성 문제 3가지를 추가 해결했다.**
+`List<T>`를 직접 캐싱하는 과정에서 3가지 직렬화 문제가 발생했다.
 
 | # | 증상 | 원인 | 해결 |
 |---|------|------|------|
-| 1 | `List<CategoryResponse>` 캐시 HIT 시 역직렬화 실패 | `As.PROPERTY` 방식은 JSON 배열에 `@class` 프로퍼티를 내장할 수 없어 `List` 타입 래퍼가 누락됨. 읽을 때 Jackson이 타입 정보를 찾지 못함 | `CacheConfig` 전역 직렬화 방식을 `As.WRAPPER_ARRAY`로 변경 → `["java.util.ArrayList", [...]]` 형식으로 타입 래퍼 보장 |
-| 2 | 캐시에 저장된 리스트 역직렬화 불가 | `Stream.toList()`의 반환 타입이 JDK 내부 패키지-프라이빗 클래스(`ImmutableCollections$ListN`)라 Jackson이 인스턴스화 불가 | `Collectors.toList()`로 교체 → 공개 타입 `ArrayList` 반환, 직렬화 포맷도 `java.util.ArrayList`로 확정 |
-| 3 | `CategoryResponse` 역직렬화 불가 | Lombok `@Builder`만 있으면 Jackson이 역직렬화 시 사용할 생성자(`no-args` 또는 `@JsonCreator`)를 찾지 못함 | `@Jacksonized` 추가 → Lombok이 `@JsonDeserialize(builder = ...)` + `@JsonPOJOBuilder(withPrefix = "")` 자동 생성. `children` 필드도 `List.of()` → `new ArrayList<>()`로 교체 |
+| 1 | `List<CategoryResponse>` HIT 시 역직렬화 실패 | `As.PROPERTY`는 JSON 배열에 `@class` 프로퍼티 내장 불가 → 타입 정보 누락 | `CacheConfig` 직렬화 방식을 `As.WRAPPER_ARRAY`로 변경 |
+| 2 | 캐시 리스트 역직렬화 불가 | `Stream.toList()` 반환 타입이 JDK 내부 클래스(`ImmutableCollections$ListN`) → Jackson 인스턴스화 불가 | `Collectors.toList()`로 교체 |
+| 3 | `CategoryResponse` 역직렬화 불가 | Lombok `@Builder`만 있으면 Jackson이 역직렬화 생성자를 찾지 못함 | `@Jacksonized` 추가 + `children` 필드 `new ArrayList<>()` |
 
-> **교훈**: 기존 캐시(`products`, `inventory`, `orders`)는 단일 객체를 캐싱해 `As.PROPERTY`에서 문제가 없었다. `List<T>`를 직접 캐싱하면 컬렉션 타입 래퍼 방식이 달라지므로 통합 테스트에서 반드시 캐시 HIT 경로까지 검증해야 한다.
+> **교훈**: 기존 캐시(`products`, `inventory`, `orders`)는 단일 객체 캐싱이라 `As.PROPERTY`에서 문제가 없었다. `List<T>` 직접 캐싱 시 컬렉션 타입 래퍼 방식이 달라지므로 통합 테스트에서 캐시 HIT 경로까지 반드시 검증해야 한다.
 
 ### Trade-off
 
 | 항목 | 내용 |
 |------|------|
-| 최대 30분 Stale | write API가 누락되면 TTL 만료까지 구버전 카테고리 노출. 현재는 `create / update / delete` 모두 `@CacheEvict` 적용 |
+| 최대 30분 Stale | write API 누락 시 TTL 만료까지 구버전 카테고리 노출. 현재는 `create / update / delete` 모두 `@CacheEvict` 적용 |
 | Write 경로 관리 부담 | 향후 카테고리 변경 로직 추가 시 `@CacheEvict` 누락이 silent bug가 됨 — 코드 리뷰에서 반드시 확인 필요 |
-| `As.WRAPPER_ARRAY` 전환 영향 | 기존 캐시 키(`products::*`, `inventory::*`, `orders::*`)의 직렬화 포맷이 변경됨. 운영 배포 시 기존 캐시 키 무효화 필요 (`FLUSHDB` 또는 자연 TTL 만료 대기) |
-| 직렬화 제약 추가 | 캐시 대상 DTO에 `@Jacksonized`와 가변 `List` 사용을 강제해야 함. 누락 시 캐시 HIT에서만 역직렬화 에러가 발생해 원인 파악이 어려움 |
-| Cold Start | 재배포 직후 또는 TTL 만료 직후 첫 요청은 DB 조회 + 트리 조립이 발생 |
+| `As.WRAPPER_ARRAY` 전환 영향 | 기존 캐시 키(`products::*`, `inventory::*`, `orders::*`) 직렬화 포맷 변경 → 운영 배포 시 기존 키 무효화 필요 |
+| 직렬화 제약 | 캐시 대상 DTO에 `@Jacksonized`와 가변 `List` 강제 — 누락 시 캐시 HIT에서만 역직렬화 에러 발생 |
+| Cold Start | 재배포 직후 또는 TTL 만료 직후 첫 요청은 DB 조회 + 트리 조립 발생 |
 
 ### 결과
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -26,7 +26,7 @@ Client
   Elasticsearch — 상품 전문 검색 (MySQL fallback)
   MinIO(S3) — 상품 이미지 Presigned URL
   OutboxEventStore — ORDER_CREATED/CANCELLED · PAYMENT_CONFIRMED · SHIPMENT_CREATE · POINT_EARN
-  Flyway V1~V34 — 스키마 버전 관리
+  Flyway V1~V37 — 스키마 버전 관리
 ```
 
 **주요 데이터 흐름**: 주문 생성 → 재고 예약(분산 락) → PENDING → Toss 결제 승인 → Outbox 이벤트(배송·포인트) → CONFIRMED → 배송 상태 전이 → 완료
@@ -37,9 +37,27 @@ Client
 
 ## 🔴 긴급 — 프로덕션 버그 (데이터 손실·사용자 피해)
 
-> ✅ **현재 미해결 항목 없음.** 아래 #52는 완료 처리됨.
+### 80. Payment 금액에 쿠폰/포인트 할인이 반영되지 않음 — 사용자 과다 결제
+
+**위치**: `domain/payment/service/PaymentService.java:95`, `:120`
+
+**문제**: `prepare()`에서 `order.getTotalAmount()`로 금액을 검증하고 Payment에도 원가를 저장한다. `OrderService.create()`에서 쿠폰 할인(`discountAmount`)과 포인트 사용(`usedPoints`)은 `totalAmount`를 변경하지 않고 별도 필드에만 기록하므로, **Payment.amount = 상품 합계 원가**가 된다. Toss에 원가 전액이 결제 요청되어 사용자가 할인·포인트 차감 없이 전액을 지불하게 된다.
+
+**개선**: Order에 `getPayableAmount()` (= `totalAmount - discountAmount - usedPoints`, 최소 0) 계산 메서드를 추가. `prepare()`에서 이 값으로 검증 및 Payment 저장.
 
 ---
+
+### 81. 동일 상품 중복 주문 항목 시 `Collectors.toMap` 500 에러
+
+**위치**: `domain/order/service/OrderService.java:131-132`, `:456-457`
+
+**문제**: `request.getItems()`에 동일 `productId`가 2회 이상 포함되면 `Collectors.toMap(Product::getId, p -> p)`에서 `IllegalStateException: Duplicate key`가 발생. 500 에러로 사용자에게 노출된다. `preview()`에서도 동일.
+
+**개선**: 요청 검증에서 중복 `productId` 사전 차단, 또는 `Collectors.toMap`에 merge function(`(a, b) -> a`) 지정.
+
+---
+
+> 아래 #52는 완료 처리됨.
 
 ### ✅ 52. Toss 승인 완료 후 주문 만료 경합 — `PAYMENT_IN_PROGRESS` 상태로 해결
 
@@ -87,6 +105,240 @@ Client
 **문제**: `X-Forwarded-For: client, proxy1, proxy2`에서 마지막 IP(`proxy2`)를 추출. 공격자가 헤더를 `X-Forwarded-For: real_ip, attacker_ip`로 조작하면 `attacker_ip`로 Rate Limit 버킷이 생성되어 IP 기반 제한 무력화. 현재 `trust-proxy=true/false` 설정만 있고 프록시 수 기반 추출은 미구현.
 
 **개선**: `rate-limit.trusted-proxy-count` 설정 추가, 헤더 끝에서 N번째 IP 추출.
+
+---
+
+### 66. `PaymentService.confirm()` catch 블록 — `resetOrderOnPaymentError()` 실패 시 Order 영구 PAYMENT_IN_PROGRESS
+
+**위치**: `domain/payment/service/PaymentService.java:166-172`
+
+**문제**: catch 블록 내 호출 순서상 `resetOrderOnPaymentError()`가 예외를 던지면 `release(idempotencyKey)` 가 실행되지 않는다.
+
+```java
+catch (Exception e) {
+    transactionHelper.resetOrderOnPaymentError(...); // ← 여기서 실패(DB 장애)하면
+    idempotencyManager.release(idempotencyKey);       // ← 이 줄은 건너뜀
+    throw e;
+}
+```
+
+- `PROCESSING_TTL = 60초`이므로 Redis 키 자체는 1분 후 자동 만료 → 재시도 허용됨
+- **그러나** Order 상태가 PAYMENT_IN_PROGRESS로 영구 잔존 → 만료 스케줄러가 영원히 스킵 → 사용자 재주문 불가
+- DB가 순간 장애 후 복구돼도 이 Order는 stuck 상태로 방치됨
+
+**개선**: `try-finally`로 `release()`를 보장하거나, `resetOrderOnPaymentError()` 내에서 예외를 삼키고 로그만 남기는 방어 처리 추가.
+
+---
+
+### 72. `CouponService.releaseCoupon()` — 쿠폰 `usageCount` lost update 가능
+
+**위치**: `domain/coupon/service/CouponService.java:228`, `domain/coupon/entity/Coupon.java:120`
+
+**문제**: `releaseCoupon()`에서 쿠폰을 LAZY 로드(잠금 없음) 후 `decreaseUsage()`로 dirty checking UPDATE를 한다. 같은 시각에 `applyCoupon()`이 `findByCodeWithLock()`(FOR UPDATE)으로 동일 쿠폰을 잠그고 `increaseUsage()` → 커밋하는 경우, `releaseCoupon()`의 flush가 DB에 이미 커밋된 증가값을 덮어쓰는 **lost update**를 발생시킨다.
+
+```
+T1(release) : SELECT coupon (usageCount=5, 잠금 없음) → in-memory: 4
+T2(apply)   : SELECT FOR UPDATE (usageCount=5) → 6으로 증가 → 커밋 (DB=6)
+T1(flush)   : UPDATE coupons SET usage_count=4  ← DB의 6을 4로 덮어씀
+```
+
+결과: `maxUsageCount=5`인 쿠폰이 실제 6회 사용됐음에도 `usageCount=4`로 기록되어 추가 사용이 허용됨.
+
+**개선**: `releaseCoupon()`에서 쿠폰을 `findByIdWithLock()`으로 비관적 잠금 후 조회하거나, `@Modifying @Query("UPDATE coupons SET usage_count = usage_count - 1 WHERE id = ?")` 원자적 SQL로 교체.
+
+---
+
+### 73. `CouponService.claim()` / `issueToUser()` — TOCTOU: 동시 요청 시 제네릭 409 반환
+
+**위치**: `domain/coupon/service/CouponService.java:154`, `:91`
+
+**문제**: `existsByUserIdAndCouponId()` 체크 통과 → `save()` 사이에 동일 사용자의 다른 요청이 check를 통과하면, 양쪽이 INSERT를 시도한다. DB UNIQUE KEY `uk_user_coupons(user_id, coupon_id)`가 중복을 막고, `GlobalExceptionHandler`가 `DataIntegrityViolationException`을 **HTTP 409** 로 변환하므로 500 에러는 발생하지 않는다. 그러나 응답 바디가 `DataIntegrityViolationException` 경로로 내려가므로 `COUPON_ALREADY_ISSUED` 비즈니스 에러 코드 대신 **제네릭 메시지**가 반환된다. `issueToUser()`도 동일 패턴.
+
+**개선**: `save()` 주변에 `DataIntegrityViolationException` catch → `BusinessException(COUPON_ALREADY_ISSUED)` 재발행. 또는 `@DistributedLock`으로 같은 사용자의 동시 claim 직렬화.
+
+---
+
+### 77. Outbox `POINT_EARN` — `earn()` 비멱등성으로 포인트 이중 적립 가능
+
+**위치**: `common/outbox/OutboxEventProcessor.java`, `domain/point/service/PointService.java:96`
+
+**문제**: `processOne()`은 `REQUIRES_NEW` 트랜잭션이고, 내부에서 호출하는 `earn()`도 `REQUIRES_NEW`로 독립 커밋된다. `earn()` 커밋 직후 `processOne` 트랜잭션이 롤백(DB 순간 장애, 네트워크 등)되면 `outbox.markPublished()`가 반영되지 않는다. 다음 relay 사이클에서 같은 Outbox 이벤트를 다시 처리 → `earn()` 재호출 → **포인트 이중 적립**.
+
+```
+processOne() REQUIRES_NEW {
+    dispatch() → earn() REQUIRES_NEW → 커밋 ✅ (포인트 +10)
+    outbox.markPublished()            → 롤백 ❌
+}
+→ 다음 relay: earn() 재호출 → 포인트 +10 (총 +20)
+```
+
+`PointTransactionRepository`에 `existsByOrderIdAndType()` 같은 멱등성 체크가 없으므로 중복 적립이 DB에 그대로 기록된다.
+
+**개선**: `earn()` 내부에서 `pointTransactionRepository.existsByOrderIdAndType(orderId, EARN)` 선행 체크 → 이미 존재하면 early return. 또는 `(userId, orderId, type)` UNIQUE 제약(마이그레이션) 추가.
+
+---
+
+### 78. `PaymentService.cancel()` — `applyCancelResult()` TX 실패 시 Toss "already cancelled" stuck
+
+**위치**: `domain/payment/service/PaymentService.java` `cancel()`, `domain/payment/service/PaymentTransactionHelper.java` `applyCancelResult()`
+
+**문제**: `cancel()`은 `NOT_SUPPORTED`로 실행되며, Toss cancel API 호출 성공 후 `applyCancelResult()` 트랜잭션이 실패(DB 장애, 타임아웃)하면:
+- Toss: 결제 취소 완료 (환불 진행)
+- DB: `payment.status = DONE`, `order.status = CONFIRMED` 그대로 잔존
+
+이후 재시도 시 `applyCancelResult()` 진입 전 Toss cancel API를 다시 호출 → Toss가 "이미 취소된 결제" 에러 반환 → `BusinessException` throw → DB 상태 영구 미갱신. `RefundService.requestRefund()`에서도 `payment.status != DONE` 체크로 인해 재시도 불가.
+
+**개선**: Toss cancel API 응답 전 `payment`를 `CANCEL_IN_PROGRESS` 중간 상태로 먼저 커밋 (confirm의 `PAYMENT_IN_PROGRESS` 패턴과 동일). `applyCancelResult()` 재시도 시 이미 취소 완료인 경우 Toss API 응답 무시하고 DB 상태만 갱신하는 idempotent 경로 추가.
+
+---
+
+### 85. `CacheConfig` `LaissezFaireSubTypeValidator` — 역직렬화 가젯 공격 벡터
+
+**위치**: `common/config/CacheConfig.java:44-47`
+
+**문제**: `LaissezFaireSubTypeValidator`는 **모든 타입의 역직렬화를 허용**한다. `activateDefaultTyping(NON_FINAL)`과 결합하면, Redis에 악의적 JSON 페이로드 주입 시 임의 클래스 인스턴스화 → RCE 가능.
+
+**개선**: `BasicPolymorphicTypeValidator.builder().allowIfBaseType("com.stockmanagement.").allowIfBaseType("java.util.").allowIfBaseType("java.time.").build()` 화이트리스트 전환.
+
+---
+
+### 97. `AuthController.logout()` — 인증 없이 호출 가능
+
+**위치**: `domain/user/controller/AuthController.java:64-73`
+
+**문제**: `/api/auth/**` 전체가 `permitAll()`이어서 로그아웃도 인증 없이 호출 가능. `Authorization` 헤더만 있으면 JWT 검증 결과와 무관하게 블랙리스트 등록 진행. 제3자가 유효 토큰을 무효화하는 서비스 거부 가능.
+
+**개선**: 로그아웃을 `/api/auth/**` 패턴에서 분리하여 `authenticated()` 규칙 적용. 또는 `revoke()` 전 `validateToken()` 검증.
+
+---
+
+### 82. 회원 탈퇴 시 Access Token 미무효화 — 최대 24시간 API 접근 가능
+
+**위치**: `domain/user/service/UserService.java:132-143`
+
+**문제**: `deactivate()`는 Refresh Token만 폐기(`revokeAll`)하고, Access Token을 블랙리스트에 등록하지 않는다. JWT 유효 시간이 24시간이므로, 탈퇴 직후에도 기존 Access Token으로 API 접근이 가능하다.
+
+**개선**: `deactivate()` 호출 시 현재 요청의 Access Token도 `jwtBlacklist.revoke()`로 등록. 또는 `JwtAuthenticationFilter`에서 사용자 활성 상태를 Redis 캐시 기반 추가 확인.
+
+---
+
+### 83. `LoginRateLimiter` username 단독 제한 — 타인 계정 잠금(Account Lockout DoS) 가능
+
+**위치**: `common/security/LoginRateLimiter.java:44`
+
+**문제**: 공격자가 타인의 username으로 5회 틀린 비밀번호를 입력하면 해당 사용자의 로그인이 15분간 차단된다. IP 기반 제한이 병행되지 않아 IP를 바꾸며 반복 가능.
+
+**개선**: `username + IP` 복합 키 사용, 또는 username 단독 임계값을 20회로 높이고 IP 기반 제한(10회/15분) 추가하는 이중 구조.
+
+---
+
+### 84. `SignupRequest.username` 패턴 검증 없음 — Redis 키 오염 가능
+
+**위치**: `domain/user/dto/SignupRequest.java:9-11`
+
+**문제**: username에 `@NotBlank @Size(min=3, max=50)`만 적용. 콜론(`:`)·줄바꿈(`\n`) 등 특수문자 허용. Redis 키 조합(`rate-limit:login:{username}`, `refresh:user:{username}`)에 직접 사용되어 키 구조 오염, 로그 인젝션, unicode zero-width 문자로 시각적 동일 username 생성 가능.
+
+**개선**: `@Pattern(regexp = "^[a-zA-Z0-9_-]+$")` 추가.
+
+---
+
+### 86. `StorageConfig` `S3Presigner` `forcePathStyle` 누락 — MinIO Presigned URL 호스트 불일치
+
+**위치**: `common/config/StorageConfig.java:44-51`
+
+**문제**: `S3Client`에는 `.forcePathStyle(true)` 설정이 있지만, `S3Presigner`에는 누락. Presigner가 virtual-hosted style URL(`http://bucket.endpoint/key`)을 생성하여 MinIO 환경에서 DNS 해석 실패.
+
+**개선**: `S3Presigner.builder()` 체인에 `.serviceConfiguration(S3Configuration.builder().pathStyleAccessEnabled(true).build())` 추가.
+
+---
+
+### 87. `ProductService.update()` `@CachePut`이 이미지 없는 응답을 캐시 — getById()와 불일치
+
+**위치**: `domain/product/service/ProductService.java:182-189`
+
+**문제**: `update()`는 `@CachePut`으로 캐시를 갱신하지만 `buildProductResponse()`(이미지 **미포함**)를 호출한다. `getById()`는 `buildProductResponseWithImages()`(이미지 **포함**)를 캐시에 저장. `update()` 후 캐시에 이미지 없는 응답이 들어가고, 이후 `getById()`가 이 캐시를 반환하므로 이미지가 사라져 보인다.
+
+**개선**: `update()`에서도 `buildProductResponseWithImages()` 사용. 또는 `@CachePut` 대신 `@CacheEvict`로 무효화.
+
+---
+
+### 88. `ProductImageService` 이미지 변경 시 products 캐시 미무효화
+
+**위치**: `domain/product/image/service/ProductImageService.java`
+
+**문제**: `getById()`가 `@Cacheable`이고 이미지 목록을 캐시에 포함한다. 그런데 `saveImage()`/`deleteImage()`/`updateImageOrder()`에서 `products` 캐시를 evict하지 않아, 이미지 등록/삭제 후에도 이전 이미지 목록이 포함된 캐시가 반환된다.
+
+**개선**: `ProductImageService`의 변경 메서드에 `@CacheEvict(cacheNames = "products", key = "#productId")` 추가.
+
+---
+
+### 89. `PresignedUrlRequest.fileExtension` 문자 검증 없음 — 오브젝트 키 구조 오염
+
+**위치**: `domain/product/image/dto/PresignedUrlRequest.java:12`
+
+**문제**: `@NotBlank`만 있고 허용 확장자/문자 검증 없음. `fileExtension = "../../etc/passwd"` 같은 값으로 오브젝트 키 구조가 오염된다.
+
+**개선**: `@Pattern(regexp = "^[a-zA-Z0-9]{1,10}$")` 허용 확장자 패턴 추가.
+
+---
+
+### 90. `EmailService.buildItemsTable()` `item.getProduct()` — `@Async` 스레드에서 LazyInitializationException 가능성
+
+**위치**: `common/email/EmailService.java:213`
+
+**문제**: `@Async` 비동기 스레드에서 `item.getProduct().getName()` 호출. `EmailEventListener`에 `@Transactional(readOnly=true)`가 있어 새 영속성 컨텍스트가 열리지만, `findByIdWithItems()`가 `product`까지 fetch join하지 않으면 `LazyInitializationException` 발생.
+
+**개선**: `OrderRepository.findByIdWithItems()`가 `JOIN FETCH i.product`까지 포함하는지 확인. 미포함 시 쿼리 확장 또는 이벤트 페이로드에 product name 포함.
+
+---
+
+### 91. `PointService.getOrCreate()` 동시 요청 시 Duplicate Key 예외
+
+**위치**: `domain/point/service/PointService.java:191-194`
+
+**문제**: 동일 사용자의 첫 주문 2건이 동시에 들어오면, 두 스레드 모두 `findByUserIdWithLock()` empty → INSERT 시도 → `user_points.user_id UNIQUE` 위반. `PointService.earn()`은 `REQUIRES_NEW`로 독립 트랜잭션이므로 결제 확인 전체가 롤백되지는 않지만 포인트 적립이 누락된다.
+
+**개선**: `DataIntegrityViolationException` catch 후 재조회 retry 패턴 적용.
+
+---
+
+### 92. `CouponCreateRequest` 날짜 교차 검증 없음 + PERCENTAGE 100% 초과 허용
+
+**위치**: `domain/coupon/dto/CouponCreateRequest.java`
+
+**문제**: (1) `validFrom >= validUntil`이면 즉시 만료 상태 쿠폰이 생성됨. (2) `discountType=PERCENTAGE`일 때 `discountValue > 100` 허용. `maxDiscountAmount` 설정에 따라 의도치 않은 할인 금액 발생 가능.
+
+**개선**: (1) `validFrom.isAfter(validUntil)` 검증. (2) PERCENTAGE 시 `discountValue <= 100` 검증 추가.
+
+---
+
+### 93. `WishlistService.getList()` 필터링 후 `totalElements` 불일치
+
+**위치**: `domain/product/wishlist/service/WishlistService.java:98-105`
+
+**문제**: soft-deleted 상품을 필터링한 후 `PageImpl`의 `totalElements`를 원래 값 그대로 전달. 프론트엔드가 "전체 N건" 표시나 페이지 수 계산 시 부정확.
+
+**개선**: DB 쿼리 레벨에서 DISCONTINUED 상품 제외(`JOIN Product WHERE status = ACTIVE`). 또는 필터링 후 content 크기 기반으로 totalElements 재계산.
+
+---
+
+### 94. `RefundService.requestRefund()` 동시 요청 시 Duplicate Key → 500 에러
+
+**위치**: `domain/refund/service/RefundService.java:83-97`
+
+**문제**: 동일 결제에 대해 동시 환불 요청 시 두 스레드 모두 `findByPaymentId()` empty → INSERT → `refunds.payment_id UNIQUE` 위반. `noRollbackFor=Exception.class`이지만 Hibernate가 `rollback-only` 표시 → `UnexpectedRollbackException` → 500 에러.
+
+**개선**: `save()` 주변에서 `DataIntegrityViolationException` catch 후 재조회. 또는 비관적 락으로 직렬화.
+
+---
+
+### 102. `PaymentTransactionHelper.applyConfirmResult()` non-DONE 응답 시 `fail()` 롤백 가능성
+
+**위치**: `domain/payment/service/PaymentTransactionHelper.java:145-157`
+
+**문제**: Toss 응답이 DONE이 아니면 `payment.fail()` 후 `BusinessException` throw. 예외로 인해 Spring이 rollback-only 표시 → `fail()` dirty checking 미커밋. Payment가 PENDING으로 잔존하여 재시도 시 Toss API 재호출.
+
+**개선**: non-DONE 처리를 `REQUIRES_NEW` 트랜잭션으로 분리. 또는 에러 상태를 반환값으로 전달.
 
 ---
 
@@ -144,6 +396,113 @@ Client
 
 ---
 
+### 67. `DailyOrderStatsScheduler` — 4개 개별 쿼리 → 단일 GROUP BY 통합 가능
+
+**위치**: `domain/order/scheduler/DailyOrderStatsScheduler.java:44-49`
+
+**문제**: 전일 통계를 4개 별도 쿼리로 집계한다.
+
+```java
+countByCreatedAtBetween(start, end)                        // SELECT COUNT(*)
+countByStatusAndCreatedAtBetween(CONFIRMED, start, end)    // SELECT COUNT(*)
+countByStatusAndCreatedAtBetween(CANCELLED, start, end)    // SELECT COUNT(*)
+sumRevenueByCreatedAtBetween(start, end)                   // SELECT SUM(total_amount)
+```
+
+`OrderRepository`에 이미 `findOrderStats()` GROUP BY 메서드가 있지만 날짜 범위 파라미터가 없어 미사용.
+
+**개선**: `findOrderStats(start, end)` — `WHERE created_at BETWEEN :start AND :end GROUP BY status` 단일 쿼리로 count·revenue를 한 번에 조회. 일 1회 실행이므로 체감 영향은 미미하나, 패턴 정리 차원.
+
+---
+
+### 68. `InventorySnapshotScheduler` — `Page<T>` COUNT 중복 쿼리 → `Slice<T>` 전환
+
+**위치**: `domain/inventory/scheduler/InventorySnapshotScheduler.java:50`
+
+**문제**: `inventoryRepository.findAll(PageRequest.of(pageNum, PAGE_SIZE))`는 Spring Data JPA `Page<T>` 계약상 매 페이지마다 `SELECT COUNT(*) FROM inventory` 쿼리를 추가로 실행한다. `totalElements`는 첫 번째 페이지(line 54)에서만 사용하고 이후 페이지에서는 `isLast()` 만 체크하므로 나머지 페이지의 COUNT 쿼리는 불필요한 오버헤드다.
+
+**개선**: `Page<T>` → `Slice<T>` 전환. 첫 페이지만 `Page<T>`로 조회해 `totalElements`를 캡처하고 이후 페이지는 `Slice<T>`를 사용하거나, `findAll(PageRequest…)` 대신 `id > :lastId LIMIT n` 커서 쿼리로 교체.
+
+---
+
+### 69. `PaymentService.getByOrderId()` — 소유권 체크에 전체 Order 엔티티 로드
+
+**위치**: `domain/payment/service/PaymentService.java:308`
+
+**문제**: USER 소유권 검증 시 `orderRepository.findById(orderId)`로 Order 전체 엔티티를 로드한다. 목적은 `order.getUserId()` 스칼라 값 추출뿐이며, `LazyInitializationException` 방지 목적의 fetch join도 불필요하다.
+
+```java
+Order order = orderRepository.findById(orderId)  // 전체 엔티티 로드
+        .orElseThrow(...);
+if (!order.getUserId().equals(userId)) { ... }
+```
+
+`ShipmentService.getByOrderId()`는 이미 동일 문제를 `findUserIdById()` 프로젝션으로 해결했으나, `PaymentService`는 미적용 상태.
+
+**개선**: `orderRepository.findUserIdById(orderId)` 스칼라 쿼리로 교체 (일관성 + 불필요 컬럼 로드 제거).
+
+---
+
+### 70. `CartService.addOrUpdate()` — 응답 구성용 전체 장바구니 재조회
+
+**위치**: `domain/order/cart/service/CartService.java:92`
+
+**문제**: 항목 추가·수량 변경 후 `return getCart(userId)`를 호출한다. `getCart()`는 내부에서 `findByUserId()` + `findAllByProductIdIn()` 2개 쿼리를 추가로 실행한다. 방금 저장한 항목을 포함한 장바구니를 다시 전부 다시 읽는 구조다.
+
+**개선**: 변경된 CartItem 상태를 in-memory로 응답에 반영하거나, `addOrUpdate()` 반환 타입을 `void`/단건 DTO로 바꾸고 클라이언트가 별도 GET으로 최신 장바구니를 조회하게 분리.
+
+---
+
+### 74. `PointService.refundByOrder()` — 포인트 미사용 주문도 항상 `SELECT FOR UPDATE`
+
+**위치**: `domain/point/service/PointService.java:147-148`
+
+**문제**: `getOrCreate(userId)`가 메서드 진입 직후 호출되어, 주문에 `USE`/`EARN` 트랜잭션이 없어도 항상 `SELECT ... FOR UPDATE`를 실행한다 (포인트를 전혀 사용하지 않은 주문 취소 포함). 포인트 계정이 없으면 빈 `UserPoint` 레코드를 새로 INSERT한다 — 이 레코드는 사용되지 않는 유령(ghost) 레코드다.
+
+**개선**: `pointTransactionRepository.findByOrderId(orderId)`를 먼저 실행하고, 결과가 비어 있으면 `getOrCreate()` 없이 early return.
+
+---
+
+### 75. `RefundService` — `userRepository.findByUsername()` DB round-trip
+
+**위치**: `domain/refund/service/RefundService.java:60`, `:114`, `:124`
+
+**문제**: `requestRefund()`, `getById()`, `getByPaymentId()` 세 메서드 모두 `userRepository.findByUsername(username)`으로 User 엔티티 전체를 로드한다. 목적은 `user.getId()`(Long) 하나뿐이며, JWT 클레임에서 추출한 userId를 파라미터로 받으면 DB 조회 없이 처리 가능하다. 이미 다른 서비스(#29, #49, #69, #71)에서 적용된 동일 패턴의 미적용 케이스.
+
+**개선**: 시그니처를 `(String username)` → `(Long userId)` 로 변경. 컨트롤러에서 `resolveUserId()` 헬퍼로 JWT claim 추출.
+
+---
+
+### 79. Outbox `SHIPMENT_CREATE` — nested `REQUIRES_NEW` 실패 시 false dead letter 누적
+
+**위치**: `common/outbox/OutboxEventProcessor.java`, `domain/shipment/service/ShipmentService.java` `createForOrder()`
+
+**문제**: #77과 동일한 nested REQUIRES_NEW 패턴. `createForOrder()`가 `REQUIRES_NEW`로 배송 레코드를 독립 커밋한 뒤 `processOne` TX가 롤백되면, 다음 relay 사이클에서 `createForOrder()` 재시도 → `ShipmentAlreadyExists` 예외 → `outbox.recordFailure()`. 이를 5회 반복하면 MAX_RETRY 도달 → **dead letter** 로 분류된다. 실제 배송은 이미 올바르게 생성됐음에도 운영 알림(`outbox.dead_letters` Gauge 증가)이 오발된다.
+
+**개선**: `createForOrder()` 내부에서 `shipmentRepository.existsByOrderId(orderId)` 선행 체크 → 이미 존재하면 early return (idempotent). 또는 `order_id UNIQUE` 제약을 DB에 추가하고, `DataIntegrityViolationException`을 catch 후 정상 처리.
+
+---
+
+### 76. `PaymentTransactionHelper.loadAndValidateForCancel()` — 소유권 체크에 전체 Order 엔티티 로드
+
+**위치**: `domain/payment/service/PaymentTransactionHelper.java:273`
+
+**문제**: USER 소유권 검증 시 `orderRepository.findById(payment.getOrderId())`로 Order 엔티티 전체를 로드한다. `order.getUserId()` 스칼라 값만 필요하며, `findUserIdById()` 스칼라 프로젝션이 이미 존재한다. #69(PaymentService.getByOrderId)와 동일 패턴.
+
+**개선**: `orderRepository.findUserIdById(payment.getOrderId())` 스칼라 쿼리로 교체.
+
+---
+
+### 71. `OrderService.getHistory()` — 소유권 체크에 전체 Order 엔티티 로드
+
+**위치**: `domain/order/service/OrderService.java:291`
+
+**문제**: `historyRepository.findByOrderIdOrderByCreatedAtAsc(orderId)` 호출 전 소유권 검증을 위해 `orderRepository.findById(orderId)`로 전체 Order 엔티티를 로드한다. items 컬렉션은 이 흐름에서 사용하지 않으며 LAZY 이므로 로딩되진 않지만, 엔티티 전체를 로드할 이유도 없다.
+
+**개선**: `findUserIdById()` 스칼라 프로젝션으로 교체. 이미 #49, #69와 동일 패턴의 미적용 케이스.
+
+---
+
 ### 25. API 버전 관리 부재
 
 **위치**: 모든 컨트롤러 (`/api/products`, `/api/orders` 등)
@@ -151,6 +510,166 @@ Client
 **문제**: 버전 prefix 없이 `/api/` 직접 사용. 응답 스키마 변경 시 하위 호환성 관리 불가.
 
 **개선**: `/api/v1/` prefix 도입.
+
+---
+
+### 95. `GlobalExceptionHandler` — `HttpMessageNotReadableException` 등 4xx 에러가 500으로 응답
+
+**위치**: `common/exception/GlobalExceptionHandler.java`
+
+**문제**: JSON 파싱 실패(`HttpMessageNotReadableException`), 쿼리 파라미터 타입 불일치(`MethodArgumentTypeMismatchException`), 필수 파라미터 누락(`MissingServletRequestParameterException`) 등이 전용 핸들러 없이 최하단 `Exception` 핸들러로 빠져 500 응답. 에러 모니터링 노이즈.
+
+**개선**: 각각에 대해 `@ExceptionHandler` 추가, 400 Bad Request로 응답.
+
+---
+
+### 96. `SecurityConfig` — Swagger UI 운영 환경 무인증 노출
+
+**위치**: `common/config/SecurityConfig.java:81`
+
+**문제**: `/swagger-ui/**`, `/v3/api-docs/**`가 `permitAll()`. 프로파일 분기 없이 운영에서도 전체 API 스키마 공개.
+
+**개선**: `springdoc.api-docs.enabled=${SWAGGER_ENABLED:false}` 환경 변수 전환. 또는 ADMIN 권한 필요하도록 변경.
+
+---
+
+### 98. `RefreshTokenStore` 역색인 Set TTL 없음 — Redis 메모리 누수
+
+**위치**: `common/security/RefreshTokenStore.java:45`
+
+**문제**: `refresh:user:{username}` Set은 `issue()` 시 TTL 미설정. 개별 토큰 키(`refresh:token:{uuid}`)는 30일 TTL로 만료되지만, Set 내 UUID 문자열은 만료 후에도 잔존. 장기 활성 사용자의 역색인 크기가 무한 증가.
+
+**개선**: `issue()` 시 Set에 35일 TTL 설정. 또는 주기적 정리 스케줄러 추가.
+
+---
+
+### 99. `AsyncConfig` `RejectedExecutionHandler` 미설정 — 이벤트 무음 소실
+
+**위치**: `common/config/AsyncConfig.java:27-36`
+
+**문제**: `maxPoolSize=8`, `queueCapacity=50`. 동시에 58개 이상 비동기 이벤트 발생 시 기본 `AbortPolicy`에 의해 `RejectedExecutionException` → 이벤트 소실. `@Async void` 반환이므로 호출자에게 전파 안 됨.
+
+**개선**: `CallerRunsPolicy`로 거부된 작업을 호출 스레드에서 실행. 또는 `AsyncUncaughtExceptionHandler` 커스텀 구현.
+
+---
+
+### 100. `RequestIdFilter` 외부 주입 `X-Request-Id` 무검증 — 로그 인젝션
+
+**위치**: `common/filter/RequestIdFilter.java:32-35`
+
+**문제**: 클라이언트가 보낸 `X-Request-Id`를 길이/형식 검증 없이 사용. 줄바꿈(`\n`, `\r`) 포함 시 가짜 로그 라인 삽입 가능. 수 KB 길이 값으로 로그 부풀리기.
+
+**개선**: 길이 상한(64자) + 영숫자/하이픈 패턴 검증. 초과 시 무시하고 UUID 생성.
+
+---
+
+### 101. `OutboxEventPurgeScheduler` — 대량 삭제 시 단일 트랜잭션 테이블 잠금
+
+**위치**: `common/outbox/OutboxEventPurgeScheduler.java:33-36`
+
+**문제**: `@Transactional` + `DELETE WHERE publishedAt < :before`가 단일 트랜잭션. 7일간 수만~수십만 건이면 장시간 잠금으로 relay/INSERT 블로킹.
+
+**개선**: 1,000건 단위 배치 삭제 루프 전환.
+
+---
+
+### 103. 커서 스크롤 `size` 파라미터 상한 미검증
+
+**위치**: `domain/order/controller/OrderController.java:133`, `domain/inventory/controller/InventoryController.java:82`
+
+**문제**: `@RequestParam(defaultValue = "20") int size`에 `@Max` 제약 없음. `size=1000000` 전달 시 메모리 과다 사용 및 DB 부하.
+
+**개선**: `@Min(1) @Max(100)` 범위 제약 추가.
+
+---
+
+### 104. `resolveUserId()` 헬퍼 6개 컨트롤러에 동일 코드 복붙
+
+**위치**: `ProductController`, `ReviewController`, `WishlistController`, `ShipmentController`, `RefundController`, `CartController`
+
+**문제**: JWT details에서 userId 추출하는 동일한 4줄 메서드가 6곳에 copy-paste. 변경 시 모든 곳 수정 필요.
+
+**개선**: `SecurityUtils`에 유틸리티 메서드 추출. 또는 `HandlerMethodArgumentResolver`로 `@CurrentUserId Long userId` 어노테이션 자동 주입.
+
+---
+
+### 105. 비밀번호 정책 부재 — 복잡도 요구사항 없음
+
+**위치**: `domain/user/dto/SignupRequest.java:14-15`, `ChangePasswordRequest.java:17`
+
+**문제**: `@Size(min=8)` 뿐. `aaaaaaaa` 같은 단순 비밀번호 허용. credential stuffing/사전 공격에 취약.
+
+**개선**: 대문자/소문자/숫자/특수문자 중 최소 2~3종 포함 `@Pattern` 또는 커스텀 `ConstraintValidator`.
+
+---
+
+### 106. `CartRepository.deleteByUserId()` — N+1 DELETE 쿼리
+
+**위치**: `domain/order/cart/repository/CartRepository.java:25,28`
+
+**문제**: Spring Data JPA 파생 삭제 메서드는 SELECT 후 건별 DELETE. 장바구니 10개 상품 → 11개 쿼리.
+
+**개선**: `@Modifying @Query("DELETE FROM CartItem c WHERE c.userId = :userId")` 벌크 DELETE.
+
+---
+
+### 107. `AdminController.updateRole()` — 마지막 ADMIN 자기 해제 시 ADMIN 0명
+
+**위치**: `domain/admin/controller/AdminController.java:68-72`
+
+**문제**: 유일한 ADMIN이 자기를 USER로 변경하면 시스템에 ADMIN이 0명. DB 직접 조작 외 복구 불가.
+
+**개선**: 현재 ADMIN 수 체크하여 마지막 ADMIN 권한 해제 차단.
+
+---
+
+### 108. `ChangePasswordRequest` — 현재/신규 비밀번호 동일 허용
+
+**위치**: `domain/user/service/UserService.java:167-176`
+
+**문제**: 같은 비밀번호로 변경 시 Refresh Token 전체 폐기(`revokeAll`) 부작용만 발생하고 보안 개선 없음.
+
+**개선**: `currentPassword.equals(newPassword)` 동일 비밀번호 변경 차단.
+
+---
+
+### 109. `Inventory` 엔티티/서비스 간 방어 로직 불일치
+
+**위치**: `domain/inventory/entity/Inventory.java:133-135` vs `domain/inventory/service/InventoryService.java:209-215`
+
+**문제**: 서비스에서 `reserved < quantity` 시 예외를 던지지만, 엔티티의 `releaseReservation()`은 `Math.max(0, reserved - quantity)`로 음수를 조용히 0으로 클램핑. 서비스 검증으로 엔티티 로직은 dead code이나, 다른 호출 경로 추가 시 데이터 불일치를 조용히 삼킬 수 있다.
+
+**개선**: 엔티티 메서드가 자체적으로 `quantity > reserved` 시 예외를 던지도록 통일.
+
+---
+
+### 110. `TossPaymentsConfig` — `secretKey` null 시 `"null:"` 인코딩
+
+**위치**: `common/config/TossPaymentsConfig.java:49-50`
+
+**문제**: `toss.secret-key` 프로퍼티 누락 시 `(secretKey + ":").getBytes()`가 `"null:"` 로 인코딩. NPE는 아니지만 잘못된 인증 헤더로 Toss API 401 실패. 원인 파악 어려움.
+
+**개선**: `@PostConstruct`에서 null/빈 문자열 검증 후 `IllegalStateException` throw. JWT, Admin과 동일 패턴.
+
+---
+
+### 111. `RefundRequest.reason` 길이 검증 없음
+
+**위치**: `domain/refund/dto/RefundRequest.java:15`
+
+**문제**: `@NotBlank`만 있고 `@Size(max=300)` 없음. `Refund.reason` 컬럼은 `length=300`이므로 초과 입력 시 DB truncation 에러.
+
+**개선**: `@Size(max = 300)` 추가.
+
+---
+
+### 112. `RedisConfig` — `RedissonClient` `destroyMethod` 미설정
+
+**위치**: `common/config/RedisConfig.java:26-31`
+
+**문제**: `RedissonClient`는 `Closeable` 미구현이므로 Spring 자동 destroy 추론 불가. Graceful shutdown 시 Netty EventLoopGroup과 Redis 연결이 정리되지 않고 강제 종료.
+
+**개선**: `@Bean(destroyMethod = "shutdown")` 명시.
 
 ---
 

--- a/docs/ToDoFrontRequest.md
+++ b/docs/ToDoFrontRequest.md
@@ -155,23 +155,13 @@
      { id, productId, createdAt, product: { name, price, thumbnailUrl, availableQuantity, status } }
 ```
 
-**20. 위시리스트 페이지네이션 없음**
+**~~20. 위시리스트 페이지네이션 없음~~ ✅ 완료 (Wave 3)**
 
-`GET /api/wishlist`는 `List<>` 반환 — 위시리스트가 100건 이상이면 전체를 한번에 불러온다.
+`GET /api/wishlist?page=&size=` → `Page<WishlistResponse>` 반환.
 
-```
-개선: GET /api/wishlist?page=&size= → Page<WishlistResponse>
-```
+**~~21. 리뷰 별점 분포 통계 없음~~ ✅ 완료 (Wave 3)**
 
-**21. 리뷰 별점 분포 통계 없음**
-
-상품 상세 페이지의 별점 히스토그램(★5: 42건, ★4: 18건 ...) 구현 불가.
-현재 `avgRating`·`reviewCount`만 있고 분포가 없다. 클라이언트에서 계산하려면 전체 리뷰를 다 가져와야 한다.
-
-```
-필요: GET /api/products/{id}/reviews/stats
-     → { avgRating, reviewCount, distribution: { 1:n, 2:n, 3:n, 4:n, 5:n } }
-```
+`GET /api/products/{id}/reviews/stats` → `{ avgRating, reviewCount, distribution: { 1:n, ..., 5:n } }`.
 
 **22. 주문 상세에 환불 정보 미포함**
 
@@ -340,17 +330,9 @@ POST /api/orders → OrderItemRequest.variantId
 
 ### 🟠 중요 — 결제·주문 흐름 결함
 
-**33. 결제 실패 후 재결제 불가**
+**~~33. 결제 실패 후 재결제 불가~~ ✅ 완료 (Wave 3)**
 
-`V8 migration`에서 `payments.order_id UNIQUE` 제약이 추가되었다. 결제가 FAILED 상태가 되면 동일 주문으로 `POST /api/payments/prepare`를 재호출해도 UNIQUE 충돌이 발생한다. 프론트에서 "다시 결제하기" 버튼을 구현할 방법이 없다.
-
-```
-현재: payments.order_id UNIQUE → FAILED 상태에서 재결제 시 DB 제약 위반
-필요: 아래 중 하나 선택
-  A) FAILED 결제를 PENDING으로 reset 후 재시도 허용
-  B) payments.order_id UNIQUE 제거 + (order_id, status) 복합 제약으로 교체
-  C) POST /api/payments/{orderId}/retry 엔드포인트 추가
-```
+FAILED 결제를 `Payment.resetForRetry(newTossOrderId)`로 PENDING으로 재설정. `POST /api/payments/prepare` 재호출 허용.
 
 **34. `OrderResponse`에 배송지 스냅샷 없음**
 
@@ -417,14 +399,9 @@ POST /api/orders → OrderItemRequest.variantId
      review   → reviewCount 내림차순
 ```
 
-**40. 배송 예상 도착일 없음**
+**~~40. 배송 예상 도착일 없음~~ ✅ 완료 (Wave 3)**
 
-`ShipmentResponse`에 `shippedAt`, `deliveredAt`(실제 배송 완료)은 있지만 `estimatedDeliveryAt`(예상 도착일)이 없다. "예상 배송일: 4월 20일(월)" 표시 불가.
-
-```
-개선: ShipmentResponse에 estimatedDeliveryAt: LocalDate 추가
-     PATCH /api/shipments/orders/{orderId}/ship Body에 estimatedDeliveryAt 포함
-```
+V36 migration. `ShipmentResponse.estimatedDeliveryAt: LocalDate` 추가. `ShipmentUpdateRequest`에 `@FutureOrPresent estimatedDeliveryAt` 포함.
 
 **41. 홈 화면 전용 집계 API 없음**
 
@@ -525,18 +502,9 @@ Spring Security 필터 레이어의 401(미인증)/403(권한 없음) 에러는 
      thumbnailUrl: String
 ```
 
-**47. 장바구니 가격 변동 감지 없음**
+**~~47. 장바구니 가격 변동 감지 없음~~ ✅ 완료 (Wave 3)**
 
-`CartItemResponse.unitPrice`는 `Product.price`를 실시간으로 참조한다 (스냅샷 아님).
-장바구니에 담은 이후 가격이 인하/인상되어도 프론트에서 이를 감지할 수 없다.
-"이 상품의 가격이 변경되었습니다 (10,000원 → 8,000원)" 알림 구현 불가.
-
-```
-개선: CartItemResponse에 추가
-     originalPrice: BigDecimal   (장바구니에 담을 당시 가격)
-     currentPrice: BigDecimal    (현재 가격)
-     priceChanged: Boolean       (originalPrice != currentPrice)
-```
+V37 migration. `CartItem.savedPrice` 추가 (담을 당시 가격 스냅샷). `CartItemResponse`에 `savedPrice`, `priceChanged` 추가.
 
 **48. `CategoryResponse`에 상품 수 없음**
 
@@ -698,29 +666,13 @@ EARN 시 해당 포인트가 언제 만료되는지 `PointTransaction`·`PointTr
           → 30일 내 소멸 예정 포인트 목록
 ```
 
-**58. Refresh Token 만료 시간 미노출**
+**~~58. Refresh Token 만료 시간 미노출~~ ✅ 완료 (Wave 3)**
 
-`LoginResponse`: `{ accessToken, tokenType, expiresIn, refreshToken }`.
-`expiresIn`은 access token 만료 초(예: 3600)이고 refresh token 만료 시간은 없다.
-Refresh Token은 30일 TTL(Redis)인데, 사용자에게 "30일 후 재로그인 필요" 사전 안내가 불가하고,
-프론트에서 refresh 요청 시점 판단을 위한 expiry 계산도 불가.
+`LoginResponse`에 `refreshTokenExpiresAt: LocalDateTime` 추가 (발급 시점 + 30일).
 
-```
-개선: LoginResponse에 refreshTokenExpiresAt: LocalDateTime 추가
-     또는 refreshExpiresIn: long (초 단위)
-```
+**~~59. 사용자 친화적 주문 번호 없음~~ ✅ 완료 (Wave 3)**
 
-**59. 사용자 친화적 주문 번호 없음**
-
-`OrderResponse.id`는 DB auto-increment Long이 그대로 노출된다 (예: `142`).
-CS 문의 시 "주문번호를 알려주세요" → "142번" 같은 상황이 발생하고,
-경쟁사가 주문 생성 빈도를 역산할 수 있는 정보 노출 문제도 있다.
-
-```
-개선: OrderResponse에 orderNumber: String 추가
-     형식 예시: "20240418-0000142" (날짜 + zero-padded id)
-     → V? migration: orders.order_number GENERATED ALWAYS 또는 애플리케이션 레벨 생성
-```
+`OrderResponse.orderNumber: String` 추가. 형식: `"yyyyMMdd-0000142"` (앱 레벨 생성, migration 불필요).
 
 ---
 

--- a/docs/ToDoFrontRequest.md
+++ b/docs/ToDoFrontRequest.md
@@ -633,3 +633,144 @@ Spring Security 필터 레이어의 401(미인증)/403(권한 없음) 에러는 
 | 🟡 중장기 | 재고 수량 직접 노출 정책 | 비즈니스 정책 결정 필요 |
 | 🟡 중장기 | 부분 환불 지원 여부 불명확 | 다품목 환불 UX |
 | 🟡 중장기 | 인앱 알림 시스템 없음 | 실시간 상태 알림 |
+
+---
+
+## 5차 검토 — 인증·포인트·배송·폼 UX 결함
+
+---
+
+### 🔴 필수
+
+**54. `@Valid` 에러 응답에 필드별 구조 없음**
+
+`GlobalExceptionHandler.handleValidationException()`이 모든 필드 오류를 `Collectors.joining(", ")`으로 단일 문자열로 합쳐 반환한다:
+```
+{ success: false, message: "이름은 필수입니다., 이메일 형식이 올바르지 않습니다." }
+```
+회원가입·배송지 입력 폼에서 각 필드 아래 인라인 에러 메시지를 표시할 수 없다.
+어떤 필드에 어떤 오류가 있는지 파싱 불가.
+
+```
+필요: { success: false, code: "VALIDATION_FAILED", errors: [
+         { field: "email",    message: "이메일 형식이 올바르지 않습니다." },
+         { field: "password", message: "8자 이상 입력해주세요." }
+       ]}
+```
+
+---
+
+### 🟠 중요
+
+**55. 내 배송 목록 API 없음**
+
+`ShipmentController`에는 `GET /api/shipments/orders/{orderId}` 단건 조회만 있다.
+마이페이지 "배송 현황" 탭에서 진행 중인 전체 배송을 한 번에 보여주려면
+주문 목록 → 각 orderId로 배송 조회를 반복해야 한다.
+
+```
+필요: GET /api/shipments/my?status=SHIPPED&page=&size=
+     → 현재 배송 중인 주문들만 필터로 빠르게 조회
+```
+
+**56. 사용자 반품 신청 플로우 없음**
+
+`PATCH /api/shipments/orders/{orderId}/return`은 ADMIN 전용이다.
+사용자가 반품을 신청하면 관리자가 처리하는 일반적인 쇼핑몰 흐름을 구현할 수 없다.
+현재 사용자가 할 수 있는 건 `POST /api/refunds` 환불 요청뿐이지만, 실물 반품과 환불은 별개 프로세스다.
+
+```
+필요: POST /api/shipments/orders/{orderId}/return-request
+     Body: { reason, bankName, accountNumber, accountHolder }  (환불 계좌 정보)
+     → 관리자가 /api/shipments/orders/{orderId}/return으로 최종 처리
+```
+
+**57. 포인트 적립분 만료 예정일 없음**
+
+`PointTransactionType.EXPIRE`가 정의되어 있어 포인트 소멸은 처리되지만,
+EARN 시 해당 포인트가 언제 만료되는지 `PointTransaction`·`PointTransactionResponse` 어디에도 기록되지 않는다.
+"이번 달 말 2,500P 소멸 예정" 알림 및 포인트 이력 표시 불가.
+
+```
+개선: PointTransaction 엔티티에 expiredAt: LocalDateTime 추가 (EARN 시 1년 후 등 정책 적용)
+     PointTransactionResponse에 expiredAt 포함
+     필요: GET /api/points/expiring-soon?withinDays=30
+          → 30일 내 소멸 예정 포인트 목록
+```
+
+**58. Refresh Token 만료 시간 미노출**
+
+`LoginResponse`: `{ accessToken, tokenType, expiresIn, refreshToken }`.
+`expiresIn`은 access token 만료 초(예: 3600)이고 refresh token 만료 시간은 없다.
+Refresh Token은 30일 TTL(Redis)인데, 사용자에게 "30일 후 재로그인 필요" 사전 안내가 불가하고,
+프론트에서 refresh 요청 시점 판단을 위한 expiry 계산도 불가.
+
+```
+개선: LoginResponse에 refreshTokenExpiresAt: LocalDateTime 추가
+     또는 refreshExpiresIn: long (초 단위)
+```
+
+**59. 사용자 친화적 주문 번호 없음**
+
+`OrderResponse.id`는 DB auto-increment Long이 그대로 노출된다 (예: `142`).
+CS 문의 시 "주문번호를 알려주세요" → "142번" 같은 상황이 발생하고,
+경쟁사가 주문 생성 빈도를 역산할 수 있는 정보 노출 문제도 있다.
+
+```
+개선: OrderResponse에 orderNumber: String 추가
+     형식 예시: "20240418-0000142" (날짜 + zero-padded id)
+     → V? migration: orders.order_number GENERATED ALWAYS 또는 애플리케이션 레벨 생성
+```
+
+---
+
+### 🟡 중장기
+
+**60. 가상계좌 입금 정보 없음**
+
+Toss 가상계좌 결제 시 사용자에게 안내할 은행명·계좌번호·입금 기한이 `PaymentResponse`에 없다.
+가상계좌 방식 결제를 지원하려면 별도 Toss API 조회가 필요하거나 Webhook 수신 후 저장해야 한다.
+
+```
+개선: PaymentResponse에 virtualAccount 필드 추가 (nullable, 가상계좌 결제 시만)
+     { bank, accountNumber, dueDate: LocalDateTime }
+```
+
+**61. 배송비 정책 API 없음**
+
+`OrderPreviewResponse.shippingFee`는 항상 0 (무료배송 하드코딩, 주석 확인).
+배송비 정책이 바뀌어도 프론트 코드를 수정해야 하고, 상품 상세·장바구니에서
+"XX원 이상 무료배송" 문구를 동적으로 표시할 수 없다.
+
+```
+필요: GET /api/shipping/policy
+     → { freeShippingThreshold, defaultFee, conditions: [...] }
+     (Admin에서 수정 가능하도록 DB 테이블 또는 설정 관리)
+```
+
+**62. 상품 Q&A 없음**
+
+상품 상세 페이지의 Q&A 탭은 한국 쇼핑몰에서 필수 UI다. 문의 등록·답변 플로우 전체가 없다.
+
+```
+필요: GET    /api/products/{productId}/qna?page=
+      POST   /api/products/{productId}/qna           (구매자·비구매자 모두 가능)
+      POST   /api/products/{productId}/qna/{id}/answer  (ADMIN 또는 판매자)
+      DELETE /api/products/{productId}/qna/{id}      (작성자 또는 ADMIN)
+```
+
+---
+
+### 5차 요약
+
+| 우선순위 | 항목 | 근거 |
+|---|---|---|
+| 🔴 필수 | `@Valid` 에러 필드별 구조 없음 | `GlobalExceptionHandler` join() 확인 — 폼 인라인 에러 불가 |
+| 🟠 중요 | 내 배송 목록 API 없음 | `ShipmentController` 단건 조회만 존재 |
+| 🟠 중요 | 사용자 반품 신청 없음 | `return` 엔드포인트가 ADMIN 전용 |
+| 🟠 중요 | 포인트 만료 예정일 없음 | `PointTransaction`에 `expiredAt` 미존재, EXPIRE 타입은 있음 |
+| 🟠 중요 | Refresh Token 만료 시간 없음 | `LoginResponse` 필드 확인 — access token expiry만 있음 |
+| 🟠 중요 | 사용자 친화적 주문 번호 없음 | DB id 그대로 노출 |
+| 🟡 중장기 | 가상계좌 입금 정보 없음 | `PaymentResponse`에 가상계좌 상세 없음 |
+| 🟡 중장기 | 배송비 정책 API 없음 | `shippingFee=0` 하드코딩 |
+| 🟡 중장기 | 상품 Q&A 없음 | 한국 쇼핑몰 필수 기능 |

--- a/docs/ToDoFrontRequest.md
+++ b/docs/ToDoFrontRequest.md
@@ -111,3 +111,356 @@
 | 리뷰 정렬/필터 | 3차 |
 | 장바구니 선택 결제 | 3차 |
 | 이미지 순서 변경 API | 3차 |
+
+---
+
+## 2차 검토 — 시니어 프론트엔드 관점 추가 항목
+
+---
+
+### 🔴 필수 — 없으면 서비스 운영 불가
+
+**17. 비밀번호 찾기/재설정 API 없음**
+
+현재 `PATCH /api/users/me/password`(기존 비밀번호 필요)만 있다.
+비밀번호를 잊은 사용자는 계정 복구 수단이 전혀 없다 — 실서비스에선 CS 문의 폭발.
+
+```
+필요: POST /api/auth/forgot-password   { email }
+      POST /api/auth/reset-password    { token, newPassword }
+흐름: 이메일로 재설정 링크 발송 → 토큰 검증 → 비밀번호 교체
+```
+
+**18. 배송지 수령인 정보 없음**
+
+`DeliveryAddressResponse`에 `address`, `postalCode`는 있지만 `recipientName`, `recipientPhone`이 없다.
+한국 택배는 수령인 이름·연락처가 운송장 필수 항목이다. 주문자 != 수령인(선물) 케이스도 흔하다.
+
+```
+현재: { id, address, detailAddress, postalCode, isDefault }
+필요: { id, recipientName, recipientPhone, address, detailAddress, postalCode, isDefault }
+```
+
+---
+
+### 🟠 중요 — N+1 또는 UX 치명적 결함
+
+**19. 위시리스트 목록에 상품 상세 미포함 (N+1)**
+
+`GET /api/wishlist` 응답: `{ id, productId, userId, createdAt }` — 상품명·가격·이미지·재고 없음.
+위시리스트 페이지를 렌더링하려면 `productId` 개수만큼 `GET /api/products/{id}`를 반복 호출해야 한다.
+
+```
+개선: GET /api/wishlist 응답에 product 필드 포함
+     { id, productId, createdAt, product: { name, price, thumbnailUrl, availableQuantity, status } }
+```
+
+**20. 위시리스트 페이지네이션 없음**
+
+`GET /api/wishlist`는 `List<>` 반환 — 위시리스트가 100건 이상이면 전체를 한번에 불러온다.
+
+```
+개선: GET /api/wishlist?page=&size= → Page<WishlistResponse>
+```
+
+**21. 리뷰 별점 분포 통계 없음**
+
+상품 상세 페이지의 별점 히스토그램(★5: 42건, ★4: 18건 ...) 구현 불가.
+현재 `avgRating`·`reviewCount`만 있고 분포가 없다. 클라이언트에서 계산하려면 전체 리뷰를 다 가져와야 한다.
+
+```
+필요: GET /api/products/{id}/reviews/stats
+     → { avgRating, reviewCount, distribution: { 1:n, 2:n, 3:n, 4:n, 5:n } }
+```
+
+**22. 주문 상세에 환불 정보 미포함**
+
+`GET /api/orders/{id}/detail` 응답: `{ order, payment, shipment }` — `refund` 없음.
+마이페이지 주문 상세에서 환불 진행 상황을 보려면 `paymentKey`로 `/api/refunds/payments/{paymentId}`를 추가 호출해야 한다.
+
+```
+개선: GET /api/orders/{id}/detail 응답에 refund 필드 추가
+     { order, payment, shipment, refund }
+```
+
+**23. `OrderPreviewResponse` 필드 미흡**
+
+현재 응답: `{ totalAmount, discountAmount, usedPoints, finalAmount }`.
+결제 화면에서 필요한 항목이 누락되어 클라이언트가 직접 계산해야 한다.
+
+```
+현재: { totalAmount, discountAmount, usedPoints, finalAmount }
+필요: { originalAmount, couponDiscount, pointDiscount,
+        shippingFee, finalAmount, earnablePoints }
+```
+→ `couponDiscount`(쿠폰 할인액), `shippingFee`(배송비), `earnablePoints`(결제 시 적립 예정 포인트) 누락.
+
+**24. 주문 취소 사유 없음**
+
+`POST /api/orders/{id}/cancel` 요청 바디 없음 — 취소 사유를 받지 않는다.
+운영 분석, CS 처리, 취소 이력 표시에 필요하다.
+
+```
+개선: POST /api/orders/{id}/cancel  Body: { reason: string (optional) }
+```
+
+---
+
+### 🟡 중장기 — UX 완성도·신규 기능
+
+**25. 검색 자동완성 API 없음**
+
+검색창 입력 시 실시간 추천어(상품명 prefix 매칭)가 없다.
+현재 `GET /api/products?q=` 전체 검색만 있어 키 입력마다 호출하기 부적합하다.
+
+```
+필요: GET /api/products/search/suggestions?q=티셔
+     → { suggestions: ["티셔츠", "티셔츠 반팔", ...] }  (Elasticsearch prefix query)
+```
+
+**26. 소셜 로그인 없음**
+
+한국 쇼핑몰에서 카카오·네이버 로그인은 사실상 필수다.
+현재 username/password 방식만 있어 전환율에 직접적인 영향을 준다.
+
+```
+필요: GET  /api/auth/oauth2/{provider}          (provider: kakao | naver | google)
+      GET  /api/auth/oauth2/{provider}/callback  (Redirect URI)
+```
+
+**27. 이메일 인증 없음**
+
+회원가입 후 이메일 인증 단계가 없다.
+스팸 계정 방지, 비밀번호 재설정(#17) 연동에 모두 필요하다.
+
+```
+필요: POST /api/auth/email/verify-send    { email }   (인증 메일 발송)
+      POST /api/auth/email/verify-confirm { token }   (토큰 확인)
+```
+
+**28. `UserResponse`에 전화번호 없음**
+
+마이페이지 프로필, 배송지 자동 채우기, 본인 인증에 필요하다.
+현재 `{ id, username, email, role, createdAt, pointBalance }` — `phoneNumber` 없음.
+
+```
+개선: UserResponse에 phoneNumber: String 추가
+     PATCH /api/users/me Body에 phoneNumber 수정 지원
+```
+
+**29. 포인트 적립 예정 내역 없음**
+
+결제 완료 후 "이 주문에서 N포인트 적립 예정" 표시가 불가하다.
+현재 `GET /api/points/history`는 이미 확정된 이력만 반환한다.
+
+```
+개선: PointTransactionResponse에 status (PENDING | CONFIRMED | EXPIRED) 추가
+     또는: GET /api/points/pending → 적립 예정 포인트 목록
+```
+
+**30. 상품 재입고 알림 신청 없음**
+
+품절 상품(`availableQuantity=0`) 페이지에서 "재입고 알림 신청" 버튼을 구현할 수 없다.
+
+```
+필요: POST   /api/products/{id}/restock-notify    (알림 신청)
+      DELETE /api/products/{id}/restock-notify    (신청 취소)
+      GET    /api/users/me/restock-notifications  (신청 목록)
+```
+
+**31. 최근 본 상품 없음**
+
+"최근 본 상품" 위젯은 쇼핑몰 체류 시간을 높이는 핵심 기능이다.
+현재 상품 조회 이력을 서버에서 관리하지 않아 클라이언트 localStorage에만 의존해야 한다 (기기 간 공유 불가).
+
+```
+필요: POST /api/users/me/recently-viewed       { productId }  (조회 시 자동 기록)
+      GET  /api/users/me/recently-viewed?size=10
+```
+
+---
+
+### 2차 요약
+
+| 우선순위 | 항목 | 이유 |
+|---|---|---|
+| 🔴 필수 | 비밀번호 찾기/재설정 | 사용자 계정 복구 수단 전무 |
+| 🔴 필수 | 배송지 수령인 정보 | 운송장 필수 항목 누락 |
+| 🟠 중요 | 위시리스트 상품 상세 포함 | N+1 요청 방지 |
+| 🟠 중요 | 위시리스트 페이지네이션 | 대량 데이터 처리 |
+| 🟠 중요 | 리뷰 별점 분포 통계 | 상품 상세 핵심 UI |
+| 🟠 중요 | 주문 상세에 환불 정보 포함 | 마이페이지 round-trip 제거 |
+| 🟠 중요 | `OrderPreviewResponse` 필드 보완 | 결제 화면 정확한 정보 표시 |
+| 🟠 중요 | 주문 취소 사유 | CS/운영 분석 |
+| 🟡 중장기 | 검색 자동완성 | 검색 UX |
+| 🟡 중장기 | 소셜 로그인 | 전환율 |
+| 🟡 중장기 | 이메일 인증 | 보안·스팸 방지 |
+| 🟡 중장기 | `UserResponse` 전화번호 | 프로필 완성도 |
+| 🟡 중장기 | 포인트 적립 예정 내역 | 결제 UX |
+| 🟡 중장기 | 재입고 알림 신청 | 구매 전환율 |
+| 🟡 중장기 | 최근 본 상품 | 체류 시간·재방문 유도 |
+
+---
+
+## 2차 정오표
+
+> 2차 작성 시 탐색 오류로 잘못 파악한 항목을 정정합니다.
+
+**#18 배송지 수령인 정보 없음** → ✅ 이미 구현됨
+`DeliveryAddressResponse`에 `recipient`, `phone`, `alias`, `zipCode`, `address1`, `address2` 이미 포함. 해당 항목 무효.
+
+**#23 `OrderPreviewResponse` 필드 미흡** → ✅ 이미 구현됨
+`OrderPreviewResponse`에 `originalAmount`, `couponDiscount`, `pointDiscount`, `shippingFee`, `finalAmount`, `earnablePoints` 모두 포함. 해당 항목 무효.
+
+**#19 위시리스트 N+1** → 🔶 부분 구현됨
+`WishlistResponse`에 `productName`, `productPrice`, `thumbnailUrl`은 포함되어 있으나 `availableQuantity`(재고), `status`(판매 상태)는 없음. 품절/단종 배지 표시 불가.
+
+---
+
+## 3차 검토 — 구조적 결함 및 UX 완성도
+
+---
+
+### 🔴 구조적 한계 — 카테고리 전체에 영향
+
+**32. 상품 옵션/변형(variants) 없음**
+
+`Product` 1개 = SKU 1개. 색상·사이즈 선택 개념이 없다.
+의류·신발·가방 카테고리를 다루는 순간 구현 불가. "블랙 M", "화이트 L"을 각각 다른 상품으로 등록해야 하는데, 단일 상품 상세 페이지에서 옵션 선택 → 재고 확인 → 장바구니 추가 플로우가 원천 불가능하다.
+
+```
+필요: Product ─┬─ ProductOption (color, size ...)
+               └─ ProductVariant (optionValues 조합, 자체 price/sku/inventory)
+
+GET /api/products/{id} 응답에 variants 배열 포함
+POST /api/orders → OrderItemRequest.variantId
+```
+
+---
+
+### 🟠 중요 — 결제·주문 흐름 결함
+
+**33. 결제 실패 후 재결제 불가**
+
+`V8 migration`에서 `payments.order_id UNIQUE` 제약이 추가되었다. 결제가 FAILED 상태가 되면 동일 주문으로 `POST /api/payments/prepare`를 재호출해도 UNIQUE 충돌이 발생한다. 프론트에서 "다시 결제하기" 버튼을 구현할 방법이 없다.
+
+```
+현재: payments.order_id UNIQUE → FAILED 상태에서 재결제 시 DB 제약 위반
+필요: 아래 중 하나 선택
+  A) FAILED 결제를 PENDING으로 reset 후 재시도 허용
+  B) payments.order_id UNIQUE 제거 + (order_id, status) 복합 제약으로 교체
+  C) POST /api/payments/{orderId}/retry 엔드포인트 추가
+```
+
+**34. `OrderResponse`에 배송지 스냅샷 없음**
+
+`OrderResponse.deliveryAddressId`만 있다. 사용자가 이후 배송지를 삭제하면 `delivery_addresses.ON DELETE SET NULL`로 인해 `deliveryAddressId`가 null이 된다. 주문 이력에서 실제 배송된 주소를 볼 수 없는 상황이 발생한다.
+
+```
+필요: OrderResponse에 snapshotAddress 필드 추가
+     { recipientName, phone, address1, address2, zipCode }
+     → 주문 생성 시점 주소를 order_delivery_snapshots 테이블에 별도 저장
+```
+
+**35. 주문 아이템별 부분 취소 없음**
+
+`POST /api/orders/{id}/cancel`은 전체 주문 취소만 가능하다. "10종류 상품 중 품절된 3개만 취소" 같은 부분 취소 플로우를 구현할 수 없다. 쇼핑몰 운영 중 흔히 발생하는 시나리오다.
+
+```
+필요: POST /api/orders/{id}/items/cancel
+     Body: { itemIds: [1, 3, 5], reason: "..." }
+```
+
+**36. `WishlistResponse`에 재고·판매 상태 미포함**
+
+`productName`, `productPrice`, `thumbnailUrl`은 있지만 `availableQuantity`, `status`가 없다.
+위시리스트에 담긴 상품이 품절/단종되었을 때 "품절" 오버레이 배지를 표시할 수 없다.
+
+```
+개선: WishlistResponse에 추가
+     availableQuantity: int
+     productStatus: ProductStatus (ACTIVE | DISCONTINUED)
+```
+
+**37. 내 결제 목록에 주문 상품 정보 없음**
+
+`GET /api/payments/my` 응답인 `PaymentResponse`는 `orderId`만 있다. 결제 내역 페이지("무엇을 결제했나")를 표시하려면 각 `orderId`로 `GET /api/orders/{id}`를 추가 호출해야 한다.
+
+```
+개선: PaymentResponse에 orderSummary 필드 추가
+     { orderName, itemCount, thumbnailUrl }
+     → Payment 생성 시 snapshots 저장 또는 JOIN 쿼리로 포함
+```
+
+---
+
+### 🟡 중장기 — UX 완성도
+
+**38. 공개 쿠폰 다운로드 목록 없음**
+
+`GET /api/coupons`는 ADMIN 전용이다. 일반 사용자에게 "다운로드 가능한 쿠폰 목록" 페이지를 보여줄 수 없다. 현재 사용자는 코드를 이미 알고 있어야만 `POST /api/coupons/claim`으로 등록 가능하다.
+
+```
+필요: GET /api/coupons/public?page=&size=
+     → 공개 쿠폰만 반환 (isPublic=true, active=true, 기간 유효, 수량 여유)
+     → "쿠폰 다운로드" 버튼: POST /api/coupons/claim { couponCode }
+```
+
+**39. 상품 정렬 옵션 부족**
+
+현재 ES 정렬: `price_asc`, `price_desc`, `newest`, `relevance` 4가지뿐이다.
+"판매량 순", "리뷰 많은 순" 없음 — 쇼핑몰에서 가장 많이 쓰이는 정렬 2가지가 빠져 있다.
+
+```
+개선: sort 파라미터에 추가
+     popular  → 누적 판매량 기준 (daily_order_stats 활용)
+     review   → reviewCount 내림차순
+```
+
+**40. 배송 예상 도착일 없음**
+
+`ShipmentResponse`에 `shippedAt`, `deliveredAt`(실제 배송 완료)은 있지만 `estimatedDeliveryAt`(예상 도착일)이 없다. "예상 배송일: 4월 20일(월)" 표시 불가.
+
+```
+개선: ShipmentResponse에 estimatedDeliveryAt: LocalDate 추가
+     PATCH /api/shipments/orders/{orderId}/ship Body에 estimatedDeliveryAt 포함
+```
+
+**41. 홈 화면 전용 집계 API 없음**
+
+홈 화면 구성에 필요한 데이터(신상품, 인기상품, 진행 중인 이벤트/배너, 추천 카테고리)를 모으려면 최소 3~4번의 개별 API를 병렬 호출해야 한다. SSR/SSG 환경에서는 직접적인 성능 문제가 된다.
+
+```
+필요: GET /api/home
+     → { banners, newArrivals, popularProducts, featuredCategories }
+     → 서버에서 Redis 캐시 기반으로 단일 응답 반환 (TTL: 5~10분)
+```
+
+**42. 결제 수단 상세 정보 없음**
+
+`PaymentResponse.method`는 단순 String이다. 카드 결제인 경우 카드사, 카드 번호 뒷 4자리가 없어 "KB국민카드 ****1234" 표시 불가. 가상계좌인 경우 은행명·계좌번호 없음.
+
+```
+개선: PaymentResponse에 methodDetail 필드 추가 (nullable)
+     카드:     { cardCompany, cardNumber(마스킹), installmentPlanMonths }
+     가상계좌: { bank, accountNumber, dueDate }
+     계좌이체: { bank }
+```
+
+---
+
+### 3차 요약
+
+| 우선순위 | 항목 | 이유 |
+|---|---|---|
+| 🔴 구조적 | 상품 옵션/variants 없음 | 의류·신발 등 카테고리 구현 불가 |
+| 🟠 중요 | 결제 실패 후 재결제 불가 | order_id UNIQUE 제약 — 사용자 이탈 |
+| 🟠 중요 | OrderResponse 배송지 스냅샷 누락 | 주문 이력 데이터 유실 |
+| 🟠 중요 | 주문 아이템별 부분 취소 없음 | 일상적 운영 시나리오 미지원 |
+| 🟠 중요 | WishlistResponse 재고/상태 미포함 | 품절 배지 표시 불가 |
+| 🟠 중요 | 내 결제 목록 주문 상품 정보 없음 | 결제 내역 N+1 |
+| 🟡 중장기 | 공개 쿠폰 다운로드 목록 | 마케팅 쿠폰 배포 불가 |
+| 🟡 중장기 | 상품 정렬 옵션 부족 | popular/review 정렬 없음 |
+| 🟡 중장기 | 배송 예상 도착일 없음 | 배송 UX |
+| 🟡 중장기 | 홈 화면 집계 API 없음 | SSR 성능 |
+| 🟡 중장기 | 결제 수단 상세 정보 없음 | 결제 내역 표시 |

--- a/docs/ToDoFrontRequest.md
+++ b/docs/ToDoFrontRequest.md
@@ -464,3 +464,172 @@ POST /api/orders → OrderItemRequest.variantId
 | 🟡 중장기 | 배송 예상 도착일 없음 | 배송 UX |
 | 🟡 중장기 | 홈 화면 집계 API 없음 | SSR 성능 |
 | 🟡 중장기 | 결제 수단 상세 정보 없음 | 결제 내역 표시 |
+
+---
+
+## 4차 검토 — API 인터페이스 결함 및 데이터 누락
+
+---
+
+### 🔴 필수 — 개발 시작 전 합의 필요
+
+**43. 에러 응답에 머신-리더블 코드 없음**
+
+`ApiResponse` 에러 응답 구조: `{ success: false, message: "재고가 부족합니다." }`.
+`message`는 사람이 읽는 한국어 문자열이고 기계가 읽는 에러 코드가 없다.
+프론트에서 에러 종류별로 다른 UX(토스트/모달/인라인 메시지)를 적용하려면 `message` 텍스트를 직접 비교해야 한다 — i18n 불가, 문자열 변경 시 프론트 코드 깨짐.
+
+```
+현재: { success: false, message: "재고가 부족합니다." }
+필요: { success: false, code: "INSUFFICIENT_STOCK", message: "재고가 부족합니다." }
+     → code는 ErrorCode enum name() 그대로 사용
+```
+
+**44. Spring Security 에러와 일반 에러 응답 형식 불일치**
+
+`GlobalExceptionHandler`는 `BusinessException` 등을 `ApiResponse` 형식으로 처리하지만,
+Spring Security 필터 레이어의 401(미인증)/403(권한 없음) 에러는 `AuthenticationEntryPoint`/`AccessDeniedHandler`가 별도 설정되지 않아 Spring Boot 기본 형식(`{ timestamp, status, error, path }`)으로 반환된다.
+프론트 에러 인터셉터가 두 가지 형식을 모두 처리해야 하는 문제가 생긴다.
+
+```
+현재: 
+  401/403 → { timestamp: ..., status: 403, error: "Forbidden", path: "/api/orders" }
+  비즈니스 에러 → { success: false, message: "..." }
+
+필요: 모든 에러 → { success: false, code: "...", message: "..." }
+  → SecurityConfig에 authenticationEntryPoint/accessDeniedHandler 추가
+```
+
+---
+
+### 🟠 중요 — 이미지 및 데이터 누락
+
+**45. `OrderItemResponse`에 썸네일 없음**
+
+`OrderItemResponse` 필드: `id`, `productId`, `productName`, `quantity`, `unitPrice`, `subtotal`, `hasReview`.
+`thumbnailUrl`이 없다. 주문 목록·상세 페이지에서 상품 이미지를 표시하려면 `productId`마다 `GET /api/products/{id}`를 반복 호출해야 한다.
+주문 당시 이미지가 이후 변경될 수도 있으므로 스냅샷 저장이 올바른 방향이다.
+
+```
+개선: OrderItemResponse에 추가
+     thumbnailUrl: String  (주문 당시 thumbnailUrl 스냅샷)
+```
+
+**46. `CartItemResponse`에 썸네일 없음**
+
+`CartItemResponse` 필드: `productId`, `productName`, `unitPrice`, `quantity`, `subtotal`, `availableQuantity`, `isAvailable`.
+장바구니 화면에서 상품 이미지를 표시할 방법이 없다. `productId`로 별도 조회 필요.
+
+```
+개선: CartItemResponse에 추가
+     thumbnailUrl: String
+```
+
+**47. 장바구니 가격 변동 감지 없음**
+
+`CartItemResponse.unitPrice`는 `Product.price`를 실시간으로 참조한다 (스냅샷 아님).
+장바구니에 담은 이후 가격이 인하/인상되어도 프론트에서 이를 감지할 수 없다.
+"이 상품의 가격이 변경되었습니다 (10,000원 → 8,000원)" 알림 구현 불가.
+
+```
+개선: CartItemResponse에 추가
+     originalPrice: BigDecimal   (장바구니에 담을 당시 가격)
+     currentPrice: BigDecimal    (현재 가격)
+     priceChanged: Boolean       (originalPrice != currentPrice)
+```
+
+**48. `CategoryResponse`에 상품 수 없음**
+
+네비게이션 메뉴나 카테고리 탐색 페이지에서 "상의 (234)", "하의 (189)" 같은 상품 수 표시가 일반적이다.
+현재 `CategoryResponse`에는 `id`, `name`, `description`, `parentId`, `children` 만 있다.
+
+```
+개선: CategoryResponse에 productCount: long 추가
+     (하위 포함 여부를 boolean includeChildren 파라미터로 선택)
+```
+
+**49. `MyCouponResponse`에 사용 주문 정보 없음**
+
+사용된 쿠폰이 "어떤 주문에서 얼마나 할인되었는지" 알 수 없다.
+쿠폰 이력 페이지("2024-04-01 주문 #12345에서 3,000원 할인")를 구현하려면 별도 데이터가 필요하다.
+
+```
+개선: MyCouponResponse에 추가 (사용된 쿠폰인 경우)
+     usedAt: LocalDateTime
+     usedOrderId: Long
+     actualDiscountAmount: BigDecimal
+```
+
+---
+
+### 🟡 중장기 — API 설계 일관성
+
+**50. 페이지네이션 전략 혼재 (Page vs CursorPage)**
+
+주문 목록 조회가 두 가지 방식으로 중복 존재한다:
+- `GET /api/orders` → `Page<OrderResponse>` (offset 기반)
+- `GET /api/orders/scroll` → `CursorPage<OrderResponse>` (커서 기반)
+
+재고 이력은 `CursorPage`, 상품/카테고리/쿠폰은 `Page`. 어떤 API가 어떤 방식인지 패턴이 없다.
+프론트에서 API마다 다른 페이지네이션 로직을 작성해야 하고, 무한 스크롤과 페이지 번호 UI를 각각 구현해야 한다.
+
+```
+개선 방향 합의 필요:
+  - 목록 기본: Page (어드민 테이블, 정렬 가능한 목록)
+  - 무한 스크롤: CursorPage (피드형 목록)
+  - GET /api/orders/scroll 제거 또는 GET /api/orders에 통합
+```
+
+**51. 재고 수량 직접 노출 정책 미비**
+
+`ProductResponse.availableQuantity`, `CartItemResponse.availableQuantity` 등에서 정확한 재고 숫자를 그대로 노출한다.
+경쟁사가 API를 통해 재고 현황을 파악하거나, 사용자가 "재고 9개" 보다 "품절 임박" 뱃지가 더 구매 전환에 효과적이다.
+
+```
+개선 방향 합의 필요:
+  A) 임계값 이하만 숫자 표시: 10개 이상 → null, 10개 미만 → 실제 숫자
+  B) 단계별 표시: IN_STOCK | LOW_STOCK | OUT_OF_STOCK enum 반환
+  C) 현행 유지 (정확한 숫자 노출)
+```
+
+**52. 부분 환불 지원 여부 불명확**
+
+`POST /api/payments/{paymentKey}/cancel` API가 전액 취소만 지원하는지, 금액 지정 부분 취소도 가능한지 문서·응답만으로 판단 불가.
+다품목 주문에서 특정 상품만 환불하는 UX를 구현하려면 부분 취소 지원이 필수다.
+
+```
+명확화 필요: POST /api/payments/{paymentKey}/cancel Body에
+     amount: BigDecimal (지정 안 하면 전액, 지정 시 부분 취소)
+     → Toss Payments API 부분 취소 지원 여부와 연동 필요
+```
+
+**53. 인앱 알림 시스템 없음**
+
+주문 상태 변경(결제 완료, 배송 출고 등)을 실시간으로 사용자에게 전달할 방법이 없다.
+이메일 발송(`EmailService`)은 있지만 앱/웹 내 알림 UI(헤더 벨 아이콘, 읽지 않은 알림 수)를 구현할 수 없다.
+
+```
+필요: 
+  GET  /api/notifications?read=false&page=
+  POST /api/notifications/{id}/read
+  GET  /api/notifications/unread-count
+  → SSE(Server-Sent Events) 또는 주기적 polling 방식 선택 필요
+```
+
+---
+
+### 4차 요약
+
+| 우선순위 | 항목 | 핵심 이유 |
+|---|---|---|
+| 🔴 필수 | 에러 응답에 `errorCode` 없음 | 에러 종류 구분 불가 — i18n·조건부 UX 불가 |
+| 🔴 필수 | Security 에러 형식 불일치 | 인터셉터 구현 복잡 |
+| 🟠 중요 | `OrderItemResponse` 썸네일 없음 | 주문 목록 이미지 N+1 |
+| 🟠 중요 | `CartItemResponse` 썸네일 없음 | 장바구니 이미지 N+1 |
+| 🟠 중요 | 장바구니 가격 변동 감지 없음 | 스냅샷 구조 부재 |
+| 🟠 중요 | `CategoryResponse` 상품 수 없음 | 네비게이션 UX |
+| 🟠 중요 | `MyCouponResponse` 사용 주문 없음 | 쿠폰 이력 UX |
+| 🟡 중장기 | 페이지네이션 전략 혼재 | 프론트 구현 복잡성 |
+| 🟡 중장기 | 재고 수량 직접 노출 정책 | 비즈니스 정책 결정 필요 |
+| 🟡 중장기 | 부분 환불 지원 여부 불명확 | 다품목 환불 UX |
+| 🟡 중장기 | 인앱 알림 시스템 없음 | 실시간 상태 알림 |

--- a/docs/ToDoFrontRequest.md
+++ b/docs/ToDoFrontRequest.md
@@ -3,146 +3,111 @@
 
 ## 프론트엔드 관점 API 검토 — 쇼핑몰
 
-### 🔴 결제 흐름 — 없으면 구현 불가
+> **전체 16개 항목 모두 구현 완료** (1차·2차·3차 커밋)
 
-**1. `PaymentPrepareResponse`에 Toss 결제창 필수 필드 누락**
+### 🔴 결제 흐름
 
-현재 응답: `tossOrderId`, `amount`만 반환.
-Toss 결제창(`loadTossPayments()`) 초기화에는 `orderName`(상품명 요약), `customerName`(구매자 이름), `customerEmail`이 필수 파라미터다. 현재 프론트가 이걸 채우려면 `/api/orders/{id}` → `/api/users/me`를 추가로 2번 호출해야 한다.
+**~~1. `PaymentPrepareResponse`에 Toss 결제창 필수 필드 누락~~ ✅ 완료 (1차)**
 
-```
-현재: { tossOrderId, amount }
-필요: { tossOrderId, amount, orderName, customerName, customerEmail }
-```
+`orderName`, `customerName`, `customerEmail` 필드 추가.
+응답: `{ tossOrderId, amount, orderName, customerName, customerEmail }`
 
-**2. 주문 최종 금액 계산 API 없음**
+**~~2. 주문 최종 금액 계산 API 없음~~ ✅ 완료 (1차)**
 
-주문 생성 전 "쿠폰 + 포인트 복합 적용 시 최종 결제 금액" 미리보기가 없다. `/api/coupons/validate`는 쿠폰 할인만 계산하고 포인트를 반영하지 않는다. 결제 화면에서 "쿠폰 적용 + 포인트 5,000P 사용 시 최종 금액은?" 같은 계산을 클라이언트에서 직접 해야 하는데, 쿠폰 할인 계산 로직(PERCENTAGE cap, minimumOrderAmount 등)이 서버에만 있다.
-
-```
-필요: POST /api/orders/preview
-     { items, couponCode, usePoints, deliveryAddressId }
-     → { originalAmount, couponDiscount, pointDiscount, shippingFee, finalAmount, earnablePoints }
-```
+`POST /api/orders/preview` 구현.
+`{ items, couponCode, usePoints, deliveryAddressId }` → `{ originalAmount, couponDiscount, pointDiscount, shippingFee, finalAmount, earnablePoints }`
 
 ---
 
-### 🟠 목록 조회 — N+1 요청을 강요하는 구조
+### 🟠 목록 조회
 
-**3. 주문 목록에 배송 상태 없음**
+**~~3. 주문 목록에 배송 상태 없음~~ ✅ 완료 (1차·2차)**
 
-`GET /api/orders`는 `OrderResponse`(주문 정보)만 반환한다. "내 주문 목록" 페이지에서 각 주문의 배송 상태(준비중/배송중/배송완료)를 표시하려면 주문 1건당 `GET /api/shipments/orders/{orderId}` 1번씩 추가 호출이 발생한다. 주문 20건 목록 = 최대 21번 요청.
+`OrderResponse.shipmentStatus` 추가. `findStatusMapByOrderIds()` 배치 쿼리로 N+1 방지.
 
-`OrderResponse` 또는 `OrderDetailResponse`를 목록 API에서도 선택적으로 내려주거나, `shipmentStatus` 필드 하나만 추가해도 해결된다.
+**~~4. 상품 목록에 위시리스트 여부(`wishlisted`) 없음~~ ✅ 완료 (2차)**
 
-**4. 상품 목록에 위시리스트 여부(`wishlisted`) 없음**
+`GET /api/products` 응답에 `wishlisted: Boolean` 포함 (비로그인 시 null).
 
-`GET /api/products` 응답에는 위시리스트 여부가 없다. 상품 카드마다 ♥ 아이콘 상태를 표시하려면 로그인 사용자 기준으로 `GET /api/wishlist` 전체 목록을 먼저 불러온 뒤 클라이언트에서 교차 대조해야 한다. 위시리스트 수천 건 보유 사용자라면 응답 페이로드도 크다.
+**~~5. 내 결제 목록 API 없음~~ ✅ 완료 (1차)**
 
-```
-개선: GET /api/products 응답에 wishlisted: boolean (비로그인 시 null 또는 false)
-```
+`GET /api/payments/my?page=&size=&status=` 구현.
 
-**5. 내 결제 목록 API 없음**
+**~~6. 내 환불 목록 API 없음~~ ✅ 완료 (1차)**
 
-현재 결제 조회는 `paymentKey` 또는 `orderId` 단건 조회만 있다. "내 결제 내역" 페이지(카드사 청구 확인용)를 구현하려면 주문 목록을 먼저 불러온 뒤 각 주문별 결제를 조회해야 한다.
-
-```
-필요: GET /api/payments/my?page=&size=&status=
-```
-
-**6. 내 환불 목록 API 없음**
-
-`GET /api/refunds/{id}`, `GET /api/refunds/payments/{paymentId}` 단건만 있고 목록이 없다.
-
-```
-필요: GET /api/refunds/my?page=&size=
-```
+`GET /api/refunds/my?page=&size=` 구현.
 
 ---
 
-### 🟡 상품/리뷰 — 완성도 문제
+### 🟡 상품/리뷰
 
-**7. 상품 상세에 "리뷰 작성 가능 여부" 없음**
+**~~7. 상품 상세에 "리뷰 작성 가능 여부" 없음~~ ✅ 완료 (1차)**
 
-리뷰 작성 버튼 노출 조건: 로그인 + 구매 완료 + 미작성. 현재 API로는 이 조건을 확인하려면 `GET /api/users/me/orders`를 모두 가져와 해당 상품이 포함된 CONFIRMED 주문이 있는지 + 이미 리뷰를 작성했는지(`PUT` 시도 시 에러로만 확인 가능)를 클라이언트에서 판단해야 한다.
+`GET /api/products/{id}` 응답에 `canReview: Boolean` 추가 (로그인 시 계산, 비로그인 시 null).
 
-```
-개선: GET /api/products/{id} 응답에 canReview: boolean (로그인 시만 계산, 비로그인은 false)
-     또는: GET /api/users/me/reviewable-products
-```
+**~~8. `ReviewResponse`에 작성자 정보 없음~~ ✅ 완료 (1차)**
 
-**8. `ReviewResponse`에 작성자 정보 없음**
+`ReviewResponse.username` 추가 (마스킹). `buildUsernameMap()` 배치 조회로 N+1 방지.
 
-`userId`만 있고 `username`이 없다. 리뷰 목록에서 "작성자: 홍**" 같은 마스킹 표시가 일반적인데, 현재는 불가능하다. 닉네임/마스킹 username 필드 추가 필요.
+**~~9. 리뷰 정렬/필터 없음~~ ✅ 완료 (3차)**
 
-**9. 리뷰 정렬/필터 없음**
+`GET /api/products/{productId}/reviews?rating=&sort=` 지원. 기본 정렬 `createdAt desc`.
 
-`GET /api/products/{productId}/reviews`는 최신순 고정이다. "별점 높은 순", "별점 낮은 순", "별점 N점만 보기" 필터가 없다. 리뷰 수가 많은 상품에서 UX 부족.
+**~~10. 내가 작성한 리뷰 목록 없음~~ ✅ 완료 (1차)**
 
-**10. 내가 작성한 리뷰 목록 없음**
-
-마이페이지 > 내 리뷰 관리 화면 구현 불가.
-
-```
-필요: GET /api/users/me/reviews?page=&size=
-```
+`GET /api/users/me/reviews?page=&size=` 구현.
 
 ---
 
-### 🟡 사용자 UX — 헤더/마이페이지
+### 🟡 사용자 UX
 
-**11. `GET /api/users/me` 응답에 포인트 잔액 없음**
+**~~11. `GET /api/users/me` 응답에 포인트 잔액 없음~~ ✅ 완료 (1차)**
 
-로그인 후 헤더에 포인트 잔액을 표시하는 패턴이 일반적이다. 현재는 페이지 진입마다 `GET /api/points/balance`를 별도 호출해야 한다. `UserResponse`에 `pointBalance: long` 하나만 추가하면 초기 렌더링 1 round-trip으로 해결된다.
+`UserResponse.pointBalance: Long` 추가.
 
-**12. 쿠폰 목록 필터 없음**
+**~~12. 쿠폰 목록 필터 없음~~ ✅ 완료 (1차)**
 
-`GET /api/coupons/my`는 전체 발급 쿠폰을 반환한다. "사용 가능한 것만", "만료된 것만" 탭 구현을 위한 `?usable=true` 같은 필터가 없다. 현재는 전체를 받아서 `isUsable`로 클라이언트 필터링해야 한다.
-
----
-
-### 🟡 기타 구현 시 불편한 부분
-
-**13. 장바구니 선택 결제 불가**
-
-`POST /api/cart/checkout`은 장바구니 전체를 주문으로 전환한다. 일부 상품만 선택해서 결제하는 기능이 없다. 선택 항목 ID 목록을 받는 파라미터 추가 필요.
-
-**14. 배송 추적 URL 없음**
-
-`ShipmentResponse`에 `carrier`(택배사)와 `trackingNumber`는 있지만 "배송 조회 바로가기" 딥링크 URL이 없다. 택배사별 트래킹 URL 매핑은 서버에서 해주는 게 관리가 편하다.
-
-```
-개선: trackingUrl: "https://www.cjlogistics.com/ko/tool/parcel/tracking?gnbInvcNo=1234"
-```
-
-**15. 상품 이미지 `sortOrder` 관리 API 없음**
-
-이미지 등록 / 삭제는 있지만 순서 변경(드래그 앤 드롭 정렬) API가 없다. `PATCH /api/products/{id}/images/order` 같은 순서 일괄 업데이트 필요.
-
-**16. 카테고리 하위 포함 상품 검색 불가**
-
-`GET /api/products?category=패션`으로 검색하면 "패션" 정확 일치만 동작한다. "패션 > 상의 > 티셔츠"처럼 하위 카테고리를 포함해서 검색하려면 프론트에서 카테고리 트리를 먼저 가져와 하위 ID를 모두 수집한 뒤 여러 번 요청해야 한다.
-
-```
-개선: ?categoryId=5&includeChildren=true  (또는 categoryId=5로 하위 포함 자동 처리)
-```
+`GET /api/coupons/my?usable=true` 지원.
 
 ---
 
-### 요약 우선순위
+### 🟡 기타
 
-| 우선순위 | 항목 | 이유 |
-|---|---|---|
-| 🔴 필수 | `PaymentPrepareResponse` 필드 보완 | 결제창 렌더링 불가 |
-| 🔴 필수 | 주문 금액 미리보기 API | 결제 전 UX 핵심 |
-| 🟠 중요 | 주문 목록에 `shipmentStatus` 포함 | N+1 요청 방지 |
-| 🟠 중요 | 내 결제/환불 목록 API | 마이페이지 기본 기능 |
-| 🟠 중요 | 상품 상세 `canReview` 필드 | 리뷰 버튼 노출 조건 |
-| 🟠 중요 | `ReviewResponse` 작성자 username | 리뷰 목록 표시 |
-| 🟡 중장기 | 상품 목록 `wishlisted` 포함 | 목록 N+1 제거 |
-| 🟡 중장기 | 내 리뷰 목록 API | 마이페이지 완성도 |
-| 🟡 중장기 | `UserResponse`에 포인트 잔액 포함 | 헤더 표시 최적화 |
-| 🟡 중장기 | 쿠폰 목록 usable 필터 | 쿠폰 탭 UX |
-| 🟡 중장기 | 카테고리 하위 포함 검색 | 상품 탐색 UX |
-| 🟡 중장기 | 배송 트래킹 URL | 배송 조회 UX |
+**~~13. 장바구니 선택 결제 불가~~ ✅ 완료 (3차)**
+
+`POST /api/cart/checkout` 요청에 `selectedProductIds: List<Long>` 추가. null=전체 결제, 지정 시 선택 상품만 주문 후 나머지 장바구니 유지.
+
+**~~14. 배송 추적 URL 없음~~ ✅ 완료 (1차)**
+
+`ShipmentResponse.trackingUrl` 추가. CJ대한통운·한진택배·롯데택배·우체국택배 자동 매핑. 미지원 배송사는 null.
+
+**~~15. 상품 이미지 `sortOrder` 관리 API 없음~~ ✅ 완료 (3차)**
+
+`PATCH /api/products/{productId}/images/order` 구현. `[{ imageId, displayOrder }]` 배열로 일괄 변경.
+
+**~~16. 카테고리 하위 포함 상품 검색 불가~~ ✅ 완료 (2차)**
+
+`GET /api/products?categoryId=5&includeChildren=true` 지원.
+
+---
+
+### 구현 완료 요약
+
+| 항목 | 커밋 |
+|---|---|
+| `PaymentPrepareResponse` 필드 보완 | 1차 |
+| 주문 금액 미리보기 API | 1차 |
+| 주문 목록 `shipmentStatus` | 1차·2차 |
+| 내 결제 목록 API | 1차 |
+| 내 환불 목록 API | 1차 |
+| 상품 상세 `canReview` | 1차 |
+| 리뷰 `username` 마스킹 | 1차 |
+| 내 리뷰 목록 API | 1차 |
+| `UserResponse` 포인트 잔액 | 1차 |
+| 쿠폰 `usable` 필터 | 1차 |
+| 배송 추적 URL | 1차 |
+| 상품 목록 `wishlisted` | 2차 |
+| 카테고리 하위 포함 검색 | 2차 |
+| 리뷰 정렬/필터 | 3차 |
+| 장바구니 선택 결제 | 3차 |
+| 이미지 순서 변경 API | 3차 |

--- a/docs/ToDoFrontRequest.md
+++ b/docs/ToDoFrontRequest.md
@@ -1,0 +1,148 @@
+
+---
+
+## 프론트엔드 관점 API 검토 — 쇼핑몰
+
+### 🔴 결제 흐름 — 없으면 구현 불가
+
+**1. `PaymentPrepareResponse`에 Toss 결제창 필수 필드 누락**
+
+현재 응답: `tossOrderId`, `amount`만 반환.
+Toss 결제창(`loadTossPayments()`) 초기화에는 `orderName`(상품명 요약), `customerName`(구매자 이름), `customerEmail`이 필수 파라미터다. 현재 프론트가 이걸 채우려면 `/api/orders/{id}` → `/api/users/me`를 추가로 2번 호출해야 한다.
+
+```
+현재: { tossOrderId, amount }
+필요: { tossOrderId, amount, orderName, customerName, customerEmail }
+```
+
+**2. 주문 최종 금액 계산 API 없음**
+
+주문 생성 전 "쿠폰 + 포인트 복합 적용 시 최종 결제 금액" 미리보기가 없다. `/api/coupons/validate`는 쿠폰 할인만 계산하고 포인트를 반영하지 않는다. 결제 화면에서 "쿠폰 적용 + 포인트 5,000P 사용 시 최종 금액은?" 같은 계산을 클라이언트에서 직접 해야 하는데, 쿠폰 할인 계산 로직(PERCENTAGE cap, minimumOrderAmount 등)이 서버에만 있다.
+
+```
+필요: POST /api/orders/preview
+     { items, couponCode, usePoints, deliveryAddressId }
+     → { originalAmount, couponDiscount, pointDiscount, shippingFee, finalAmount, earnablePoints }
+```
+
+---
+
+### 🟠 목록 조회 — N+1 요청을 강요하는 구조
+
+**3. 주문 목록에 배송 상태 없음**
+
+`GET /api/orders`는 `OrderResponse`(주문 정보)만 반환한다. "내 주문 목록" 페이지에서 각 주문의 배송 상태(준비중/배송중/배송완료)를 표시하려면 주문 1건당 `GET /api/shipments/orders/{orderId}` 1번씩 추가 호출이 발생한다. 주문 20건 목록 = 최대 21번 요청.
+
+`OrderResponse` 또는 `OrderDetailResponse`를 목록 API에서도 선택적으로 내려주거나, `shipmentStatus` 필드 하나만 추가해도 해결된다.
+
+**4. 상품 목록에 위시리스트 여부(`wishlisted`) 없음**
+
+`GET /api/products` 응답에는 위시리스트 여부가 없다. 상품 카드마다 ♥ 아이콘 상태를 표시하려면 로그인 사용자 기준으로 `GET /api/wishlist` 전체 목록을 먼저 불러온 뒤 클라이언트에서 교차 대조해야 한다. 위시리스트 수천 건 보유 사용자라면 응답 페이로드도 크다.
+
+```
+개선: GET /api/products 응답에 wishlisted: boolean (비로그인 시 null 또는 false)
+```
+
+**5. 내 결제 목록 API 없음**
+
+현재 결제 조회는 `paymentKey` 또는 `orderId` 단건 조회만 있다. "내 결제 내역" 페이지(카드사 청구 확인용)를 구현하려면 주문 목록을 먼저 불러온 뒤 각 주문별 결제를 조회해야 한다.
+
+```
+필요: GET /api/payments/my?page=&size=&status=
+```
+
+**6. 내 환불 목록 API 없음**
+
+`GET /api/refunds/{id}`, `GET /api/refunds/payments/{paymentId}` 단건만 있고 목록이 없다.
+
+```
+필요: GET /api/refunds/my?page=&size=
+```
+
+---
+
+### 🟡 상품/리뷰 — 완성도 문제
+
+**7. 상품 상세에 "리뷰 작성 가능 여부" 없음**
+
+리뷰 작성 버튼 노출 조건: 로그인 + 구매 완료 + 미작성. 현재 API로는 이 조건을 확인하려면 `GET /api/users/me/orders`를 모두 가져와 해당 상품이 포함된 CONFIRMED 주문이 있는지 + 이미 리뷰를 작성했는지(`PUT` 시도 시 에러로만 확인 가능)를 클라이언트에서 판단해야 한다.
+
+```
+개선: GET /api/products/{id} 응답에 canReview: boolean (로그인 시만 계산, 비로그인은 false)
+     또는: GET /api/users/me/reviewable-products
+```
+
+**8. `ReviewResponse`에 작성자 정보 없음**
+
+`userId`만 있고 `username`이 없다. 리뷰 목록에서 "작성자: 홍**" 같은 마스킹 표시가 일반적인데, 현재는 불가능하다. 닉네임/마스킹 username 필드 추가 필요.
+
+**9. 리뷰 정렬/필터 없음**
+
+`GET /api/products/{productId}/reviews`는 최신순 고정이다. "별점 높은 순", "별점 낮은 순", "별점 N점만 보기" 필터가 없다. 리뷰 수가 많은 상품에서 UX 부족.
+
+**10. 내가 작성한 리뷰 목록 없음**
+
+마이페이지 > 내 리뷰 관리 화면 구현 불가.
+
+```
+필요: GET /api/users/me/reviews?page=&size=
+```
+
+---
+
+### 🟡 사용자 UX — 헤더/마이페이지
+
+**11. `GET /api/users/me` 응답에 포인트 잔액 없음**
+
+로그인 후 헤더에 포인트 잔액을 표시하는 패턴이 일반적이다. 현재는 페이지 진입마다 `GET /api/points/balance`를 별도 호출해야 한다. `UserResponse`에 `pointBalance: long` 하나만 추가하면 초기 렌더링 1 round-trip으로 해결된다.
+
+**12. 쿠폰 목록 필터 없음**
+
+`GET /api/coupons/my`는 전체 발급 쿠폰을 반환한다. "사용 가능한 것만", "만료된 것만" 탭 구현을 위한 `?usable=true` 같은 필터가 없다. 현재는 전체를 받아서 `isUsable`로 클라이언트 필터링해야 한다.
+
+---
+
+### 🟡 기타 구현 시 불편한 부분
+
+**13. 장바구니 선택 결제 불가**
+
+`POST /api/cart/checkout`은 장바구니 전체를 주문으로 전환한다. 일부 상품만 선택해서 결제하는 기능이 없다. 선택 항목 ID 목록을 받는 파라미터 추가 필요.
+
+**14. 배송 추적 URL 없음**
+
+`ShipmentResponse`에 `carrier`(택배사)와 `trackingNumber`는 있지만 "배송 조회 바로가기" 딥링크 URL이 없다. 택배사별 트래킹 URL 매핑은 서버에서 해주는 게 관리가 편하다.
+
+```
+개선: trackingUrl: "https://www.cjlogistics.com/ko/tool/parcel/tracking?gnbInvcNo=1234"
+```
+
+**15. 상품 이미지 `sortOrder` 관리 API 없음**
+
+이미지 등록 / 삭제는 있지만 순서 변경(드래그 앤 드롭 정렬) API가 없다. `PATCH /api/products/{id}/images/order` 같은 순서 일괄 업데이트 필요.
+
+**16. 카테고리 하위 포함 상품 검색 불가**
+
+`GET /api/products?category=패션`으로 검색하면 "패션" 정확 일치만 동작한다. "패션 > 상의 > 티셔츠"처럼 하위 카테고리를 포함해서 검색하려면 프론트에서 카테고리 트리를 먼저 가져와 하위 ID를 모두 수집한 뒤 여러 번 요청해야 한다.
+
+```
+개선: ?categoryId=5&includeChildren=true  (또는 categoryId=5로 하위 포함 자동 처리)
+```
+
+---
+
+### 요약 우선순위
+
+| 우선순위 | 항목 | 이유 |
+|---|---|---|
+| 🔴 필수 | `PaymentPrepareResponse` 필드 보완 | 결제창 렌더링 불가 |
+| 🔴 필수 | 주문 금액 미리보기 API | 결제 전 UX 핵심 |
+| 🟠 중요 | 주문 목록에 `shipmentStatus` 포함 | N+1 요청 방지 |
+| 🟠 중요 | 내 결제/환불 목록 API | 마이페이지 기본 기능 |
+| 🟠 중요 | 상품 상세 `canReview` 필드 | 리뷰 버튼 노출 조건 |
+| 🟠 중요 | `ReviewResponse` 작성자 username | 리뷰 목록 표시 |
+| 🟡 중장기 | 상품 목록 `wishlisted` 포함 | 목록 N+1 제거 |
+| 🟡 중장기 | 내 리뷰 목록 API | 마이페이지 완성도 |
+| 🟡 중장기 | `UserResponse`에 포인트 잔액 포함 | 헤더 표시 최적화 |
+| 🟡 중장기 | 쿠폰 목록 usable 필터 | 쿠폰 탭 UX |
+| 🟡 중장기 | 카테고리 하위 포함 검색 | 상품 탐색 UX |
+| 🟡 중장기 | 배송 트래킹 URL | 배송 조회 UX |

--- a/src/main/java/com/stockmanagement/common/config/SecurityConfig.java
+++ b/src/main/java/com/stockmanagement/common/config/SecurityConfig.java
@@ -100,6 +100,8 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.PUT, "/api/products/**").hasRole("ADMIN")
                         .requestMatchers(HttpMethod.DELETE, "/api/products/**").hasRole("ADMIN")
                         .requestMatchers(HttpMethod.POST, "/api/inventory/**").hasRole("ADMIN")
+                        // 내 배송 목록 조회 — 인증된 사용자 전용 (ADMIN PATCH 패턴보다 앞에 선언)
+                        .requestMatchers(HttpMethod.GET, "/api/shipments/my").authenticated()
                         // 배송 상태 변경 (출고/완료/반품)은 ADMIN 전용
                         .requestMatchers(HttpMethod.PATCH, "/api/shipments/**").hasRole("ADMIN")
                         // 카테고리 조회 공개, 관리 (생성/수정/삭제)는 ADMIN 전용

--- a/src/main/java/com/stockmanagement/common/config/SecurityConfig.java
+++ b/src/main/java/com/stockmanagement/common/config/SecurityConfig.java
@@ -1,5 +1,8 @@
 package com.stockmanagement.common.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.stockmanagement.common.dto.ApiResponse;
+import com.stockmanagement.common.exception.ErrorCode;
 import com.stockmanagement.common.security.JwtBlacklist;
 import com.stockmanagement.common.security.JwtAuthenticationFilter;
 import com.stockmanagement.common.security.JwtTokenProvider;
@@ -9,6 +12,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -23,6 +27,7 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 
@@ -33,6 +38,7 @@ public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final JwtBlacklist jwtBlacklist;
+    private final ObjectMapper objectMapper;
 
     @Value("${cors.allowed-origins:http://localhost:3000}")
     private String allowedOrigins;
@@ -142,6 +148,24 @@ public class SecurityConfig {
                                         "connect-src 'self'; " +
                                         "frame-ancestors 'none'"));
                 })
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint((request, response, e) -> {
+                            response.setStatus(401);
+                            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                            response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+                            response.getWriter().write(
+                                    objectMapper.writeValueAsString(
+                                            ApiResponse.error(ErrorCode.UNAUTHORIZED, "인증이 필요합니다.")));
+                        })
+                        .accessDeniedHandler((request, response, e) -> {
+                            response.setStatus(403);
+                            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                            response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+                            response.getWriter().write(
+                                    objectMapper.writeValueAsString(
+                                            ApiResponse.error(ErrorCode.FORBIDDEN, "접근 권한이 없습니다.")));
+                        })
+                )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, jwtBlacklist),
                         UsernamePasswordAuthenticationFilter.class);
 

--- a/src/main/java/com/stockmanagement/common/dto/ApiResponse.java
+++ b/src/main/java/com/stockmanagement/common/dto/ApiResponse.java
@@ -1,21 +1,22 @@
 package com.stockmanagement.common.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import lombok.AccessLevel;
+import com.stockmanagement.common.exception.ErrorCode;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+
+import java.util.List;
 
 /**
  * 모든 API 응답을 감싸는 통합 응답 래퍼.
  *
  * <p>성공 시: {@code { "success": true, "data": { ... } }}
- * <br>실패 시: {@code { "success": false, "message": "오류 메시지" }}
+ * <br>실패 시: {@code { "success": false, "errorCode": "ORDER_NOT_FOUND", "message": "오류 메시지" }}
+ * <br>검증 실패 시: {@code { "success": false, "errors": [{ "field": "email", "message": "..." }] }}
  *
  * <p>null 필드는 JSON 직렬화에서 제외된다 ({@link JsonInclude#NON_NULL}).
  * 생성자를 private으로 막고 정적 팩토리 메서드만 노출해 일관된 형태를 강제한다.
  */
 @Getter
-@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ApiResponse<T> {
 
@@ -23,18 +24,46 @@ public class ApiResponse<T> {
     private final T data;
     private final String message;
 
+    /** 비즈니스 예외 에러 코드 — null이면 JSON 생략 */
+    private final String errorCode;
+
+    /** @Valid 필드별 에러 목록 — null이면 JSON 생략 */
+    private final List<FieldErrorDetail> errors;
+
+    private ApiResponse(boolean success, T data, String message,
+                        String errorCode, List<FieldErrorDetail> errors) {
+        this.success = success;
+        this.data = data;
+        this.message = message;
+        this.errorCode = errorCode;
+        this.errors = errors;
+    }
+
     /** 데이터가 있는 성공 응답 */
     public static <T> ApiResponse<T> ok(T data) {
-        return new ApiResponse<>(true, data, null);
+        return new ApiResponse<>(true, data, null, null, null);
     }
 
     /** 데이터 없는 성공 응답 (204 No Content 등) */
     public static <T> ApiResponse<T> ok() {
-        return new ApiResponse<>(true, null, null);
+        return new ApiResponse<>(true, null, null, null, null);
     }
 
-    /** 실패 응답 — success=false, message에 오류 내용 */
+    /** 실패 응답 — errorCode 없이 message만 포함 (레거시 호환) */
     public static <T> ApiResponse<T> error(String message) {
-        return new ApiResponse<>(false, null, message);
+        return new ApiResponse<>(false, null, message, null, null);
     }
+
+    /** 실패 응답 — ErrorCode + message 포함 */
+    public static <T> ApiResponse<T> error(ErrorCode errorCode, String message) {
+        return new ApiResponse<>(false, null, message, errorCode.name(), null);
+    }
+
+    /** @Valid 검증 실패 응답 — 필드별 에러 목록 포함 */
+    public static <T> ApiResponse<T> validationError(List<FieldErrorDetail> errors) {
+        return new ApiResponse<>(false, null, "입력값이 올바르지 않습니다.", null, errors);
+    }
+
+    /** 필드별 에러 정보. */
+    public record FieldErrorDetail(String field, String message) {}
 }

--- a/src/main/java/com/stockmanagement/common/exception/ErrorCode.java
+++ b/src/main/java/com/stockmanagement/common/exception/ErrorCode.java
@@ -106,6 +106,8 @@ public enum ErrorCode {
     SETTING_NOT_FOUND(HttpStatus.NOT_FOUND, "시스템 설정을 찾을 수 없습니다."),
 
     // ===== Common =====
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "잘못된 입력값입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."),
     LOCK_ACQUISITION_FAILED(HttpStatus.TOO_MANY_REQUESTS, "현재 요청이 많습니다. 잠시 후 다시 시도해주세요."),

--- a/src/main/java/com/stockmanagement/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/stockmanagement/common/exception/GlobalExceptionHandler.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
+import java.util.List;
 import java.util.stream.Collectors;
 
 /**
@@ -41,7 +42,7 @@ public class GlobalExceptionHandler {
         ErrorCode errorCode = e.getErrorCode();
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
-                .body(ApiResponse.error(e.getMessage()));
+                .body(ApiResponse.error(errorCode, e.getMessage()));
     }
 
     /**
@@ -50,12 +51,12 @@ public class GlobalExceptionHandler {
      */
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ApiResponse<Void>> handleValidationException(MethodArgumentNotValidException e) {
-        String message = e.getBindingResult().getFieldErrors().stream()
-                .map(FieldError::getDefaultMessage)
-                .collect(Collectors.joining(", "));
+        List<ApiResponse.FieldErrorDetail> errors = e.getBindingResult().getFieldErrors().stream()
+                .map(fe -> new ApiResponse.FieldErrorDetail(fe.getField(), fe.getDefaultMessage()))
+                .collect(Collectors.toList());
         return ResponseEntity
                 .badRequest()
-                .body(ApiResponse.error(message));
+                .body(ApiResponse.validationError(errors));
     }
 
     /**

--- a/src/main/java/com/stockmanagement/domain/coupon/controller/CouponController.java
+++ b/src/main/java/com/stockmanagement/domain/coupon/controller/CouponController.java
@@ -67,12 +67,14 @@ public class CouponController {
         return ApiResponse.ok(null);
     }
 
-    @Operation(summary = "내 쿠폰 목록 [USER] — 발급된 쿠폰 + 사용 가능 여부")
+    @Operation(summary = "내 쿠폰 목록 [USER] — 발급된 쿠폰 + 사용 가능 여부",
+               description = "usable=true: 사용 가능한 쿠폰만, usable=false: 만료/소진된 쿠폰만, 미지정: 전체.")
     @GetMapping("/my")
     public ApiResponse<List<MyCouponResponse>> getMyCoupons(
-            @AuthenticationPrincipal String username) {
+            @AuthenticationPrincipal String username,
+            @RequestParam(required = false) Boolean usable) {
         Long userId = userService.resolveUserId(username);
-        return ApiResponse.ok(couponService.getMyCoupons(userId));
+        return ApiResponse.ok(couponService.getMyCoupons(userId, usable));
     }
 
     @Operation(summary = "공개 쿠폰 등록 [USER] — 쿠폰 코드 입력으로 내 지갑에 추가")

--- a/src/main/java/com/stockmanagement/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/stockmanagement/domain/coupon/service/CouponService.java
@@ -108,6 +108,15 @@ public class CouponService {
      * </ul>
      */
     public List<MyCouponResponse> getMyCoupons(Long userId) {
+        return getMyCoupons(userId, null);
+    }
+
+    /**
+     * 사용자 쿠폰 목록을 조회한다. usable 파라미터로 사용 가능 여부 필터링 지원.
+     *
+     * @param usable null=전체, true=사용 가능만, false=사용 불가만
+     */
+    public List<MyCouponResponse> getMyCoupons(Long userId, Boolean usable) {
         List<UserCoupon> userCoupons = userCouponRepository.findByUserId(userId);
         if (userCoupons.isEmpty()) {
             return List.of();
@@ -131,6 +140,7 @@ public class CouponService {
                     int usedCount = usedCountMap.getOrDefault(uc.getCoupon().getId(), 0);
                     return MyCouponResponse.from(uc, isUsable(uc.getCoupon(), usedCount, now));
                 })
+                .filter(r -> usable == null || r.isUsable() == usable)
                 .toList();
     }
 

--- a/src/main/java/com/stockmanagement/domain/order/cart/dto/CartCheckoutRequest.java
+++ b/src/main/java/com/stockmanagement/domain/order/cart/dto/CartCheckoutRequest.java
@@ -6,6 +6,8 @@ import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 /** 장바구니 → 주문 전환 요청 DTO. */
 @Getter
 @NoArgsConstructor
@@ -29,4 +31,7 @@ public class CartCheckoutRequest {
 
     /** 배송지 ID — 선택 항목. null이면 배송지 미지정 */
     private Long deliveryAddressId;
+
+    /** 선택 결제할 상품 ID 목록 — null이면 장바구니 전체 결제 */
+    private List<Long> selectedProductIds;
 }

--- a/src/main/java/com/stockmanagement/domain/order/cart/dto/CartItemResponse.java
+++ b/src/main/java/com/stockmanagement/domain/order/cart/dto/CartItemResponse.java
@@ -17,6 +17,8 @@ public class CartItemResponse {
     private int quantity;
     private BigDecimal subtotal;
 
+    /** 상품 대표 이미지 URL — null이면 이미지 없음 */
+    private String thumbnailUrl;
     /** 현재 가용 재고 수량 — null이면 재고 정보 미포함 */
     private Integer availableQuantity;
     /** 담은 수량만큼 구매 가능한지 여부 — null이면 재고 정보 미포함 */
@@ -31,6 +33,7 @@ public class CartItemResponse {
         return CartItemResponse.builder()
                 .productId(item.getProduct().getId())
                 .productName(item.getProduct().getName())
+                .thumbnailUrl(item.getProduct().getThumbnailUrl())
                 .unitPrice(unitPrice)
                 .quantity(item.getQuantity())
                 .subtotal(unitPrice.multiply(BigDecimal.valueOf(item.getQuantity())))

--- a/src/main/java/com/stockmanagement/domain/order/cart/dto/CartItemResponse.java
+++ b/src/main/java/com/stockmanagement/domain/order/cart/dto/CartItemResponse.java
@@ -23,6 +23,10 @@ public class CartItemResponse {
     private Integer availableQuantity;
     /** 담은 수량만큼 구매 가능한지 여부 — null이면 재고 정보 미포함 */
     private Boolean isAvailable;
+    /** 장바구니 담은 시점의 단가 — null이면 기록 없음 (이전 데이터) */
+    private BigDecimal savedPrice;
+    /** 담은 이후 가격이 변동되었는지 여부 — null이면 savedPrice 기록 없음 */
+    private Boolean priceChanged;
 
     public static CartItemResponse from(CartItem item) {
         return from(item, null);
@@ -30,6 +34,8 @@ public class CartItemResponse {
 
     public static CartItemResponse from(CartItem item, Integer availableQuantity) {
         BigDecimal unitPrice = item.getProduct().getPrice();
+        BigDecimal savedPrice = item.getSavedPrice();
+        Boolean priceChanged = savedPrice != null ? savedPrice.compareTo(unitPrice) != 0 : null;
         return CartItemResponse.builder()
                 .productId(item.getProduct().getId())
                 .productName(item.getProduct().getName())
@@ -39,6 +45,8 @@ public class CartItemResponse {
                 .subtotal(unitPrice.multiply(BigDecimal.valueOf(item.getQuantity())))
                 .availableQuantity(availableQuantity)
                 .isAvailable(availableQuantity != null ? availableQuantity >= item.getQuantity() : null)
+                .savedPrice(savedPrice)
+                .priceChanged(priceChanged)
                 .build();
     }
 }

--- a/src/main/java/com/stockmanagement/domain/order/cart/entity/CartItem.java
+++ b/src/main/java/com/stockmanagement/domain/order/cart/entity/CartItem.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 /**
@@ -39,6 +40,10 @@ public class CartItem {
     @Column(nullable = false)
     private int quantity;
 
+    /** 장바구니 담은 시점의 단가 — 현재 가격과 비교하여 가격 변동 감지에 사용 */
+    @Column(precision = 12, scale = 2)
+    private BigDecimal savedPrice;
+
     @CreationTimestamp
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
@@ -48,10 +53,11 @@ public class CartItem {
     private LocalDateTime updatedAt;
 
     @Builder
-    private CartItem(Long userId, Product product, int quantity) {
+    private CartItem(Long userId, Product product, int quantity, BigDecimal savedPrice) {
         this.userId = userId;
         this.product = product;
         this.quantity = quantity;
+        this.savedPrice = savedPrice;
     }
 
     /** 수량을 변경한다. */

--- a/src/main/java/com/stockmanagement/domain/order/cart/repository/CartRepository.java
+++ b/src/main/java/com/stockmanagement/domain/order/cart/repository/CartRepository.java
@@ -4,6 +4,7 @@ import com.stockmanagement.domain.order.cart.entity.CartItem;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -22,4 +23,7 @@ public interface CartRepository extends JpaRepository<CartItem, Long> {
 
     /** 사용자의 장바구니 전체 삭제 */
     void deleteByUserId(Long userId);
+
+    /** 사용자의 장바구니에서 특정 상품들만 삭제 (선택 결제 후 나머지 유지) */
+    void deleteByUserIdAndProductIdIn(Long userId, Collection<Long> productIds);
 }

--- a/src/main/java/com/stockmanagement/domain/order/cart/service/CartService.java
+++ b/src/main/java/com/stockmanagement/domain/order/cart/service/CartService.java
@@ -86,6 +86,7 @@ public class CartService {
                     .userId(userId)
                     .product(product)
                     .quantity(request.getQuantity())
+                    .savedPrice(product.getPrice())
                     .build();
             cartRepository.save(item);
         }

--- a/src/main/java/com/stockmanagement/domain/order/cart/service/CartService.java
+++ b/src/main/java/com/stockmanagement/domain/order/cart/service/CartService.java
@@ -23,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -127,7 +128,19 @@ public class CartService {
      */
     @Transactional
     public OrderResponse checkout(Long userId, CartCheckoutRequest checkoutRequest) {
-        List<CartItem> items = cartRepository.findByUserId(userId);
+        List<CartItem> allItems = cartRepository.findByUserId(userId);
+        if (allItems.isEmpty()) {
+            throw new BusinessException(ErrorCode.CART_EMPTY);
+        }
+
+        // selectedProductIds가 없으면 전체, 있으면 해당 상품만 결제
+        List<Long> selected = checkoutRequest.getSelectedProductIds();
+        List<CartItem> items = (selected == null || selected.isEmpty())
+                ? allItems
+                : allItems.stream()
+                        .filter(i -> selected.contains(i.getProduct().getId()))
+                        .toList();
+
         if (items.isEmpty()) {
             throw new BusinessException(ErrorCode.CART_EMPTY);
         }
@@ -146,8 +159,11 @@ public class CartService {
 
         OrderResponse orderResponse = orderService.create(orderRequest, userId);
 
-        // 주문 생성 성공 후 장바구니 비우기
-        cartRepository.deleteByUserId(userId);
+        // 결제한 상품만 장바구니에서 제거 (선택 결제 시 나머지 유지)
+        Set<Long> checkedOutProductIds = items.stream()
+                .map(i -> i.getProduct().getId())
+                .collect(Collectors.toSet());
+        cartRepository.deleteByUserIdAndProductIdIn(userId, checkedOutProductIds);
 
         return orderResponse;
     }

--- a/src/main/java/com/stockmanagement/domain/order/controller/OrderController.java
+++ b/src/main/java/com/stockmanagement/domain/order/controller/OrderController.java
@@ -6,6 +6,8 @@ import com.stockmanagement.common.ratelimit.RateLimit;
 import com.stockmanagement.common.security.SecurityUtils;
 import com.stockmanagement.domain.order.dto.OrderCreateRequest;
 import com.stockmanagement.domain.order.dto.OrderDetailResponse;
+import com.stockmanagement.domain.order.dto.OrderPreviewRequest;
+import com.stockmanagement.domain.order.dto.OrderPreviewResponse;
 import com.stockmanagement.domain.order.dto.OrderResponse;
 import com.stockmanagement.domain.order.dto.OrderSearchRequest;
 import com.stockmanagement.domain.order.dto.OrderStatusHistoryResponse;
@@ -53,6 +55,15 @@ public class OrderController {
     private final OrderService orderService;
     private final OrderDetailService orderDetailService;
     private final UserService userService;
+
+    @Operation(summary = "주문 금액 미리보기", description = "쿠폰·포인트 적용 시 최종 결제 금액을 계산한다. 주문 생성 없이 순수 계산만 수행.")
+    @PostMapping("/preview")
+    public ApiResponse<OrderPreviewResponse> preview(
+            @RequestBody @Valid OrderPreviewRequest request,
+            @AuthenticationPrincipal String username,
+            Authentication authentication) {
+        return ApiResponse.ok(orderService.preview(request, resolveUserId(authentication, username)));
+    }
 
     @Operation(summary = "주문 생성", description = "재고 예약(reserved++) 후 PENDING 주문 생성. 동일 idempotencyKey 재요청 시 기존 주문 반환.")
     @PostMapping

--- a/src/main/java/com/stockmanagement/domain/order/controller/OrderController.java
+++ b/src/main/java/com/stockmanagement/domain/order/controller/OrderController.java
@@ -4,6 +4,7 @@ import com.stockmanagement.common.dto.ApiResponse;
 import com.stockmanagement.common.dto.CursorPage;
 import com.stockmanagement.common.ratelimit.RateLimit;
 import com.stockmanagement.common.security.SecurityUtils;
+import com.stockmanagement.domain.order.dto.OrderCancelRequest;
 import com.stockmanagement.domain.order.dto.OrderCreateRequest;
 import com.stockmanagement.domain.order.dto.OrderDetailResponse;
 import com.stockmanagement.domain.order.dto.OrderPreviewRequest;
@@ -139,10 +140,12 @@ public class OrderController {
     @PostMapping("/{id}/cancel")
     public ApiResponse<OrderResponse> cancel(
             @PathVariable Long id,
+            @RequestBody(required = false) @Valid OrderCancelRequest request,
             @AuthenticationPrincipal String username,
             Authentication authentication) {
         boolean isAdmin = SecurityUtils.isAdmin(authentication);
-        return ApiResponse.ok(orderService.cancel(id, resolveUserId(authentication, username), isAdmin));
+        String reason = request != null ? request.reason() : null;
+        return ApiResponse.ok(orderService.cancel(id, resolveUserId(authentication, username), isAdmin, reason));
     }
 
     @Operation(summary = "주문 상태 변경 이력 조회", description = "생성·취소·확정·환불 등 모든 상태 전이를 시간순으로 반환. ADMIN은 모든 주문, USER는 본인 주문만 가능.")

--- a/src/main/java/com/stockmanagement/domain/order/dto/OrderCancelRequest.java
+++ b/src/main/java/com/stockmanagement/domain/order/dto/OrderCancelRequest.java
@@ -1,0 +1,9 @@
+package com.stockmanagement.domain.order.dto;
+
+import jakarta.validation.constraints.Size;
+
+/** 주문 취소 요청 DTO — reason 미입력 허용 */
+public record OrderCancelRequest(
+        @Size(max = 255, message = "취소 사유는 255자를 초과할 수 없습니다.")
+        String reason
+) {}

--- a/src/main/java/com/stockmanagement/domain/order/dto/OrderDetailResponse.java
+++ b/src/main/java/com/stockmanagement/domain/order/dto/OrderDetailResponse.java
@@ -1,6 +1,7 @@
 package com.stockmanagement.domain.order.dto;
 
 import com.stockmanagement.domain.payment.dto.PaymentResponse;
+import com.stockmanagement.domain.refund.dto.RefundResponse;
 import com.stockmanagement.domain.shipment.dto.ShipmentResponse;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,4 +23,7 @@ public class OrderDetailResponse {
 
     /** 배송 정보 — 결제 완료 전이면 null */
     private final ShipmentResponse shipment;
+
+    /** 환불 정보 — 환불 요청 전이면 null */
+    private final RefundResponse refund;
 }

--- a/src/main/java/com/stockmanagement/domain/order/dto/OrderItemResponse.java
+++ b/src/main/java/com/stockmanagement/domain/order/dto/OrderItemResponse.java
@@ -36,6 +36,9 @@ public class OrderItemResponse {
     /** 리뷰 작성 여부 — null이면 정보 미포함, true/false면 작성 여부 */
     private final Boolean hasReview;
 
+    /** 상품 대표 이미지 URL — null이면 이미지 없음 */
+    private final String thumbnailUrl;
+
     /** OrderItem 엔티티를 응답 DTO로 변환 (hasReview 미포함). */
     public static OrderItemResponse from(OrderItem item) {
         return from(item, null);
@@ -51,6 +54,7 @@ public class OrderItemResponse {
                 .unitPrice(item.getUnitPrice())
                 .subtotal(item.getSubtotal())
                 .hasReview(hasReview)
+                .thumbnailUrl(item.getProduct().getThumbnailUrl())
                 .build();
     }
 }

--- a/src/main/java/com/stockmanagement/domain/order/dto/OrderPreviewRequest.java
+++ b/src/main/java/com/stockmanagement/domain/order/dto/OrderPreviewRequest.java
@@ -1,0 +1,33 @@
+package com.stockmanagement.domain.order.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+/** 주문 금액 미리보기 요청 DTO. */
+@Getter
+@Setter
+@NoArgsConstructor
+public class OrderPreviewRequest {
+
+    @NotNull
+    @Size(min = 1, message = "주문 항목은 1개 이상이어야 합니다.")
+    @Valid
+    private List<OrderItemRequest> items;
+
+    /** 쿠폰 코드 (선택) */
+    private String couponCode;
+
+    /** 사용 포인트 (선택, 0이면 미사용) */
+    @Min(0)
+    private long usePoints;
+
+    /** 배송지 ID (선택 — 현재 배송비 미구현이므로 예약 필드) */
+    private Long deliveryAddressId;
+}

--- a/src/main/java/com/stockmanagement/domain/order/dto/OrderPreviewResponse.java
+++ b/src/main/java/com/stockmanagement/domain/order/dto/OrderPreviewResponse.java
@@ -1,0 +1,30 @@
+package com.stockmanagement.domain.order.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+/** 주문 금액 미리보기 응답 DTO. */
+@Getter
+@Builder
+public class OrderPreviewResponse {
+
+    /** 쿠폰·포인트 적용 전 상품 합계 금액 */
+    private final BigDecimal originalAmount;
+
+    /** 쿠폰 할인 금액 (0이면 쿠폰 미적용) */
+    private final BigDecimal couponDiscount;
+
+    /** 포인트 할인 금액 (0이면 포인트 미사용) */
+    private final BigDecimal pointDiscount;
+
+    /** 배송비 (현재 무료배송 정책 — 0) */
+    private final BigDecimal shippingFee;
+
+    /** 최종 결제 금액 = originalAmount - couponDiscount - pointDiscount + shippingFee */
+    private final BigDecimal finalAmount;
+
+    /** 결제 완료 시 적립 예정 포인트 (finalAmount × 1%) */
+    private final long earnablePoints;
+}

--- a/src/main/java/com/stockmanagement/domain/order/dto/OrderResponse.java
+++ b/src/main/java/com/stockmanagement/domain/order/dto/OrderResponse.java
@@ -47,6 +47,9 @@ public class OrderResponse {
     /** 배송 상태 — null이면 배송 미생성 (결제 완료 전 또는 취소된 주문) */
     private final ShipmentStatus shipmentStatus;
 
+    /** 취소 사유 — CANCELLED 상태가 아니거나 사유 미입력 시 null */
+    private final String cancelReason;
+
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
 
@@ -80,6 +83,7 @@ public class OrderResponse {
                                         : null))
                         .toList())
                 .shipmentStatus(shipmentStatus)
+                .cancelReason(order.getCancelReason())
                 .createdAt(order.getCreatedAt())
                 .updatedAt(order.getUpdatedAt())
                 .build();

--- a/src/main/java/com/stockmanagement/domain/order/dto/OrderResponse.java
+++ b/src/main/java/com/stockmanagement/domain/order/dto/OrderResponse.java
@@ -2,6 +2,7 @@ package com.stockmanagement.domain.order.dto;
 
 import com.stockmanagement.domain.order.entity.Order;
 import com.stockmanagement.domain.order.entity.OrderStatus;
+import com.stockmanagement.domain.shipment.entity.ShipmentStatus;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.extern.jackson.Jacksonized;
@@ -43,20 +44,25 @@ public class OrderResponse {
     /** 주문 항목 목록 */
     private final List<OrderItemResponse> items;
 
+    /** 배송 상태 — null이면 배송 미생성 (결제 완료 전 또는 취소된 주문) */
+    private final ShipmentStatus shipmentStatus;
+
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
 
     /** Order 엔티티를 응답 DTO로 변환하는 정적 팩토리 메서드 */
     public static OrderResponse from(Order order) {
-        return from(order, null);
+        return from(order, null, null);
     }
 
     /**
-     * Order 엔티티를 hasReview 포함 응답 DTO로 변환한다.
+     * Order 엔티티를 hasReview + shipmentStatus 포함 응답 DTO로 변환한다.
      *
      * @param reviewedProductIds 현재 사용자가 리뷰를 작성한 상품 ID 집합 (null이면 hasReview=null)
+     * @param shipmentStatus     배송 상태 (null이면 배송 미생성)
      */
-    public static OrderResponse from(Order order, java.util.Set<Long> reviewedProductIds) {
+    public static OrderResponse from(Order order, java.util.Set<Long> reviewedProductIds,
+                                     ShipmentStatus shipmentStatus) {
         return OrderResponse.builder()
                 .id(order.getId())
                 .userId(order.getUserId())
@@ -73,6 +79,7 @@ public class OrderResponse {
                                         ? reviewedProductIds.contains(i.getProduct().getId())
                                         : null))
                         .toList())
+                .shipmentStatus(shipmentStatus)
                 .createdAt(order.getCreatedAt())
                 .updatedAt(order.getUpdatedAt())
                 .build();

--- a/src/main/java/com/stockmanagement/domain/order/dto/OrderResponse.java
+++ b/src/main/java/com/stockmanagement/domain/order/dto/OrderResponse.java
@@ -9,6 +9,7 @@ import lombok.extern.jackson.Jacksonized;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 /**
@@ -24,6 +25,8 @@ import java.util.List;
 public class OrderResponse {
 
     private final Long id;
+    /** 사용자 친화적 주문 번호 (예: 20240301-0000042) */
+    private final String orderNumber;
     private final Long userId;
     private final OrderStatus status;
     private final BigDecimal totalAmount;
@@ -66,8 +69,13 @@ public class OrderResponse {
      */
     public static OrderResponse from(Order order, java.util.Set<Long> reviewedProductIds,
                                      ShipmentStatus shipmentStatus) {
+        String orderNumber = order.getCreatedAt() != null
+                ? order.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyyMMdd"))
+                        + "-" + String.format("%07d", order.getId())
+                : null;
         return OrderResponse.builder()
                 .id(order.getId())
+                .orderNumber(orderNumber)
                 .userId(order.getUserId())
                 .status(order.getStatus())
                 .totalAmount(order.getTotalAmount())

--- a/src/main/java/com/stockmanagement/domain/order/dto/OrderResponse.java
+++ b/src/main/java/com/stockmanagement/domain/order/dto/OrderResponse.java
@@ -44,6 +44,9 @@ public class OrderResponse {
     /** 사용한 포인트 */
     private final long usedPoints;
 
+    /** 실제 결제 금액 (= totalAmount - discountAmount - usedPoints) */
+    private final BigDecimal payableAmount;
+
     /** 주문 항목 목록 */
     private final List<OrderItemResponse> items;
 
@@ -84,6 +87,7 @@ public class OrderResponse {
                 .couponId(order.getCouponId())
                 .discountAmount(order.getDiscountAmount())
                 .usedPoints(order.getUsedPoints())
+                .payableAmount(order.getPayableAmount())
                 .items(order.getItems().stream()
                         .map(i -> OrderItemResponse.from(i,
                                 reviewedProductIds != null

--- a/src/main/java/com/stockmanagement/domain/order/entity/Order.java
+++ b/src/main/java/com/stockmanagement/domain/order/entity/Order.java
@@ -187,6 +187,18 @@ public class Order {
     }
 
     /**
+     * 실제 결제 금액을 계산한다 (= totalAmount - discountAmount - usedPoints, 최소 0).
+     *
+     * <p>쿠폰 할인과 포인트 사용을 차감한 금액으로, Toss 결제 요청에 사용된다.
+     */
+    public BigDecimal getPayableAmount() {
+        BigDecimal payable = totalAmount
+                .subtract(discountAmount)
+                .subtract(BigDecimal.valueOf(usedPoints));
+        return payable.compareTo(BigDecimal.ZERO) > 0 ? payable : BigDecimal.ZERO;
+    }
+
+    /**
      * 쿠폰 할인을 적용한다.
      * 저장 후 couponService.applyCoupon() 결과를 받아 호출한다.
      */

--- a/src/main/java/com/stockmanagement/domain/order/entity/Order.java
+++ b/src/main/java/com/stockmanagement/domain/order/entity/Order.java
@@ -108,19 +108,25 @@ public class Order {
 
     // ===== 비즈니스 메서드 =====
 
+    /** 취소 사유 — null이면 사유 미입력 */
+    @Column(name = "cancel_reason", length = 255)
+    private String cancelReason;
+
     /**
      * 주문을 취소한다.
      *
      * <p>PENDING 상태인 경우에만 취소 가능하다.
      * PAYMENT_IN_PROGRESS 상태에서는 Toss API 호출이 진행 중이므로 취소 불가.
      *
+     * @param reason 취소 사유 (null 허용)
      * @throws BusinessException 취소 불가 상태일 경우
      */
-    public void cancel() {
+    public void cancel(String reason) {
         if (this.status != OrderStatus.PENDING) {
             throw new BusinessException(ErrorCode.INVALID_ORDER_STATUS);
         }
         this.status = OrderStatus.CANCELLED;
+        this.cancelReason = reason;
     }
 
     /**

--- a/src/main/java/com/stockmanagement/domain/order/service/OrderDetailService.java
+++ b/src/main/java/com/stockmanagement/domain/order/service/OrderDetailService.java
@@ -54,8 +54,10 @@ public class OrderDetailService {
                 .orElse(null);
         Set<Long> reviewedIds = reviewedProductIds(order.getUserId(), order.getItems());
 
+        com.stockmanagement.domain.shipment.entity.ShipmentStatus shipmentStatus =
+                shipment != null ? shipment.getStatus() : null;
         return OrderDetailResponse.builder()
-                .order(OrderResponse.from(order, reviewedIds))
+                .order(OrderResponse.from(order, reviewedIds, shipmentStatus))
                 .payment(payment)
                 .shipment(shipment)
                 .build();

--- a/src/main/java/com/stockmanagement/domain/order/service/OrderDetailService.java
+++ b/src/main/java/com/stockmanagement/domain/order/service/OrderDetailService.java
@@ -10,6 +10,8 @@ import com.stockmanagement.domain.order.repository.OrderRepository;
 import com.stockmanagement.domain.payment.dto.PaymentResponse;
 import com.stockmanagement.domain.payment.repository.PaymentRepository;
 import com.stockmanagement.domain.product.review.repository.ReviewRepository;
+import com.stockmanagement.domain.refund.dto.RefundResponse;
+import com.stockmanagement.domain.refund.repository.RefundRepository;
 import com.stockmanagement.domain.shipment.dto.ShipmentResponse;
 import com.stockmanagement.domain.shipment.repository.ShipmentRepository;
 import lombok.RequiredArgsConstructor;
@@ -34,6 +36,7 @@ public class OrderDetailService {
     private final OrderRepository orderRepository;
     private final PaymentRepository paymentRepository;
     private final ShipmentRepository shipmentRepository;
+    private final RefundRepository refundRepository;
     private final ReviewRepository reviewRepository;
 
     /**
@@ -52,6 +55,9 @@ public class OrderDetailService {
         ShipmentResponse shipment = shipmentRepository.findByOrderId(order.getId())
                 .map(ShipmentResponse::from)
                 .orElse(null);
+        RefundResponse refund = refundRepository.findByOrderId(order.getId())
+                .map(RefundResponse::from)
+                .orElse(null);
         Set<Long> reviewedIds = reviewedProductIds(order.getUserId(), order.getItems());
 
         com.stockmanagement.domain.shipment.entity.ShipmentStatus shipmentStatus =
@@ -60,6 +66,7 @@ public class OrderDetailService {
                 .order(OrderResponse.from(order, reviewedIds, shipmentStatus))
                 .payment(payment)
                 .shipment(shipment)
+                .refund(refund)
                 .build();
     }
 

--- a/src/main/java/com/stockmanagement/domain/order/service/OrderService.java
+++ b/src/main/java/com/stockmanagement/domain/order/service/OrderService.java
@@ -42,6 +42,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -124,10 +125,15 @@ public class OrderService {
         List<OrderItem> items = new ArrayList<>();
         BigDecimal totalAmount = BigDecimal.ZERO;
 
-        // 상품 ID 일괄 조회 — 루프마다 findById()를 호출하는 N+1 방지
+        // 중복 상품 ID 검증 — 동일 상품이 여러 항목에 포함되면 수량을 합쳐서 제출해야 함
         List<Long> productIds = request.getItems().stream()
                 .map(OrderItemRequest::getProductId)
                 .toList();
+        if (new HashSet<>(productIds).size() != productIds.size()) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT, "동일 상품이 중복으로 포함되어 있습니다. 수량을 합쳐서 제출해주세요.");
+        }
+
+        // 상품 ID 일괄 조회 — 루프마다 findById()를 호출하는 N+1 방지
         Map<Long, Product> productMap = productRepository.findAllById(productIds).stream()
                 .collect(Collectors.toMap(Product::getId, p -> p));
 
@@ -453,6 +459,10 @@ public class OrderService {
         List<Long> productIds = request.getItems().stream()
                 .map(OrderItemRequest::getProductId)
                 .toList();
+        if (new HashSet<>(productIds).size() != productIds.size()) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT, "동일 상품이 중복으로 포함되어 있습니다. 수량을 합쳐서 제출해주세요.");
+        }
+
         Map<Long, Product> productMap = productRepository.findAllById(productIds).stream()
                 .collect(Collectors.toMap(Product::getId, p -> p));
 

--- a/src/main/java/com/stockmanagement/domain/order/service/OrderService.java
+++ b/src/main/java/com/stockmanagement/domain/order/service/OrderService.java
@@ -6,9 +6,13 @@ import com.stockmanagement.common.exception.ErrorCode;
 import com.stockmanagement.domain.coupon.service.CouponService;
 import com.stockmanagement.domain.inventory.service.InventoryService;
 import com.stockmanagement.domain.point.service.PointService;
+import com.stockmanagement.domain.shipment.entity.ShipmentStatus;
+import com.stockmanagement.domain.shipment.repository.ShipmentRepository;
 import com.stockmanagement.domain.user.address.service.DeliveryAddressService;
 import com.stockmanagement.domain.order.dto.OrderCreateRequest;
 import com.stockmanagement.domain.order.dto.OrderItemRequest;
+import com.stockmanagement.domain.order.dto.OrderPreviewRequest;
+import com.stockmanagement.domain.order.dto.OrderPreviewResponse;
 import com.stockmanagement.domain.order.dto.OrderResponse;
 import com.stockmanagement.domain.order.dto.OrderSearchRequest;
 import com.stockmanagement.domain.order.dto.OrderStatusHistoryResponse;
@@ -73,6 +77,7 @@ public class OrderService {
     private final PointService pointService;
     private final OutboxEventStore outboxEventStore;
     private final DeliveryAddressService deliveryAddressService;
+    private final ShipmentRepository shipmentRepository;
 
     /**
      * 주문을 생성한다.
@@ -233,7 +238,9 @@ public class OrderService {
         Order order = orderRepository.findByIdWithItems(id)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
         validateOrderOwnership(order, userId, isAdmin);
-        return OrderResponse.from(order);
+        ShipmentStatus shipmentStatus = shipmentRepository.findByOrderId(id)
+                .map(s -> s.getStatus()).orElse(null);
+        return OrderResponse.from(order, null, shipmentStatus);
     }
 
     /**
@@ -254,8 +261,13 @@ public class OrderService {
                                        OrderSearchRequest request, Pageable pageable) {
         // USER: 본인 주문만 조회 — DTO를 직접 변경하지 않고 forceUserId로 Specification에 주입
         Long forceUserId = isAdmin ? null : userId;
-        return orderRepository.findAll(OrderSpecification.of(request, forceUserId), pageable)
-                .map(OrderResponse::from);
+        Page<Order> page = orderRepository.findAll(OrderSpecification.of(request, forceUserId), pageable);
+
+        // 배송 상태 배치 조회 (N+1 방지)
+        List<Long> orderIds = page.map(Order::getId).toList();
+        Map<Long, ShipmentStatus> statusMap = shipmentRepository.findStatusMapByOrderIds(orderIds);
+
+        return page.map(o -> OrderResponse.from(o, null, statusMap.get(o.getId())));
     }
 
     /**
@@ -276,8 +288,12 @@ public class OrderService {
         List<Order> items = lastId == null
                 ? orderRepository.findCursorByUserId(userId, status, limit)
                 : orderRepository.findCursorByUserIdAfter(userId, status, lastId, limit);
+        // 배송 상태 배치 조회 (N+1 방지)
+        List<Long> orderIds = items.stream().map(Order::getId).toList();
+        Map<Long, ShipmentStatus> statusMap = shipmentRepository.findStatusMapByOrderIds(orderIds);
+
         return CursorPage.of(
-                items.stream().map(OrderResponse::from).toList(),
+                items.stream().map(o -> OrderResponse.from(o, null, statusMap.get(o.getId()))).toList(),
                 size,
                 OrderResponse::getId);
     }
@@ -425,6 +441,63 @@ public class OrderService {
 
         recordHistory(order.getId(), OrderStatus.CONFIRMED, OrderStatus.CANCELLED, null);
         outboxEventStore.save(new OrderCancelledEvent(order.getId(), order.getUserId(), "PAYMENT_REFUNDED"));
+    }
+
+    /**
+     * 주문 금액을 미리보기 계산한다 (DB 쓰기 없음).
+     *
+     * <p>쿠폰·포인트를 적용한 최종 결제 금액과 적립 예정 포인트를 반환한다.
+     * 실제 주문 생성·재고 예약 없이 순수 계산만 수행한다.
+     */
+    public OrderPreviewResponse preview(OrderPreviewRequest request, Long userId) {
+        List<Long> productIds = request.getItems().stream()
+                .map(OrderItemRequest::getProductId)
+                .toList();
+        Map<Long, Product> productMap = productRepository.findAllById(productIds).stream()
+                .collect(Collectors.toMap(Product::getId, p -> p));
+
+        BigDecimal originalAmount = BigDecimal.ZERO;
+        for (OrderItemRequest item : request.getItems()) {
+            Product product = Optional.ofNullable(productMap.get(item.getProductId()))
+                    .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND));
+            if (product.getStatus() != ProductStatus.ACTIVE) {
+                throw new BusinessException(ErrorCode.PRODUCT_NOT_AVAILABLE);
+            }
+            originalAmount = originalAmount.add(product.getPrice()
+                    .multiply(BigDecimal.valueOf(item.getQuantity())));
+        }
+
+        // 쿠폰 할인 계산 (검증만 — 사용 이력 미기록)
+        BigDecimal couponDiscount = BigDecimal.ZERO;
+        if (request.getCouponCode() != null && !request.getCouponCode().isBlank()) {
+            var validateReq = new com.stockmanagement.domain.coupon.dto.CouponValidateRequest(
+                    request.getCouponCode(), originalAmount);
+            couponDiscount = couponService.validate(userId, validateReq).getDiscountAmount();
+        }
+
+        // 포인트 잔액 검증 (차감은 하지 않음)
+        long usePoints = request.getUsePoints();
+        if (usePoints > 0) {
+            pointService.validateBalance(userId, usePoints);
+        }
+        BigDecimal pointDiscount = BigDecimal.valueOf(usePoints);
+
+        BigDecimal shippingFee = BigDecimal.ZERO; // 현재 무료배송 정책
+        BigDecimal finalAmount = originalAmount.subtract(couponDiscount).subtract(pointDiscount).add(shippingFee);
+        if (finalAmount.compareTo(BigDecimal.ZERO) < 0) finalAmount = BigDecimal.ZERO;
+
+        long earnablePoints = finalAmount.compareTo(BigDecimal.ZERO) > 0
+                ? Math.max(1L, Math.round(finalAmount.doubleValue() * 0.01))
+                : 0L;
+
+        return OrderPreviewResponse.builder()
+                .originalAmount(originalAmount)
+                .couponDiscount(couponDiscount)
+                .pointDiscount(pointDiscount)
+                .shippingFee(shippingFee)
+                .finalAmount(finalAmount)
+                .earnablePoints(earnablePoints)
+                .build();
     }
 
     // ===== 내부 헬퍼 =====

--- a/src/main/java/com/stockmanagement/domain/order/service/OrderService.java
+++ b/src/main/java/com/stockmanagement/domain/order/service/OrderService.java
@@ -327,7 +327,7 @@ public class OrderService {
      */
     @Transactional
     @CacheEvict(cacheNames = "orders", key = "#id")
-    public OrderResponse cancel(Long id, Long userId, boolean isAdmin) {
+    public OrderResponse cancel(Long id, Long userId, boolean isAdmin, String reason) {
         // 비관적 락: 만료 스케줄러(cancel)와 결제 확정(confirm)의 동시 실행으로 인한
         // 재고 상태 불일치(allocated 누수)를 방지한다.
         Order order = orderRepository.findByIdWithItemsForUpdate(id)
@@ -337,7 +337,7 @@ public class OrderService {
         validateOrderOwnership(order, userId, isAdmin);
 
         // 상태 검증 + CANCELLED 전환 (PENDING이 아니면 INVALID_ORDER_STATUS 예외)
-        order.cancel();
+        order.cancel(reason);
 
         // 재고 예약 해제
         for (OrderItem item : order.getItems()) {
@@ -370,7 +370,7 @@ public class OrderService {
         Order order = orderRepository.findByIdWithItemsForUpdate(id)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
 
-        order.cancel();
+        order.cancel(null);
 
         for (OrderItem item : order.getItems()) {
             inventoryService.releaseReservation(item.getProduct().getId(), item.getQuantity());

--- a/src/main/java/com/stockmanagement/domain/payment/controller/PaymentController.java
+++ b/src/main/java/com/stockmanagement/domain/payment/controller/PaymentController.java
@@ -5,6 +5,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.stockmanagement.common.dto.ApiResponse;
 import com.stockmanagement.common.ratelimit.RateLimit;
 import com.stockmanagement.domain.payment.dto.*;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import com.stockmanagement.domain.payment.infrastructure.TossWebhookVerifier;
 import com.stockmanagement.domain.payment.infrastructure.dto.TossWebhookEvent;
 import com.stockmanagement.domain.payment.service.PaymentService;
@@ -81,6 +85,15 @@ public class PaymentController {
         webhookVerifier.verify(rawBody, signature);
         TossWebhookEvent event = objectMapper.readValue(rawBody, TossWebhookEvent.class);
         paymentService.handleWebhook(event);
+    }
+
+    @Operation(summary = "내 결제 목록", description = "현재 로그인 사용자의 결제 내역을 최신순으로 페이징 조회한다.")
+    @GetMapping("/my")
+    public ApiResponse<Page<PaymentResponse>> getMyPayments(
+            @AuthenticationPrincipal String username,
+            Authentication authentication,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ApiResponse.ok(paymentService.getMyPayments(resolveUserId(authentication, username), pageable));
     }
 
     @Operation(summary = "결제 조회", description = "paymentKey로 결제 상세 조회. 본인 결제만 가능 (ADMIN은 전체 조회).")

--- a/src/main/java/com/stockmanagement/domain/payment/dto/PaymentPrepareResponse.java
+++ b/src/main/java/com/stockmanagement/domain/payment/dto/PaymentPrepareResponse.java
@@ -10,9 +10,11 @@ import java.math.BigDecimal;
  *
  * <p>Contains the values the client must pass to the TossPayments checkout widget:
  * <ul>
- *   <li>{@code tossOrderId} → widget's {@code orderId} parameter
- *   <li>{@code amount}      → widget's {@code amount} parameter
- *   <li>{@code orderName}   → widget's {@code orderName} parameter
+ *   <li>{@code tossOrderId}    → widget's {@code orderId} parameter
+ *   <li>{@code amount}         → widget's {@code amount} parameter
+ *   <li>{@code orderName}      → widget's {@code orderName} parameter
+ *   <li>{@code customerName}   → widget's {@code customerName} parameter
+ *   <li>{@code customerEmail}  → widget's {@code customerEmail} parameter
  * </ul>
  *
  * <p>Using the server-returned {@code amount} (instead of a client-computed value)
@@ -30,4 +32,10 @@ public class PaymentPrepareResponse {
 
     /** Human-readable order name shown in the checkout UI (e.g. "iPhone 15 외 2건"). */
     private final String orderName;
+
+    /** 결제창 구매자 이름 (TossPayments customerName 파라미터). */
+    private final String customerName;
+
+    /** 결제창 구매자 이메일 (TossPayments customerEmail 파라미터). */
+    private final String customerEmail;
 }

--- a/src/main/java/com/stockmanagement/domain/payment/entity/Payment.java
+++ b/src/main/java/com/stockmanagement/domain/payment/entity/Payment.java
@@ -146,4 +146,23 @@ public class Payment {
         this.failureMessage = failureMessage;
         this.status = PaymentStatus.FAILED;
     }
+
+    /**
+     * Resets a FAILED payment to PENDING for retry.
+     *
+     * <p>FAILED 결제가 존재할 때 사용자가 "다시 결제하기"를 선택하면 기존 레코드를 재사용한다.
+     * {@code tossOrderId}는 TossPayments 측 UNIQUE 값이므로 새 UUID 기반 값으로 교체한다.
+     *
+     * @param newTossOrderId 새 결제 시도용 tossOrderId
+     * @throws BusinessException if the current status is not FAILED
+     */
+    public void resetForRetry(String newTossOrderId) {
+        if (this.status != PaymentStatus.FAILED) {
+            throw new BusinessException(ErrorCode.INVALID_PAYMENT_STATUS);
+        }
+        this.tossOrderId = newTossOrderId;
+        this.failureCode = null;
+        this.failureMessage = null;
+        this.status = PaymentStatus.PENDING;
+    }
 }

--- a/src/main/java/com/stockmanagement/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/stockmanagement/domain/payment/repository/PaymentRepository.java
@@ -1,5 +1,6 @@
 package com.stockmanagement.domain.payment.repository;
 
+import com.stockmanagement.domain.order.entity.Order;
 import com.stockmanagement.domain.payment.entity.Payment;
 import jakarta.persistence.LockModeType;
 import jakarta.persistence.QueryHint;
@@ -8,6 +9,9 @@ import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.Optional;
 
@@ -46,4 +50,8 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
 
     /** Finds a payment by our internal order ID. Used to check for existing PENDING payment. */
     Optional<Payment> findByOrderId(Long orderId);
+
+    /** 특정 사용자의 결제 목록을 최신순으로 페이징 조회한다 (주문 서브쿼리). */
+    @Query("SELECT p FROM Payment p WHERE p.orderId IN (SELECT o.id FROM Order o WHERE o.userId = :userId) ORDER BY p.createdAt DESC")
+    Page<Payment> findByUserId(@Param("userId") Long userId, Pageable pageable);
 }

--- a/src/main/java/com/stockmanagement/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/stockmanagement/domain/payment/service/PaymentService.java
@@ -96,14 +96,23 @@ public class PaymentService {
             throw new BusinessException(ErrorCode.PAYMENT_AMOUNT_MISMATCH);
         }
 
-        // 멱등성: 이미 PENDING 결제가 존재하면 기존 결제 반환
-        Optional<Payment> existing = paymentRepository.findByOrderId(order.getId());
-        if (existing.isPresent() && existing.get().getStatus() == PaymentStatus.PENDING) {
-            return buildPrepareResponse(existing.get(), order);
-        }
-
         // 이번 결제 시도용 고유 tossOrderId 생성
         String tossOrderId = buildTossOrderId(order.getId());
+
+        // 기존 결제 레코드 처리: PENDING → 멱등성 반환, FAILED → 재시도 허용, 기타 → 예외
+        Optional<Payment> existing = paymentRepository.findByOrderId(order.getId());
+        if (existing.isPresent()) {
+            Payment p = existing.get();
+            if (p.getStatus() == PaymentStatus.PENDING) {
+                return buildPrepareResponse(p, order);
+            }
+            if (p.getStatus() == PaymentStatus.FAILED) {
+                // FAILED 결제를 새 tossOrderId로 초기화하여 재사용
+                p.resetForRetry(tossOrderId);
+                return buildPrepareResponse(p, order);
+            }
+            throw new BusinessException(ErrorCode.INVALID_ORDER_STATUS);
+        }
 
         Payment payment = Payment.builder()
                 .orderId(order.getId())

--- a/src/main/java/com/stockmanagement/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/stockmanagement/domain/payment/service/PaymentService.java
@@ -7,6 +7,8 @@ import com.stockmanagement.domain.order.entity.OrderItem;
 import com.stockmanagement.domain.order.entity.OrderStatus;
 import com.stockmanagement.domain.order.repository.OrderRepository;
 import com.stockmanagement.domain.payment.dto.*;
+import com.stockmanagement.domain.user.entity.User;
+import com.stockmanagement.domain.user.repository.UserRepository;
 import com.stockmanagement.domain.payment.entity.Payment;
 import com.stockmanagement.domain.payment.entity.PaymentStatus;
 import com.stockmanagement.domain.payment.infrastructure.PaymentIdempotencyManager;
@@ -25,6 +27,9 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 /**
  * 결제 도메인 핵심 비즈니스 로직 서비스.
@@ -52,6 +57,7 @@ public class PaymentService {
 
     private final PaymentRepository paymentRepository;
     private final OrderRepository orderRepository;
+    private final UserRepository userRepository;
     private final TossPaymentsClient tossPaymentsClient;
     private final PaymentIdempotencyManager idempotencyManager;
     private final PaymentTransactionHelper transactionHelper;
@@ -302,6 +308,11 @@ public class PaymentService {
      * @param isAdmin  ADMIN 여부
      * @return 결제 정보 (없으면 Optional.empty())
      */
+    /** 현재 인증 사용자의 결제 목록을 최신순으로 페이징 조회한다. */
+    public Page<PaymentResponse> getMyPayments(Long userId, Pageable pageable) {
+        return paymentRepository.findByUserId(userId, pageable).map(PaymentResponse::from);
+    }
+
     public Optional<PaymentResponse> getByOrderId(Long orderId, Long userId, boolean isAdmin) {
         if (!isAdmin) {
             // JWT claim에서 추출한 userId로 소유권 검증 — DB 조회 불필요
@@ -331,10 +342,13 @@ public class PaymentService {
      * 예시: "MacBook Pro 외 2건"
      */
     private PaymentPrepareResponse buildPrepareResponse(Payment payment, Order order) {
+        User user = userRepository.findById(order.getUserId()).orElse(null);
         return new PaymentPrepareResponse(
                 payment.getTossOrderId(),
                 payment.getAmount(),
-                buildOrderName(order)
+                buildOrderName(order),
+                user != null ? user.getUsername() : null,
+                user != null ? user.getEmail() : null
         );
     }
 

--- a/src/main/java/com/stockmanagement/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/stockmanagement/domain/payment/service/PaymentService.java
@@ -91,8 +91,8 @@ public class PaymentService {
             throw new BusinessException(ErrorCode.INVALID_ORDER_STATUS);
         }
 
-        // 클라이언트 제출 금액을 서버 저장 금액과 비교 — 클라이언트 조작 방지
-        if (order.getTotalAmount().compareTo(request.getAmount()) != 0) {
+        // 클라이언트 제출 금액을 실제 결제 금액(쿠폰·포인트 차감 후)과 비교 — 클라이언트 조작 방지
+        if (order.getPayableAmount().compareTo(request.getAmount()) != 0) {
             throw new BusinessException(ErrorCode.PAYMENT_AMOUNT_MISMATCH);
         }
 
@@ -117,7 +117,7 @@ public class PaymentService {
         Payment payment = Payment.builder()
                 .orderId(order.getId())
                 .tossOrderId(tossOrderId)
-                .amount(order.getTotalAmount())
+                .amount(order.getPayableAmount())
                 .build();
 
         Payment saved = paymentRepository.save(payment);

--- a/src/main/java/com/stockmanagement/domain/product/category/dto/CategoryResponse.java
+++ b/src/main/java/com/stockmanagement/domain/product/category/dto/CategoryResponse.java
@@ -31,13 +31,16 @@ public class CategoryResponse {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
-    /** flat 목록용 — children 빈 리스트 */
+    /** DISCONTINUED 제외 상품 수 */
+    private long productCount;
+
+    /** flat 목록용 — children 빈 리스트, productCount 0 */
     public static CategoryResponse from(Category category) {
-        return from(category, new ArrayList<>());
+        return from(category, new ArrayList<>(), 0L);
     }
 
-    /** 명시적 children 목록으로 생성 (트리 빌드 시 사용) */
-    public static CategoryResponse from(Category category, List<CategoryResponse> children) {
+    /** 명시적 children + productCount로 생성 (트리·단건 조회 시 사용) */
+    public static CategoryResponse from(Category category, List<CategoryResponse> children, long productCount) {
         return CategoryResponse.builder()
                 .id(category.getId())
                 .name(category.getName())
@@ -47,6 +50,7 @@ public class CategoryResponse {
                 .children(children)
                 .createdAt(category.getCreatedAt())
                 .updatedAt(category.getUpdatedAt())
+                .productCount(productCount)
                 .build();
     }
 }

--- a/src/main/java/com/stockmanagement/domain/product/category/repository/CategoryRepository.java
+++ b/src/main/java/com/stockmanagement/domain/product/category/repository/CategoryRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -31,4 +32,8 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
     @EntityGraph(attributePaths = "children")
     @Query("SELECT c FROM Category c WHERE c.id = :id")
     Optional<Category> findByIdWithChildren(@Param("id") Long id);
+
+    /** 직계 자식 카테고리 ID 목록을 반환한다 (includeChildren 필터링용). */
+    @Query("SELECT c.id FROM Category c WHERE c.parent.id = :parentId")
+    List<Long> findChildIdsByParentId(@Param("parentId") Long parentId);
 }

--- a/src/main/java/com/stockmanagement/domain/product/category/service/CategoryService.java
+++ b/src/main/java/com/stockmanagement/domain/product/category/service/CategoryService.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -63,6 +64,8 @@ public class CategoryService {
     @Cacheable(cacheNames = "categories", key = "'tree'")
     public List<CategoryResponse> getTree() {
         List<Category> all = categoryRepository.findAll();
+        Set<Long> allIds = all.stream().map(Category::getId).collect(Collectors.toSet());
+        Map<Long, Long> countMap = productRepository.countMapByCategoryIds(allIds);
 
         // id → (mutable) children list
         Map<Long, List<CategoryResponse>> childrenMap = new LinkedHashMap<>();
@@ -77,22 +80,27 @@ public class CategoryService {
                 roots.add(c);
             } else {
                 childrenMap.get(c.getParent().getId())
-                        .add(CategoryResponse.from(c));
+                        .add(CategoryResponse.from(c, new ArrayList<>(), countMap.getOrDefault(c.getId(), 0L)));
             }
         }
 
         return roots.stream()
-                .map(r -> CategoryResponse.from(r, childrenMap.get(r.getId())))
+                .map(r -> CategoryResponse.from(r, childrenMap.get(r.getId()), countMap.getOrDefault(r.getId(), 0L)))
                 .collect(Collectors.toList());
     }
 
     /** 단건 조회 — children(하위 카테고리) 목록 포함 */
     public CategoryResponse getById(Long id) {
         Category category = findByIdWithChildren(id);
+        Set<Long> ids = category.getChildren().stream()
+                .map(Category::getId)
+                .collect(Collectors.toSet());
+        ids.add(category.getId());
+        Map<Long, Long> countMap = productRepository.countMapByCategoryIds(ids);
         List<CategoryResponse> children = category.getChildren().stream()
-                .map(CategoryResponse::from)
+                .map(c -> CategoryResponse.from(c, new ArrayList<>(), countMap.getOrDefault(c.getId(), 0L)))
                 .collect(Collectors.toList());
-        return CategoryResponse.from(category, children);
+        return CategoryResponse.from(category, children, countMap.getOrDefault(category.getId(), 0L));
     }
 
     @CacheEvict(cacheNames = "categories", allEntries = true)

--- a/src/main/java/com/stockmanagement/domain/product/controller/ProductController.java
+++ b/src/main/java/com/stockmanagement/domain/product/controller/ProductController.java
@@ -7,6 +7,7 @@ import com.stockmanagement.domain.product.dto.ProductSearchRequest;
 import com.stockmanagement.domain.product.dto.ProductStatusRequest;
 import com.stockmanagement.domain.product.dto.ProductUpdateRequest;
 import com.stockmanagement.domain.product.service.ProductService;
+import com.stockmanagement.domain.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -15,6 +16,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "상품", description = "상품 CRUD — 등록·조회·수정·삭제")
@@ -24,6 +28,7 @@ import org.springframework.web.bind.annotation.*;
 public class ProductController {
 
     private final ProductService productService;
+    private final UserService userService;
 
     @Operation(summary = "상품 등록", description = "ADMIN 전용. SKU 중복 시 409.")
     @PostMapping
@@ -32,9 +37,16 @@ public class ProductController {
         return ApiResponse.ok(productService.create(request));
     }
 
-    @Operation(summary = "상품 단건 조회")
+    @Operation(summary = "상품 단건 조회", description = "로그인 사용자는 canReview 필드 포함. 비로그인 시 canReview=null.")
     @GetMapping("/{id}")
-    public ApiResponse<ProductResponse> getById(@PathVariable Long id) {
+    public ApiResponse<ProductResponse> getById(
+            @PathVariable Long id,
+            @AuthenticationPrincipal String username,
+            Authentication authentication) {
+        if (isAuthenticated(authentication)) {
+            Long userId = resolveUserId(authentication, username);
+            return ApiResponse.ok(productService.getByIdForUser(id, userId));
+        }
         return ApiResponse.ok(productService.getById(id));
     }
 
@@ -42,13 +54,17 @@ public class ProductController {
                description = "검색 조건이 있으면 Elasticsearch, 없으면 MySQL 조회.\n\n" +
                        "- `q`: 키워드 (name, description, category, sku 검색)\n" +
                        "- `minPrice` / `maxPrice`: 가격 범위\n" +
-                       "- `category`: 카테고리 정확 일치\n" +
+                       "- `category`: 카테고리 이름 정확 일치\n" +
+                       "- `categoryId`: 카테고리 ID (includeChildren=true 시 하위 카테고리 포함)\n" +
                        "- `sort`: relevance(기본) | price_asc | price_desc | newest")
     @GetMapping
     public ApiResponse<Page<ProductResponse>> getList(
             @ModelAttribute @Valid ProductSearchRequest request,
-            @PageableDefault(size = 20, sort = "id") Pageable pageable) {
-        return ApiResponse.ok(productService.getList(pageable, request));
+            @PageableDefault(size = 20, sort = "id") Pageable pageable,
+            @AuthenticationPrincipal String username,
+            Authentication authentication) {
+        Long userId = isAuthenticated(authentication) ? resolveUserId(authentication, username) : null;
+        return ApiResponse.ok(productService.getList(pageable, request, userId));
     }
 
     @Operation(summary = "상품 수정", description = "ADMIN 전용.")
@@ -72,5 +88,19 @@ public class ProductController {
             @PathVariable Long id,
             @RequestBody @Valid ProductStatusRequest request) {
         return ApiResponse.ok(productService.changeStatus(id, request));
+    }
+
+    /** 실제 인증 여부 확인 — AnonymousAuthenticationToken은 비로그인으로 처리 */
+    private boolean isAuthenticated(Authentication auth) {
+        return auth != null && auth.isAuthenticated()
+                && !(auth instanceof AnonymousAuthenticationToken);
+    }
+
+    /** JWT claim details에서 userId 추출. 구 토큰이면 DB fallback. */
+    private Long resolveUserId(Authentication auth, String username) {
+        if (auth != null && auth.getDetails() instanceof Long userId) {
+            return userId;
+        }
+        return userService.resolveUserId(username);
     }
 }

--- a/src/main/java/com/stockmanagement/domain/product/dto/ProductResponse.java
+++ b/src/main/java/com/stockmanagement/domain/product/dto/ProductResponse.java
@@ -49,21 +49,36 @@ public class ProductResponse {
     /** 상품 이미지 목록 — null이면 이미지 정보 미포함 (상세 조회 시만 포함) */
     private final List<ProductImageResponse> images;
 
+    /**
+     * 현재 사용자의 리뷰 작성 가능 여부.
+     * null: 비로그인 또는 정보 미포함
+     * true: 구매 완료 + 아직 리뷰 미작성
+     * false: 미구매 또는 이미 리뷰 작성
+     */
+    private final Boolean canReview;
+
     /** Product 엔티티만으로 변환 (재고·리뷰 통계 미포함). */
     public static ProductResponse from(Product product) {
-        return from(product, null, null, null, null);
+        return from(product, null, null, null, null, null);
     }
 
     /** Product 엔티티 + 재고·리뷰 통계를 포함한 전체 응답으로 변환 (이미지 미포함). */
     public static ProductResponse from(Product product, Integer availableQuantity,
                                        Double avgRating, Long reviewCount) {
-        return from(product, availableQuantity, avgRating, reviewCount, null);
+        return from(product, availableQuantity, avgRating, reviewCount, null, null);
     }
 
     /** Product 엔티티 + 재고·리뷰 통계 + 이미지 목록을 포함한 전체 응답으로 변환. */
     public static ProductResponse from(Product product, Integer availableQuantity,
                                        Double avgRating, Long reviewCount,
                                        List<ProductImageResponse> images) {
+        return from(product, availableQuantity, avgRating, reviewCount, images, null);
+    }
+
+    /** Product 엔티티 + 재고·리뷰 통계 + 이미지 + canReview를 포함한 전체 응답으로 변환. */
+    public static ProductResponse from(Product product, Integer availableQuantity,
+                                       Double avgRating, Long reviewCount,
+                                       List<ProductImageResponse> images, Boolean canReview) {
         return ProductResponse.builder()
                 .id(product.getId())
                 .name(product.getName())
@@ -80,6 +95,7 @@ public class ProductResponse {
                 .avgRating(avgRating != null ? Math.round(avgRating * 10.0) / 10.0 : null)
                 .reviewCount(reviewCount)
                 .images(images)
+                .canReview(canReview)
                 .build();
     }
 }

--- a/src/main/java/com/stockmanagement/domain/product/dto/ProductResponse.java
+++ b/src/main/java/com/stockmanagement/domain/product/dto/ProductResponse.java
@@ -57,28 +57,39 @@ public class ProductResponse {
      */
     private final Boolean canReview;
 
+    /** 현재 사용자의 위시리스트 등록 여부 — null이면 비로그인 또는 정보 미포함 */
+    private final Boolean wishlisted;
+
     /** Product 엔티티만으로 변환 (재고·리뷰 통계 미포함). */
     public static ProductResponse from(Product product) {
-        return from(product, null, null, null, null, null);
+        return from(product, null, null, null, null, null, null);
     }
 
     /** Product 엔티티 + 재고·리뷰 통계를 포함한 전체 응답으로 변환 (이미지 미포함). */
     public static ProductResponse from(Product product, Integer availableQuantity,
                                        Double avgRating, Long reviewCount) {
-        return from(product, availableQuantity, avgRating, reviewCount, null, null);
+        return from(product, availableQuantity, avgRating, reviewCount, null, null, null);
     }
 
     /** Product 엔티티 + 재고·리뷰 통계 + 이미지 목록을 포함한 전체 응답으로 변환. */
     public static ProductResponse from(Product product, Integer availableQuantity,
                                        Double avgRating, Long reviewCount,
                                        List<ProductImageResponse> images) {
-        return from(product, availableQuantity, avgRating, reviewCount, images, null);
+        return from(product, availableQuantity, avgRating, reviewCount, images, null, null);
     }
 
     /** Product 엔티티 + 재고·리뷰 통계 + 이미지 + canReview를 포함한 전체 응답으로 변환. */
     public static ProductResponse from(Product product, Integer availableQuantity,
                                        Double avgRating, Long reviewCount,
                                        List<ProductImageResponse> images, Boolean canReview) {
+        return from(product, availableQuantity, avgRating, reviewCount, images, canReview, null);
+    }
+
+    /** Product 엔티티 + 전체 필드(재고·리뷰·이미지·canReview·wishlisted)를 포함한 응답으로 변환. */
+    public static ProductResponse from(Product product, Integer availableQuantity,
+                                       Double avgRating, Long reviewCount,
+                                       List<ProductImageResponse> images, Boolean canReview,
+                                       Boolean wishlisted) {
         return ProductResponse.builder()
                 .id(product.getId())
                 .name(product.getName())
@@ -96,6 +107,7 @@ public class ProductResponse {
                 .reviewCount(reviewCount)
                 .images(images)
                 .canReview(canReview)
+                .wishlisted(wishlisted)
                 .build();
     }
 }

--- a/src/main/java/com/stockmanagement/domain/product/dto/ProductSearchRequest.java
+++ b/src/main/java/com/stockmanagement/domain/product/dto/ProductSearchRequest.java
@@ -48,6 +48,12 @@ public class ProductSearchRequest {
      */
     private String sort;
 
+    /** 카테고리 ID 필터 — null이면 무시. includeChildren=true 시 하위 카테고리 포함 */
+    private Long categoryId;
+
+    /** categoryId 지정 시 하위 카테고리까지 포함 여부 (기본: false) */
+    private boolean includeChildren;
+
     /**
      * Elasticsearch 검색 조건 존재 여부.
      * sort만 지정한 경우도 ES로 처리한다.

--- a/src/main/java/com/stockmanagement/domain/product/image/controller/ProductImageController.java
+++ b/src/main/java/com/stockmanagement/domain/product/image/controller/ProductImageController.java
@@ -43,6 +43,14 @@ public class ProductImageController {
         return ApiResponse.ok(productImageService.getImages(productId));
     }
 
+    @Operation(summary = "이미지 순서 변경", description = "이미지 displayOrder를 일괄 변경합니다. (ADMIN 전용)")
+    @PatchMapping("/order")
+    public ApiResponse<List<ProductImageResponse>> updateImageOrder(
+            @PathVariable Long productId,
+            @Valid @RequestBody ImageOrderUpdateRequest request) {
+        return ApiResponse.ok(productImageService.updateImageOrder(productId, request));
+    }
+
     @Operation(summary = "이미지 삭제", description = "이미지를 스토리지와 DB에서 모두 삭제합니다. (ADMIN 전용)")
     @DeleteMapping("/{imageId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)

--- a/src/main/java/com/stockmanagement/domain/product/image/dto/ImageOrderItem.java
+++ b/src/main/java/com/stockmanagement/domain/product/image/dto/ImageOrderItem.java
@@ -1,0 +1,19 @@
+package com.stockmanagement.domain.product.image.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/** 이미지 순서 변경 요청의 개별 항목. */
+@Getter
+@NoArgsConstructor
+public class ImageOrderItem {
+
+    @NotNull(message = "이미지 ID는 필수입니다.")
+    private Long imageId;
+
+    @NotNull(message = "displayOrder는 필수입니다.")
+    @Min(value = 0, message = "displayOrder는 0 이상이어야 합니다.")
+    private Integer displayOrder;
+}

--- a/src/main/java/com/stockmanagement/domain/product/image/dto/ImageOrderUpdateRequest.java
+++ b/src/main/java/com/stockmanagement/domain/product/image/dto/ImageOrderUpdateRequest.java
@@ -1,0 +1,18 @@
+package com.stockmanagement.domain.product.image.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/** 이미지 순서 일괄 변경 요청 DTO. */
+@Getter
+@NoArgsConstructor
+public class ImageOrderUpdateRequest {
+
+    @NotEmpty(message = "순서 목록은 필수입니다.")
+    @Valid
+    private List<ImageOrderItem> orders;
+}

--- a/src/main/java/com/stockmanagement/domain/product/image/entity/ProductImage.java
+++ b/src/main/java/com/stockmanagement/domain/product/image/entity/ProductImage.java
@@ -50,4 +50,8 @@ public class ProductImage {
         this.imageType = imageType;
         this.displayOrder = displayOrder;
     }
+
+    public void updateDisplayOrder(int displayOrder) {
+        this.displayOrder = displayOrder;
+    }
 }

--- a/src/main/java/com/stockmanagement/domain/product/image/repository/ProductImageRepository.java
+++ b/src/main/java/com/stockmanagement/domain/product/image/repository/ProductImageRepository.java
@@ -3,6 +3,7 @@ package com.stockmanagement.domain.product.image.repository;
 import com.stockmanagement.domain.product.image.entity.ProductImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -11,4 +12,7 @@ public interface ProductImageRepository extends JpaRepository<ProductImage, Long
     List<ProductImage> findByProductIdOrderByDisplayOrderAsc(Long productId);
 
     Optional<ProductImage> findByIdAndProductId(Long id, Long productId);
+
+    /** 이미지 ID 목록 + productId로 배치 조회 (순서 변경 시 소유권 검증) */
+    List<ProductImage> findByProductIdAndIdIn(Long productId, Collection<Long> ids);
 }

--- a/src/main/java/com/stockmanagement/domain/product/image/service/ProductImageService.java
+++ b/src/main/java/com/stockmanagement/domain/product/image/service/ProductImageService.java
@@ -16,7 +16,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -69,6 +71,38 @@ public class ProductImageService {
     /** 상품에 등록된 이미지 목록 조회 (displayOrder 오름차순) */
     public List<ProductImageResponse> getImages(Long productId) {
         findProduct(productId);
+        return productImageRepository.findByProductIdOrderByDisplayOrderAsc(productId)
+                .stream()
+                .map(ProductImageResponse::from)
+                .toList();
+    }
+
+    /**
+     * 이미지 순서를 일괄 변경한다.
+     *
+     * <p>요청의 imageId가 모두 해당 productId에 속해야 하며, 개수가 일치해야 한다.
+     * Dirty Checking으로 UPDATE가 자동 실행된다.
+     */
+    @Transactional
+    public List<ProductImageResponse> updateImageOrder(Long productId, ImageOrderUpdateRequest request) {
+        findProduct(productId);
+
+        List<Long> requestedIds = request.getOrders().stream()
+                .map(ImageOrderItem::getImageId)
+                .toList();
+
+        List<ProductImage> images = productImageRepository.findByProductIdAndIdIn(productId, requestedIds);
+
+        if (images.size() != requestedIds.size()) {
+            throw new BusinessException(ErrorCode.PRODUCT_IMAGE_NOT_FOUND);
+        }
+
+        Map<Long, ProductImage> imageMap = images.stream()
+                .collect(Collectors.toMap(ProductImage::getId, img -> img));
+
+        request.getOrders().forEach(item -> imageMap.get(item.getImageId())
+                .updateDisplayOrder(item.getDisplayOrder()));
+
         return productImageRepository.findByProductIdOrderByDisplayOrderAsc(productId)
                 .stream()
                 .map(ProductImageResponse::from)

--- a/src/main/java/com/stockmanagement/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/stockmanagement/domain/product/repository/ProductRepository.java
@@ -10,6 +10,9 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * 상품 레포지토리.
@@ -65,4 +68,20 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     Page<Product> findByStatusAndCategoryIdIn(@Param("status") ProductStatus status,
                                               @Param("categoryIds") Collection<Long> categoryIds,
                                               Pageable pageable);
+
+    /**
+     * 카테고리별 ACTIVE 상품 수를 배치 조회한다.
+     *
+     * @return [categoryId, count] 쌍의 Object[] 목록
+     */
+    @Query("SELECT p.category.id, COUNT(p) FROM Product p WHERE p.category.id IN :ids AND p.status <> 'DISCONTINUED' GROUP BY p.category.id")
+    List<Object[]> countActiveProductsByCategoryIds(@Param("ids") Collection<Long> ids);
+
+    /** countActiveProductsByCategoryIds() 결과를 Map으로 변환한다. */
+    default Map<Long, Long> countMapByCategoryIds(Collection<Long> ids) {
+        return countActiveProductsByCategoryIds(ids).stream()
+                .collect(Collectors.toMap(
+                        row -> (Long) row[0],
+                        row -> (Long) row[1]));
+    }
 }

--- a/src/main/java/com/stockmanagement/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/stockmanagement/domain/product/repository/ProductRepository.java
@@ -9,6 +9,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
+
 /**
  * 상품 레포지토리.
  *
@@ -56,4 +58,11 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
            countQuery = "SELECT COUNT(p) FROM Product p WHERE " +
                         "LOWER(p.name) LIKE LOWER(CONCAT('%', :q, '%')) OR LOWER(p.sku) LIKE LOWER(CONCAT('%', :q, '%'))")
     Page<Product> searchAll(@Param("q") String query, Pageable pageable);
+
+    /** 카테고리 ID 목록 필터 — ACTIVE 상품 중 해당 카테고리에 속하는 상품만 조회 (하위 카테고리 포함 가능). */
+    @Query(value = "SELECT p FROM Product p LEFT JOIN FETCH p.category WHERE p.status = :status AND p.category.id IN :categoryIds",
+           countQuery = "SELECT COUNT(p) FROM Product p WHERE p.status = :status AND p.category.id IN :categoryIds")
+    Page<Product> findByStatusAndCategoryIdIn(@Param("status") ProductStatus status,
+                                              @Param("categoryIds") Collection<Long> categoryIds,
+                                              Pageable pageable);
 }

--- a/src/main/java/com/stockmanagement/domain/product/review/controller/ReviewController.java
+++ b/src/main/java/com/stockmanagement/domain/product/review/controller/ReviewController.java
@@ -1,6 +1,7 @@
 package com.stockmanagement.domain.product.review.controller;
 
 import com.stockmanagement.common.dto.ApiResponse;
+import com.stockmanagement.domain.product.review.dto.RatingStatsResponse;
 import com.stockmanagement.domain.product.review.dto.ReviewCreateRequest;
 import com.stockmanagement.domain.product.review.dto.ReviewResponse;
 import com.stockmanagement.domain.product.review.dto.ReviewUpdateRequest;
@@ -48,6 +49,13 @@ public class ReviewController {
             @RequestParam(required = false) Integer rating,
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
         return ApiResponse.ok(reviewService.getList(productId, pageable, rating));
+    }
+
+    @Operation(summary = "리뷰 별점 분포 통계",
+               description = "avgRating, reviewCount, distribution(1~5별 리뷰 수) 반환. 비로그인 공개.")
+    @GetMapping("/stats")
+    public ApiResponse<RatingStatsResponse> getRatingStats(@PathVariable Long productId) {
+        return ApiResponse.ok(reviewService.getRatingStats(productId));
     }
 
     @Operation(summary = "리뷰 수정 (작성자 본인)")

--- a/src/main/java/com/stockmanagement/domain/product/review/controller/ReviewController.java
+++ b/src/main/java/com/stockmanagement/domain/product/review/controller/ReviewController.java
@@ -12,6 +12,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
@@ -38,12 +39,15 @@ public class ReviewController {
         return ApiResponse.ok(reviewService.create(productId, resolveUserId(authentication, username), request));
     }
 
-    @Operation(summary = "상품 리뷰 목록 조회 (최신순)")
+    @Operation(summary = "상품 리뷰 목록 조회",
+               description = "sort: createdAt,desc(기본) | rating,desc | rating,asc\n\n" +
+                       "rating: 1~5 별점 필터 (null이면 전체)")
     @GetMapping
     public ApiResponse<Page<ReviewResponse>> getList(
             @PathVariable Long productId,
-            @PageableDefault(size = 20) Pageable pageable) {
-        return ApiResponse.ok(reviewService.getList(productId, pageable));
+            @RequestParam(required = false) Integer rating,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ApiResponse.ok(reviewService.getList(productId, pageable, rating));
     }
 
     @Operation(summary = "리뷰 수정 (작성자 본인)")

--- a/src/main/java/com/stockmanagement/domain/product/review/dto/RatingStatsResponse.java
+++ b/src/main/java/com/stockmanagement/domain/product/review/dto/RatingStatsResponse.java
@@ -1,0 +1,21 @@
+package com.stockmanagement.domain.product.review.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+
+/** 상품 리뷰 별점 분포 통계 응답 DTO. */
+@Getter
+@Builder
+public class RatingStatsResponse {
+
+    /** 평균 별점 (소수점 1자리) */
+    private final double avgRating;
+
+    /** 전체 리뷰 수 */
+    private final long reviewCount;
+
+    /** 별점별 리뷰 수 분포 — key: 1~5, value: 해당 별점 리뷰 수 */
+    private final Map<Integer, Long> distribution;
+}

--- a/src/main/java/com/stockmanagement/domain/product/review/dto/ReviewResponse.java
+++ b/src/main/java/com/stockmanagement/domain/product/review/dto/ReviewResponse.java
@@ -13,20 +13,34 @@ public class ReviewResponse {
     private Long id;
     private Long productId;
     private Long userId;
+    /** 마스킹된 작성자 이름 (예: "ab***") — null이면 정보 미포함 */
+    private String username;
     private int rating;
     private String title;
     private String content;
     private LocalDateTime createdAt;
 
     public static ReviewResponse from(Review review) {
+        return from(review, null);
+    }
+
+    public static ReviewResponse from(Review review, String username) {
         return ReviewResponse.builder()
                 .id(review.getId())
                 .productId(review.getProductId())
                 .userId(review.getUserId())
+                .username(maskUsername(username))
                 .rating(review.getRating())
                 .title(review.getTitle())
                 .content(review.getContent())
                 .createdAt(review.getCreatedAt())
                 .build();
+    }
+
+    /** 앞 2자리 유지, 나머지 마스킹. 길이 2 이하면 전체 마스킹. */
+    private static String maskUsername(String raw) {
+        if (raw == null || raw.isBlank()) return null;
+        if (raw.length() <= 2) return "***";
+        return raw.substring(0, 2) + "***";
     }
 }

--- a/src/main/java/com/stockmanagement/domain/product/review/repository/ReviewRepository.java
+++ b/src/main/java/com/stockmanagement/domain/product/review/repository/ReviewRepository.java
@@ -61,4 +61,8 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     /** 특정 사용자의 특정 별점 리뷰 목록을 페이징 조회한다. */
     Page<Review> findByUserIdAndRating(Long userId, int rating, Pageable pageable);
+
+    /** 상품의 별점별 리뷰 수 분포를 조회한다. Object[0]=rating(Integer), Object[1]=count(Long). */
+    @Query("SELECT r.rating, COUNT(r) FROM Review r WHERE r.productId = :productId GROUP BY r.rating")
+    List<Object[]> findRatingDistributionByProductId(@Param("productId") Long productId);
 }

--- a/src/main/java/com/stockmanagement/domain/product/review/repository/ReviewRepository.java
+++ b/src/main/java/com/stockmanagement/domain/product/review/repository/ReviewRepository.java
@@ -17,6 +17,12 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     /** 상품의 리뷰 목록을 최신순으로 페이징 조회한다. */
     Page<Review> findByProductIdOrderByCreatedAtDesc(Long productId, Pageable pageable);
 
+    /** 상품의 리뷰 목록을 Pageable sort로 조회한다 (정렬/필터 가변). */
+    Page<Review> findByProductId(Long productId, Pageable pageable);
+
+    /** 상품의 특정 별점 리뷰 목록을 Pageable sort로 조회한다. */
+    Page<Review> findByProductIdAndRating(Long productId, int rating, Pageable pageable);
+
     /** 특정 상품에 대한 사용자의 리뷰가 이미 존재하는지 확인한다 (1인 1리뷰 검증). */
     boolean existsByProductIdAndUserId(Long productId, Long userId);
 

--- a/src/main/java/com/stockmanagement/domain/product/review/repository/ReviewRepository.java
+++ b/src/main/java/com/stockmanagement/domain/product/review/repository/ReviewRepository.java
@@ -49,4 +49,10 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     @Query("SELECT r.productId FROM Review r WHERE r.userId = :userId AND r.productId IN :productIds")
     List<Long> findReviewedProductIdsByUserId(@Param("userId") Long userId,
                                               @Param("productIds") Collection<Long> productIds);
+
+    /** 특정 사용자의 리뷰 목록을 페이징 조회한다 (내 리뷰 목록). Pageable sort로 정렬 지원. */
+    Page<Review> findByUserId(Long userId, Pageable pageable);
+
+    /** 특정 사용자의 특정 별점 리뷰 목록을 페이징 조회한다. */
+    Page<Review> findByUserIdAndRating(Long userId, int rating, Pageable pageable);
 }

--- a/src/main/java/com/stockmanagement/domain/product/review/service/ReviewService.java
+++ b/src/main/java/com/stockmanagement/domain/product/review/service/ReviewService.java
@@ -9,12 +9,19 @@ import com.stockmanagement.domain.product.review.dto.ReviewResponse;
 import com.stockmanagement.domain.product.review.dto.ReviewUpdateRequest;
 import com.stockmanagement.domain.product.review.entity.Review;
 import com.stockmanagement.domain.product.review.repository.ReviewRepository;
+import com.stockmanagement.domain.user.entity.User;
+import com.stockmanagement.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 @Service
 @Transactional(readOnly = true)
@@ -24,6 +31,7 @@ public class ReviewService {
     private final ReviewRepository reviewRepository;
     private final ProductRepository productRepository;
     private final OrderRepository orderRepository;
+    private final UserRepository userRepository;
 
     /**
      * 리뷰를 작성한다.
@@ -55,13 +63,22 @@ public class ReviewService {
         return ReviewResponse.from(reviewRepository.save(review));
     }
 
-    /** 상품의 리뷰 목록을 최신순 페이징 조회한다. */
+    /** 상품의 리뷰 목록을 최신순 페이징 조회한다. 작성자 username을 마스킹하여 포함한다. */
     public Page<ReviewResponse> getList(Long productId, Pageable pageable) {
         if (!productRepository.existsById(productId)) {
             throw new BusinessException(ErrorCode.PRODUCT_NOT_FOUND);
         }
-        return reviewRepository.findByProductIdOrderByCreatedAtDesc(productId, pageable)
-                .map(ReviewResponse::from);
+        Page<Review> reviews = reviewRepository.findByProductIdOrderByCreatedAtDesc(productId, pageable);
+        Map<Long, String> usernameMap = buildUsernameMap(reviews.map(Review::getUserId).toList());
+        return reviews.map(r -> ReviewResponse.from(r, usernameMap.get(r.getUserId())));
+    }
+
+    /** 특정 사용자의 리뷰 목록을 페이징 조회한다. 별점 필터 지원. */
+    public Page<ReviewResponse> getMyReviews(Long userId, Pageable pageable, Integer rating) {
+        Page<Review> reviews = (rating != null)
+                ? reviewRepository.findByUserIdAndRating(userId, rating, pageable)
+                : reviewRepository.findByUserId(userId, pageable);
+        return reviews.map(ReviewResponse::from);
     }
 
     /**
@@ -105,5 +122,14 @@ public class ReviewService {
         }
 
         reviewRepository.delete(review);
+    }
+
+    // ===== 내부 헬퍼 =====
+
+    /** userId 목록으로 username Map을 배치 조회한다 (N+1 방지). */
+    private Map<Long, String> buildUsernameMap(List<Long> userIds) {
+        if (userIds.isEmpty()) return Map.of();
+        return StreamSupport.stream(userRepository.findAllById(userIds).spliterator(), false)
+                .collect(Collectors.toMap(User::getId, User::getUsername));
     }
 }

--- a/src/main/java/com/stockmanagement/domain/product/review/service/ReviewService.java
+++ b/src/main/java/com/stockmanagement/domain/product/review/service/ReviewService.java
@@ -63,12 +63,20 @@ public class ReviewService {
         return ReviewResponse.from(reviewRepository.save(review));
     }
 
-    /** 상품의 리뷰 목록을 최신순 페이징 조회한다. 작성자 username을 마스킹하여 포함한다. */
-    public Page<ReviewResponse> getList(Long productId, Pageable pageable) {
+    /**
+     * 상품의 리뷰 목록을 페이징 조회한다.
+     *
+     * <p>rating이 있으면 별점 필터를 적용한다.
+     * Pageable의 sort로 정렬을 지원한다 (기본: createdAt desc).
+     * 작성자 username을 마스킹하여 포함한다.
+     */
+    public Page<ReviewResponse> getList(Long productId, Pageable pageable, Integer rating) {
         if (!productRepository.existsById(productId)) {
             throw new BusinessException(ErrorCode.PRODUCT_NOT_FOUND);
         }
-        Page<Review> reviews = reviewRepository.findByProductIdOrderByCreatedAtDesc(productId, pageable);
+        Page<Review> reviews = (rating != null)
+                ? reviewRepository.findByProductIdAndRating(productId, rating, pageable)
+                : reviewRepository.findByProductId(productId, pageable);
         Map<Long, String> usernameMap = buildUsernameMap(reviews.map(Review::getUserId).toList());
         return reviews.map(r -> ReviewResponse.from(r, usernameMap.get(r.getUserId())));
     }

--- a/src/main/java/com/stockmanagement/domain/product/review/service/ReviewService.java
+++ b/src/main/java/com/stockmanagement/domain/product/review/service/ReviewService.java
@@ -4,6 +4,7 @@ import com.stockmanagement.common.exception.BusinessException;
 import com.stockmanagement.common.exception.ErrorCode;
 import com.stockmanagement.domain.order.repository.OrderRepository;
 import com.stockmanagement.domain.product.repository.ProductRepository;
+import com.stockmanagement.domain.product.review.dto.RatingStatsResponse;
 import com.stockmanagement.domain.product.review.dto.ReviewCreateRequest;
 import com.stockmanagement.domain.product.review.dto.ReviewResponse;
 import com.stockmanagement.domain.product.review.dto.ReviewUpdateRequest;
@@ -18,6 +19,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -130,6 +132,38 @@ public class ReviewService {
         }
 
         reviewRepository.delete(review);
+    }
+
+    /**
+     * 상품의 리뷰 별점 분포 통계를 조회한다.
+     *
+     * <p>distribution: 별점 1~5 각각의 리뷰 수. 해당 별점 리뷰가 없으면 0으로 채운다.
+     *
+     * @throws BusinessException 상품이 없는 경우
+     */
+    public RatingStatsResponse getRatingStats(Long productId) {
+        if (!productRepository.existsById(productId)) {
+            throw new BusinessException(ErrorCode.PRODUCT_NOT_FOUND);
+        }
+
+        List<Object[]> rows = reviewRepository.findRatingDistributionByProductId(productId);
+        Map<Integer, Long> distribution = new HashMap<>();
+        for (int i = 1; i <= 5; i++) distribution.put(i, 0L);
+        for (Object[] row : rows) {
+            distribution.put(((Number) row[0]).intValue(), ((Number) row[1]).longValue());
+        }
+
+        long total = distribution.values().stream().mapToLong(Long::longValue).sum();
+        double avg = total == 0 ? 0.0
+                : distribution.entrySet().stream()
+                        .mapToDouble(e -> e.getKey() * e.getValue())
+                        .sum() / total;
+
+        return RatingStatsResponse.builder()
+                .avgRating(Math.round(avg * 10) / 10.0)
+                .reviewCount(total)
+                .distribution(distribution)
+                .build();
     }
 
     // ===== 내부 헬퍼 =====

--- a/src/main/java/com/stockmanagement/domain/product/service/ProductService.java
+++ b/src/main/java/com/stockmanagement/domain/product/service/ProductService.java
@@ -4,8 +4,10 @@ import com.stockmanagement.common.exception.BusinessException;
 import com.stockmanagement.common.exception.ErrorCode;
 import com.stockmanagement.domain.inventory.entity.Inventory;
 import com.stockmanagement.domain.inventory.repository.InventoryRepository;
+import com.stockmanagement.domain.order.repository.OrderRepository;
 import com.stockmanagement.domain.product.category.entity.Category;
 import com.stockmanagement.domain.product.category.repository.CategoryRepository;
+import com.stockmanagement.domain.product.wishlist.repository.WishlistRepository;
 import com.stockmanagement.domain.product.dto.ProductCreateRequest;
 import com.stockmanagement.domain.product.dto.ProductResponse;
 import com.stockmanagement.domain.product.dto.ProductSearchRequest;
@@ -32,8 +34,10 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -58,6 +62,8 @@ public class ProductService {
     private final ReviewRepository reviewRepository;
     private final ProductImageRepository productImageRepository;
     private final ApplicationEventPublisher eventPublisher;
+    private final OrderRepository orderRepository;
+    private final WishlistRepository wishlistRepository;
 
     /**
      * 상품을 등록한다.
@@ -89,13 +95,35 @@ public class ProductService {
     }
 
     /**
+     * 인증 사용자용 단건 조회 — canReview 포함. 캐시 우회.
+     *
+     * <p>canReview = CONFIRMED 주문 보유 &amp;&amp; 해당 상품 리뷰 미작성.
+     * 비로그인 경우 {@link #getById(Long)}을 사용한다.
+     */
+    public ProductResponse getByIdForUser(Long id, Long userId) {
+        Product product = findById(id);
+        Integer available = inventoryRepository.findByProductId(id)
+                .map(Inventory::getAvailable).orElse(0);
+        ReviewStatsProjection stats = reviewRepository.findReviewStatsByProductId(id).orElse(null);
+        List<ProductImageResponse> images = productImageRepository
+                .findByProductIdOrderByDisplayOrderAsc(id).stream()
+                .map(ProductImageResponse::from).toList();
+        boolean purchased = orderRepository.existsPurchaseByUserIdAndProductId(userId, id);
+        boolean reviewed = reviewRepository.existsByProductIdAndUserId(id, userId);
+        return ProductResponse.from(product, available,
+                stats != null ? stats.getAvgRating() : null,
+                stats != null ? stats.getReviewCount() : 0L,
+                images, purchased && !reviewed);
+    }
+
+    /**
      * 상품 목록을 조회한다.
      *
      * <p>검색 조건({@code q}, {@code minPrice}, {@code maxPrice}, {@code category}, {@code sort})이
      * 하나라도 있으면 Elasticsearch로 검색하고, 없으면 MySQL 페이징 조회를 사용한다.
      * ES 장애 시 MySQL로 fallback하여 서비스 가용성을 유지한다.
      */
-    public Page<ProductResponse> getList(Pageable pageable, ProductSearchRequest request) {
+    public Page<ProductResponse> getList(Pageable pageable, ProductSearchRequest request, Long userId) {
         if (request != null && request.hasSearchCondition()) {
             try {
                 return productSearchService.search(request, pageable);
@@ -106,13 +134,21 @@ public class ProductService {
         // ES 미사용 또는 fallback: sort/keyword를 MySQL에서 처리
         Pageable effectivePageable = toSortedPageable(pageable, request);
         String keyword = request != null ? request.getQ() : null;
+        Long categoryId = request != null ? request.getCategoryId() : null;
         Page<Product> products;
-        if (keyword != null && !keyword.isBlank()) {
+        if (categoryId != null) {
+            Set<Long> categoryIds = new HashSet<>();
+            categoryIds.add(categoryId);
+            if (request.isIncludeChildren()) {
+                categoryIds.addAll(categoryRepository.findChildIdsByParentId(categoryId));
+            }
+            products = productRepository.findByStatusAndCategoryIdIn(ProductStatus.ACTIVE, categoryIds, effectivePageable);
+        } else if (keyword != null && !keyword.isBlank()) {
             products = productRepository.searchByStatus(ProductStatus.ACTIVE, keyword, effectivePageable);
         } else {
             products = productRepository.findByStatus(ProductStatus.ACTIVE, effectivePageable);
         }
-        return enrichPage(products);
+        return enrichPage(products, userId);
     }
 
     /** sort 파라미터를 Pageable의 Sort로 변환 (MySQL fallback용) */
@@ -134,7 +170,7 @@ public class ProductService {
         Page<Product> products = (search != null && !search.isBlank())
                 ? productRepository.searchAll(search, pageable)
                 : productRepository.findAll(pageable);
-        return enrichPage(products);
+        return enrichPage(products, null);
     }
 
     /**
@@ -221,7 +257,7 @@ public class ProductService {
      * 상품 페이지에 재고·리뷰 통계를 배치로 보강한다 (N+1 방지).
      * 재고/리뷰 없는 상품은 0으로 처리한다.
      */
-    private Page<ProductResponse> enrichPage(Page<Product> products) {
+    private Page<ProductResponse> enrichPage(Page<Product> products, Long userId) {
         if (products.isEmpty()) return products.map(ProductResponse::from);
 
         List<Long> ids = products.stream().map(Product::getId).toList();
@@ -233,13 +269,20 @@ public class ProductService {
                 .findReviewStatsByProductIdIn(ids).stream()
                 .collect(Collectors.toMap(ReviewStatsProjection::getProductId, s -> s));
 
+        Set<Long> wishlistedIds = (userId != null)
+                ? wishlistRepository.findWishlistedProductIds(userId, ids)
+                : Set.of();
+
         return products.map(p -> {
             ReviewStatsProjection stats = statsMap.get(p.getId());
             return ProductResponse.from(
                     p,
                     availableMap.getOrDefault(p.getId(), 0),
                     stats != null ? stats.getAvgRating() : null,
-                    stats != null ? stats.getReviewCount() : 0L);
+                    stats != null ? stats.getReviewCount() : 0L,
+                    null,
+                    null,
+                    userId != null ? wishlistedIds.contains(p.getId()) : null);
         });
     }
 

--- a/src/main/java/com/stockmanagement/domain/product/wishlist/controller/WishlistController.java
+++ b/src/main/java/com/stockmanagement/domain/product/wishlist/controller/WishlistController.java
@@ -7,12 +7,14 @@ import com.stockmanagement.domain.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @Tag(name = "Wishlist", description = "위시리스트 API")
 @RestController
@@ -54,12 +56,13 @@ public class WishlistController {
         return ApiResponse.ok(java.util.Map.of("wishlisted", wishlisted));
     }
 
-    @Operation(summary = "내 위시리스트 목록 조회")
+    @Operation(summary = "내 위시리스트 목록 조회 (페이지네이션)")
     @GetMapping
-    public ApiResponse<List<WishlistResponse>> getList(
+    public ApiResponse<Page<WishlistResponse>> getList(
             @AuthenticationPrincipal String username,
-            Authentication authentication) {
-        return ApiResponse.ok(wishlistService.getList(resolveUserId(authentication, username)));
+            Authentication authentication,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ApiResponse.ok(wishlistService.getList(resolveUserId(authentication, username), pageable));
     }
 
     /** JWT details에서 userId를 추출하고, 없으면 DB fallback. */

--- a/src/main/java/com/stockmanagement/domain/product/wishlist/dto/WishlistResponse.java
+++ b/src/main/java/com/stockmanagement/domain/product/wishlist/dto/WishlistResponse.java
@@ -1,5 +1,7 @@
 package com.stockmanagement.domain.product.wishlist.dto;
 
+import com.stockmanagement.domain.product.entity.Product;
+import com.stockmanagement.domain.product.entity.ProductStatus;
 import com.stockmanagement.domain.product.wishlist.entity.WishlistItem;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,15 +20,22 @@ public class WishlistResponse {
     private String thumbnailUrl;
     private LocalDateTime addedAt;
 
-    public static WishlistResponse of(WishlistItem item, String productName,
-                                       BigDecimal productPrice, String thumbnailUrl) {
+    /** 현재 가용 재고 수량 — null이면 재고 정보 미포함 */
+    private Integer availableQuantity;
+
+    /** 상품 판매 상태 */
+    private ProductStatus productStatus;
+
+    public static WishlistResponse of(WishlistItem item, Product product, Integer availableQuantity) {
         return WishlistResponse.builder()
                 .id(item.getId())
                 .productId(item.getProductId())
-                .productName(productName)
-                .productPrice(productPrice)
-                .thumbnailUrl(thumbnailUrl)
+                .productName(product.getName())
+                .productPrice(product.getPrice())
+                .thumbnailUrl(product.getThumbnailUrl())
                 .addedAt(item.getCreatedAt())
+                .availableQuantity(availableQuantity)
+                .productStatus(product.getStatus())
                 .build();
     }
 }

--- a/src/main/java/com/stockmanagement/domain/product/wishlist/repository/WishlistRepository.java
+++ b/src/main/java/com/stockmanagement/domain/product/wishlist/repository/WishlistRepository.java
@@ -1,6 +1,8 @@
 package com.stockmanagement.domain.product.wishlist.repository;
 
 import com.stockmanagement.domain.product.wishlist.entity.WishlistItem;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -16,8 +18,11 @@ public interface WishlistRepository extends JpaRepository<WishlistItem, Long> {
 
     Optional<WishlistItem> findByUserIdAndProductId(Long userId, Long productId);
 
-    /** 사용자의 위시리스트 목록을 최신순으로 조회한다. */
+    /** 사용자의 위시리스트 목록을 최신순으로 조회한다 (전체). */
     List<WishlistItem> findByUserIdOrderByCreatedAtDesc(Long userId);
+
+    /** 사용자의 위시리스트 목록을 최신순으로 페이징 조회한다. */
+    Page<WishlistItem> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
 
     /** 상품 목록 중 위시리스트에 등록된 상품 ID Set을 배치 조회한다 (목록 N+1 방지). */
     @Query("SELECT w.productId FROM WishlistItem w WHERE w.userId = :userId AND w.productId IN :productIds")

--- a/src/main/java/com/stockmanagement/domain/product/wishlist/repository/WishlistRepository.java
+++ b/src/main/java/com/stockmanagement/domain/product/wishlist/repository/WishlistRepository.java
@@ -2,9 +2,13 @@ package com.stockmanagement.domain.product.wishlist.repository;
 
 import com.stockmanagement.domain.product.wishlist.entity.WishlistItem;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface WishlistRepository extends JpaRepository<WishlistItem, Long> {
 
@@ -14,4 +18,9 @@ public interface WishlistRepository extends JpaRepository<WishlistItem, Long> {
 
     /** 사용자의 위시리스트 목록을 최신순으로 조회한다. */
     List<WishlistItem> findByUserIdOrderByCreatedAtDesc(Long userId);
+
+    /** 상품 목록 중 위시리스트에 등록된 상품 ID Set을 배치 조회한다 (목록 N+1 방지). */
+    @Query("SELECT w.productId FROM WishlistItem w WHERE w.userId = :userId AND w.productId IN :productIds")
+    Set<Long> findWishlistedProductIds(@Param("userId") Long userId,
+                                       @Param("productIds") Collection<Long> productIds);
 }

--- a/src/main/java/com/stockmanagement/domain/product/wishlist/service/WishlistService.java
+++ b/src/main/java/com/stockmanagement/domain/product/wishlist/service/WishlistService.java
@@ -10,6 +10,8 @@ import com.stockmanagement.domain.product.wishlist.dto.WishlistResponse;
 import com.stockmanagement.domain.product.wishlist.entity.WishlistItem;
 import com.stockmanagement.domain.product.wishlist.repository.WishlistRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -74,30 +76,32 @@ public class WishlistService {
     }
 
     /**
-     * 사용자의 위시리스트 목록을 조회한다.
+     * 사용자의 위시리스트 목록을 페이징 조회한다.
      *
      * <p>userId는 JWT claim에서 추출한 값을 컨트롤러에서 전달받아 DB users 조회를 생략한다.
      */
-    public List<WishlistResponse> getList(Long userId) {
-        List<WishlistItem> items = wishlistRepository.findByUserIdOrderByCreatedAtDesc(userId);
-        if (items.isEmpty()) {
-            return List.of();
+    public Page<WishlistResponse> getList(Long userId, Pageable pageable) {
+        Page<WishlistItem> page = wishlistRepository.findByUserIdOrderByCreatedAtDesc(userId, pageable);
+        if (page.isEmpty()) {
+            return page.map(item -> null); // 빈 페이지 반환
         }
 
         // N+1 방지: 상품 + 재고를 한 번에 배치 조회
-        List<Long> productIds = items.stream().map(WishlistItem::getProductId).toList();
+        List<Long> productIds = page.map(WishlistItem::getProductId).toList();
         Map<Long, Product> productMap = productRepository.findAllById(productIds).stream()
                 .collect(Collectors.toMap(Product::getId, Function.identity()));
         Map<Long, Integer> availableMap = inventoryRepository.findAllByProductIdIn(productIds).stream()
                 .collect(Collectors.toMap(i -> i.getProduct().getId(), Inventory::getAvailable));
 
-        // 상품이 삭제(soft delete)된 경우 위시리스트 항목을 건너뛴다 — 전체 조회 실패 방지
-        return items.stream()
+        // 상품이 삭제(soft delete)된 경우 null로 매핑 후 필터링 — Spring Data Page는 filter 미지원
+        // → toList()로 materialized 후 PageImpl로 래핑
+        List<WishlistResponse> content = page.stream()
                 .filter(item -> productMap.containsKey(item.getProductId()))
                 .map(item -> WishlistResponse.of(
                         item,
                         productMap.get(item.getProductId()),
                         availableMap.get(item.getProductId())))
                 .toList();
+        return new org.springframework.data.domain.PageImpl<>(content, pageable, page.getTotalElements());
     }
 }

--- a/src/main/java/com/stockmanagement/domain/product/wishlist/service/WishlistService.java
+++ b/src/main/java/com/stockmanagement/domain/product/wishlist/service/WishlistService.java
@@ -2,6 +2,8 @@ package com.stockmanagement.domain.product.wishlist.service;
 
 import com.stockmanagement.common.exception.BusinessException;
 import com.stockmanagement.common.exception.ErrorCode;
+import com.stockmanagement.domain.inventory.entity.Inventory;
+import com.stockmanagement.domain.inventory.repository.InventoryRepository;
 import com.stockmanagement.domain.product.entity.Product;
 import com.stockmanagement.domain.product.repository.ProductRepository;
 import com.stockmanagement.domain.product.wishlist.dto.WishlistResponse;
@@ -23,6 +25,7 @@ public class WishlistService {
 
     private final WishlistRepository wishlistRepository;
     private final ProductRepository productRepository;
+    private final InventoryRepository inventoryRepository;
 
     /**
      * 위시리스트에 상품을 추가한다.
@@ -43,7 +46,10 @@ public class WishlistService {
                 .productId(productId)
                 .build();
 
-        return toResponse(wishlistRepository.save(item), product);
+        Integer available = inventoryRepository.findByProductId(productId)
+                .map(Inventory::getAvailable)
+                .orElse(null);
+        return WishlistResponse.of(wishlistRepository.save(item), product, available);
     }
 
     /**
@@ -78,19 +84,20 @@ public class WishlistService {
             return List.of();
         }
 
-        // N+1 방지: 상품 ID 목록을 한 번에 조회
+        // N+1 방지: 상품 + 재고를 한 번에 배치 조회
         List<Long> productIds = items.stream().map(WishlistItem::getProductId).toList();
         Map<Long, Product> productMap = productRepository.findAllById(productIds).stream()
                 .collect(Collectors.toMap(Product::getId, Function.identity()));
+        Map<Long, Integer> availableMap = inventoryRepository.findAllByProductIdIn(productIds).stream()
+                .collect(Collectors.toMap(i -> i.getProduct().getId(), Inventory::getAvailable));
 
         // 상품이 삭제(soft delete)된 경우 위시리스트 항목을 건너뛴다 — 전체 조회 실패 방지
         return items.stream()
                 .filter(item -> productMap.containsKey(item.getProductId()))
-                .map(item -> toResponse(item, productMap.get(item.getProductId())))
+                .map(item -> WishlistResponse.of(
+                        item,
+                        productMap.get(item.getProductId()),
+                        availableMap.get(item.getProductId())))
                 .toList();
-    }
-
-    private WishlistResponse toResponse(WishlistItem item, Product product) {
-        return WishlistResponse.of(item, product.getName(), product.getPrice(), product.getThumbnailUrl());
     }
 }

--- a/src/main/java/com/stockmanagement/domain/refund/controller/RefundController.java
+++ b/src/main/java/com/stockmanagement/domain/refund/controller/RefundController.java
@@ -5,10 +5,15 @@ import com.stockmanagement.common.security.SecurityUtils;
 import com.stockmanagement.domain.refund.dto.RefundRequest;
 import com.stockmanagement.domain.refund.dto.RefundResponse;
 import com.stockmanagement.domain.refund.service.RefundService;
+import com.stockmanagement.domain.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -21,6 +26,7 @@ import org.springframework.web.bind.annotation.*;
 public class RefundController {
 
     private final RefundService refundService;
+    private final UserService userService;
 
     @Operation(summary = "환불 요청")
     @PostMapping
@@ -29,6 +35,15 @@ public class RefundController {
             @Valid @RequestBody RefundRequest request,
             @AuthenticationPrincipal String username) {
         return ApiResponse.ok(refundService.requestRefund(request, username));
+    }
+
+    @Operation(summary = "내 환불 목록", description = "현재 로그인 사용자의 환불 내역을 최신순으로 페이징 조회한다.")
+    @GetMapping("/my")
+    public ApiResponse<Page<RefundResponse>> getMyRefunds(
+            @AuthenticationPrincipal String username,
+            Authentication authentication,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ApiResponse.ok(refundService.getMyRefunds(resolveUserId(authentication, username), pageable));
     }
 
     @Operation(summary = "환불 단건 조회", description = "ADMIN은 모든 환불 조회 가능. USER는 본인 주문의 환불만 가능.")
@@ -49,5 +64,18 @@ public class RefundController {
             Authentication authentication) {
         boolean isAdmin = SecurityUtils.isAdmin(authentication);
         return ApiResponse.ok(refundService.getByPaymentId(paymentId, username, isAdmin));
+    }
+
+    /**
+     * JWT claim 또는 DB 조회로 userId를 결정한다.
+     *
+     * <p>JwtAuthenticationFilter가 {@code auth.setDetails(userId)}에 저장한 경우 DB 조회를 건너뛴다.
+     * 구 토큰 또는 테스트 환경처럼 details가 없으면 userService.resolveUserId(username)로 DB 조회.
+     */
+    private Long resolveUserId(Authentication auth, String username) {
+        if (auth != null && auth.getDetails() instanceof Long userId) {
+            return userId;
+        }
+        return userService.resolveUserId(username);
     }
 }

--- a/src/main/java/com/stockmanagement/domain/refund/repository/RefundRepository.java
+++ b/src/main/java/com/stockmanagement/domain/refund/repository/RefundRepository.java
@@ -11,6 +11,8 @@ public interface RefundRepository extends JpaRepository<Refund, Long> {
 
     Optional<Refund> findByPaymentId(Long paymentId);
 
+    Optional<Refund> findByOrderId(Long orderId);
+
     /** 특정 사용자의 환불 목록을 최신순으로 페이징 조회한다. */
     Page<Refund> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/stockmanagement/domain/refund/repository/RefundRepository.java
+++ b/src/main/java/com/stockmanagement/domain/refund/repository/RefundRepository.java
@@ -1,6 +1,8 @@
 package com.stockmanagement.domain.refund.repository;
 
 import com.stockmanagement.domain.refund.entity.Refund;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -8,4 +10,7 @@ import java.util.Optional;
 public interface RefundRepository extends JpaRepository<Refund, Long> {
 
     Optional<Refund> findByPaymentId(Long paymentId);
+
+    /** 특정 사용자의 환불 목록을 최신순으로 페이징 조회한다. */
+    Page<Refund> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/stockmanagement/domain/refund/service/RefundService.java
+++ b/src/main/java/com/stockmanagement/domain/refund/service/RefundService.java
@@ -18,6 +18,8 @@ import com.stockmanagement.domain.user.entity.User;
 import com.stockmanagement.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -117,6 +119,12 @@ public class RefundService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.REFUND_NOT_FOUND));
         validateOwnership(refund, user, isAdmin);
         return RefundResponse.from(refund);
+    }
+
+    /** 현재 인증 사용자의 환불 목록을 최신순으로 페이징 조회한다. */
+    public Page<RefundResponse> getMyRefunds(Long userId, Pageable pageable) {
+        return refundRepository.findByUserIdOrderByCreatedAtDesc(userId, pageable)
+                .map(RefundResponse::from);
     }
 
     /** 결제 ID로 환불 정보를 조회한다. 본인 또는 ADMIN만 가능. */

--- a/src/main/java/com/stockmanagement/domain/shipment/controller/ShipmentController.java
+++ b/src/main/java/com/stockmanagement/domain/shipment/controller/ShipmentController.java
@@ -5,10 +5,15 @@ import com.stockmanagement.common.security.SecurityUtils;
 import com.stockmanagement.domain.shipment.dto.ShipmentResponse;
 import com.stockmanagement.domain.shipment.dto.ShipmentUpdateRequest;
 import com.stockmanagement.domain.shipment.service.ShipmentService;
+import com.stockmanagement.domain.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -33,6 +38,17 @@ import org.springframework.web.bind.annotation.*;
 public class ShipmentController {
 
     private final ShipmentService shipmentService;
+    private final UserService userService;
+
+    @Operation(summary = "내 배송 목록 조회", description = "로그인한 사용자의 배송 목록을 최신순으로 반환한다.")
+    @GetMapping("/my")
+    public ApiResponse<Page<ShipmentResponse>> getMyShipments(
+            @AuthenticationPrincipal String username,
+            Authentication authentication,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        Long userId = resolveUserId(authentication, username);
+        return ApiResponse.ok(shipmentService.getMyShipments(userId, pageable));
+    }
 
     @Operation(summary = "주문별 배송 조회", description = "본인 주문의 배송 정보만 조회 가능. ADMIN은 전체 조회 가능.")
     @GetMapping("/orders/{orderId}")
@@ -63,5 +79,12 @@ public class ShipmentController {
     @PatchMapping("/orders/{orderId}/return")
     public ApiResponse<ShipmentResponse> processReturn(@PathVariable Long orderId) {
         return ApiResponse.ok(shipmentService.processReturn(orderId));
+    }
+
+    private Long resolveUserId(Authentication auth, String username) {
+        if (auth != null && auth.getDetails() instanceof Long userId) {
+            return userId;
+        }
+        return userService.resolveUserId(username);
     }
 }

--- a/src/main/java/com/stockmanagement/domain/shipment/dto/ShipmentResponse.java
+++ b/src/main/java/com/stockmanagement/domain/shipment/dto/ShipmentResponse.java
@@ -17,6 +17,8 @@ public class ShipmentResponse {
     private ShipmentStatus status;
     private String carrier;
     private String trackingNumber;
+    /** 배송사 트래킹 URL — carrier + trackingNumber 조합으로 자동 생성. null이면 미지원 배송사 */
+    private String trackingUrl;
     private LocalDateTime shippedAt;
     private LocalDateTime deliveredAt;
     private LocalDateTime createdAt;
@@ -28,9 +30,26 @@ public class ShipmentResponse {
                 .status(shipment.getStatus())
                 .carrier(shipment.getCarrier())
                 .trackingNumber(shipment.getTrackingNumber())
+                .trackingUrl(buildTrackingUrl(shipment.getCarrier(), shipment.getTrackingNumber()))
                 .shippedAt(shipment.getShippedAt())
                 .deliveredAt(shipment.getDeliveredAt())
                 .createdAt(shipment.getCreatedAt())
                 .build();
+    }
+
+    /** 국내 주요 배송사 트래킹 URL을 생성한다. 미지원 배송사는 null 반환. */
+    private static String buildTrackingUrl(String carrier, String trackingNumber) {
+        if (carrier == null || trackingNumber == null) return null;
+        return switch (carrier.toUpperCase()) {
+            case "CJ대한통운", "CJ" ->
+                    "https://trace.cjlogistics.com/next/tracking.html?wblNo=" + trackingNumber;
+            case "한진택배", "HANJIN" ->
+                    "https://www.hanjin.com/kor/CMS/DeliveryMgr/WaybillResult.do?mCode=MN038&schLang=KR&wblnumText2=" + trackingNumber;
+            case "롯데택배", "LOTTE" ->
+                    "https://www.lotteglogis.com/home/reservation/tracking/linkView?InvNo=" + trackingNumber;
+            case "우체국택배", "EPOST" ->
+                    "https://service.epost.go.kr/trace.RetrieveRegiTraceList.comm?sid1=" + trackingNumber;
+            default -> null;
+        };
     }
 }

--- a/src/main/java/com/stockmanagement/domain/shipment/dto/ShipmentResponse.java
+++ b/src/main/java/com/stockmanagement/domain/shipment/dto/ShipmentResponse.java
@@ -5,6 +5,7 @@ import com.stockmanagement.domain.shipment.entity.ShipmentStatus;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 /** 배송 응답 DTO. */
@@ -19,6 +20,7 @@ public class ShipmentResponse {
     private String trackingNumber;
     /** 배송사 트래킹 URL — carrier + trackingNumber 조합으로 자동 생성. null이면 미지원 배송사 */
     private String trackingUrl;
+    private LocalDate estimatedDeliveryAt;
     private LocalDateTime shippedAt;
     private LocalDateTime deliveredAt;
     private LocalDateTime createdAt;
@@ -31,6 +33,7 @@ public class ShipmentResponse {
                 .carrier(shipment.getCarrier())
                 .trackingNumber(shipment.getTrackingNumber())
                 .trackingUrl(buildTrackingUrl(shipment.getCarrier(), shipment.getTrackingNumber()))
+                .estimatedDeliveryAt(shipment.getEstimatedDeliveryAt())
                 .shippedAt(shipment.getShippedAt())
                 .deliveredAt(shipment.getDeliveredAt())
                 .createdAt(shipment.getCreatedAt())

--- a/src/main/java/com/stockmanagement/domain/shipment/dto/ShipmentUpdateRequest.java
+++ b/src/main/java/com/stockmanagement/domain/shipment/dto/ShipmentUpdateRequest.java
@@ -1,12 +1,15 @@
 package com.stockmanagement.domain.shipment.dto;
 
+import jakarta.validation.constraints.FutureOrPresent;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-/** 배송 출고 요청 DTO (택배사 + 운송장 번호). */
+import java.time.LocalDate;
+
+/** 배송 출고 요청 DTO (택배사 + 운송장 번호 + 예상 도착일). */
 @Getter
 @NoArgsConstructor
 public class ShipmentUpdateRequest {
@@ -19,4 +22,8 @@ public class ShipmentUpdateRequest {
     @Size(max = 50, message = "운송장 번호는 50자 이하여야 합니다.")
     @Pattern(regexp = "^[A-Za-z0-9\\-]+$", message = "운송장 번호는 영문, 숫자, 하이픈만 허용됩니다.")
     private String trackingNumber;
+
+    /** 택배사 예상 도착일 (선택, 오늘 이후여야 함) */
+    @FutureOrPresent(message = "예상 도착일은 오늘 이후여야 합니다.")
+    private LocalDate estimatedDeliveryAt;
 }

--- a/src/main/java/com/stockmanagement/domain/shipment/entity/Shipment.java
+++ b/src/main/java/com/stockmanagement/domain/shipment/entity/Shipment.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 /**
@@ -56,6 +57,10 @@ public class Shipment {
     /** 배송 완료 일시 */
     private LocalDateTime deliveredAt;
 
+    /** 택배사 예상 도착일 (출고 시 입력, 선택값) */
+    @Column(name = "estimated_delivery_at")
+    private LocalDate estimatedDeliveryAt;
+
     @CreationTimestamp
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
@@ -77,13 +82,14 @@ public class Shipment {
      *
      * @throws BusinessException PREPARING 상태가 아닌 경우
      */
-    public void ship(String carrier, String trackingNumber) {
+    public void ship(String carrier, String trackingNumber, LocalDate estimatedDeliveryAt) {
         if (this.status != ShipmentStatus.PREPARING) {
             throw new BusinessException(ErrorCode.INVALID_SHIPMENT_STATUS);
         }
         this.status = ShipmentStatus.SHIPPED;
         this.carrier = carrier;
         this.trackingNumber = trackingNumber;
+        this.estimatedDeliveryAt = estimatedDeliveryAt;
         this.shippedAt = LocalDateTime.now();
     }
 

--- a/src/main/java/com/stockmanagement/domain/shipment/repository/ShipmentRepository.java
+++ b/src/main/java/com/stockmanagement/domain/shipment/repository/ShipmentRepository.java
@@ -1,9 +1,16 @@
 package com.stockmanagement.domain.shipment.repository;
 
 import com.stockmanagement.domain.shipment.entity.Shipment;
+import com.stockmanagement.domain.shipment.entity.ShipmentStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /** 배송 레포지토리. */
 public interface ShipmentRepository extends JpaRepository<Shipment, Long> {
@@ -11,4 +18,14 @@ public interface ShipmentRepository extends JpaRepository<Shipment, Long> {
     Optional<Shipment> findByOrderId(Long orderId);
 
     boolean existsByOrderId(Long orderId);
+
+    /** 주문 ID 목록에 대한 배송 정보를 배치 조회한다 (주문 목록 N+1 방지). */
+    @Query("SELECT s FROM Shipment s WHERE s.orderId IN :orderIds")
+    List<Shipment> findAllByOrderIdIn(@Param("orderIds") Collection<Long> orderIds);
+
+    /** 주문 ID → 배송 상태 Map을 반환하는 기본 메서드. */
+    default Map<Long, ShipmentStatus> findStatusMapByOrderIds(Collection<Long> orderIds) {
+        return findAllByOrderIdIn(orderIds).stream()
+                .collect(Collectors.toMap(Shipment::getOrderId, Shipment::getStatus));
+    }
 }

--- a/src/main/java/com/stockmanagement/domain/shipment/repository/ShipmentRepository.java
+++ b/src/main/java/com/stockmanagement/domain/shipment/repository/ShipmentRepository.java
@@ -2,6 +2,8 @@ package com.stockmanagement.domain.shipment.repository;
 
 import com.stockmanagement.domain.shipment.entity.Shipment;
 import com.stockmanagement.domain.shipment.entity.ShipmentStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -28,4 +30,8 @@ public interface ShipmentRepository extends JpaRepository<Shipment, Long> {
         return findAllByOrderIdIn(orderIds).stream()
                 .collect(Collectors.toMap(Shipment::getOrderId, Shipment::getStatus));
     }
+
+    /** 특정 사용자의 배송 목록을 최신순 페이징 조회한다. */
+    @Query("SELECT s FROM Shipment s WHERE s.orderId IN (SELECT o.id FROM Order o WHERE o.userId = :userId) ORDER BY s.createdAt DESC")
+    Page<Shipment> findByUserId(@Param("userId") Long userId, Pageable pageable);
 }

--- a/src/main/java/com/stockmanagement/domain/shipment/service/ShipmentService.java
+++ b/src/main/java/com/stockmanagement/domain/shipment/service/ShipmentService.java
@@ -111,7 +111,7 @@ public class ShipmentService {
     @Transactional
     public ShipmentResponse startShipping(Long orderId, ShipmentUpdateRequest request) {
         Shipment shipment = findByOrderIdOrThrow(orderId);
-        shipment.ship(request.getCarrier(), request.getTrackingNumber());
+        shipment.ship(request.getCarrier(), request.getTrackingNumber(), request.getEstimatedDeliveryAt());
         outboxEventStore.save(new ShipmentShippedEvent(orderId, request.getCarrier(), request.getTrackingNumber()));
         return ShipmentResponse.from(shipment);
     }

--- a/src/main/java/com/stockmanagement/domain/shipment/service/ShipmentService.java
+++ b/src/main/java/com/stockmanagement/domain/shipment/service/ShipmentService.java
@@ -14,6 +14,8 @@ import com.stockmanagement.common.outbox.OutboxEventStore;
 import com.stockmanagement.domain.shipment.repository.ShipmentRepository;
 import com.stockmanagement.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -87,6 +89,17 @@ public class ShipmentService {
         }
 
         return ShipmentResponse.from(shipment);
+    }
+
+    /**
+     * 로그인한 사용자의 배송 목록을 최신순 페이징 조회한다.
+     *
+     * @param userId   요청자 ID (JWT claim 기반)
+     * @param pageable 페이지 요청
+     */
+    public Page<ShipmentResponse> getMyShipments(Long userId, Pageable pageable) {
+        return shipmentRepository.findByUserId(userId, pageable)
+                .map(ShipmentResponse::from);
     }
 
     /**

--- a/src/main/java/com/stockmanagement/domain/user/controller/UserController.java
+++ b/src/main/java/com/stockmanagement/domain/user/controller/UserController.java
@@ -2,6 +2,8 @@ package com.stockmanagement.domain.user.controller;
 
 import com.stockmanagement.common.dto.ApiResponse;
 import com.stockmanagement.domain.order.dto.OrderResponse;
+import com.stockmanagement.domain.product.review.dto.ReviewResponse;
+import com.stockmanagement.domain.product.review.service.ReviewService;
 import com.stockmanagement.domain.user.dto.ChangePasswordRequest;
 import com.stockmanagement.domain.user.dto.UpdateProfileRequest;
 import com.stockmanagement.domain.user.dto.UserResponse;
@@ -15,6 +17,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -22,21 +25,21 @@ import org.springframework.web.bind.annotation.*;
  * 사용자 REST API 컨트롤러.
  *
  * <pre>
- * GET /api/users/me          내 정보 조회 → 200 OK
- * GET /api/users/me/orders   내 주문 목록 (페이징) → 200 OK
+ * GET  /api/users/me              내 정보 조회 (포인트 잔액 포함) → 200 OK
+ * GET  /api/users/me/orders       내 주문 목록 (페이징) → 200 OK
+ * GET  /api/users/me/reviews      내 리뷰 목록 (별점 필터 + 페이징) → 200 OK
  * </pre>
- *
- * JWT 인증이 필요하다. {@link AuthenticationPrincipal}로 username을 주입받아 서비스에 전달한다.
  */
-@Tag(name = "사용자", description = "내 정보 조회 · 내 주문 목록 — JWT 인증 필요")
+@Tag(name = "사용자", description = "내 정보 조회 · 내 주문·리뷰 목록 — JWT 인증 필요")
 @RestController
 @RequestMapping("/api/users")
 @RequiredArgsConstructor
 public class UserController {
 
     private final UserService userService;
+    private final ReviewService reviewService;
 
-    @Operation(summary = "내 정보 조회")
+    @Operation(summary = "내 정보 조회", description = "포인트 잔액(pointBalance) 포함.")
     @GetMapping("/me")
     public ApiResponse<UserResponse> getMe(@AuthenticationPrincipal String username) {
         return ApiResponse.ok(userService.getMe(username));
@@ -73,5 +76,26 @@ public class UserController {
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
             Pageable pageable) {
         return ApiResponse.ok(userService.getMyOrders(username, pageable));
+    }
+
+    @Operation(summary = "내 리뷰 목록 (페이징)",
+               description = "별점 필터 지원 (?rating=1~5). sort 파라미터로 정렬 지정 (createdAt DESC 기본).")
+    @GetMapping("/me/reviews")
+    public ApiResponse<Page<ReviewResponse>> getMyReviews(
+            @AuthenticationPrincipal String username,
+            Authentication authentication,
+            @RequestParam(required = false) Integer rating,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
+            Pageable pageable) {
+        Long userId = resolveUserId(authentication, username);
+        return ApiResponse.ok(reviewService.getMyReviews(userId, pageable, rating));
+    }
+
+    /** JWT claim details에서 userId 추출. 구 토큰이면 DB fallback. */
+    private Long resolveUserId(Authentication auth, String username) {
+        if (auth != null && auth.getDetails() instanceof Long userId) {
+            return userId;
+        }
+        return userService.resolveUserId(username);
     }
 }

--- a/src/main/java/com/stockmanagement/domain/user/dto/LoginResponse.java
+++ b/src/main/java/com/stockmanagement/domain/user/dto/LoginResponse.java
@@ -1,12 +1,16 @@
 package com.stockmanagement.domain.user.dto;
 
+import java.time.LocalDateTime;
+
 public record LoginResponse(
         String accessToken,
         String tokenType,
         long expiresIn,
-        String refreshToken
+        String refreshToken,
+        LocalDateTime refreshTokenExpiresAt
 ) {
     public static LoginResponse of(String accessToken, long expiresInSeconds, String refreshToken) {
-        return new LoginResponse(accessToken, "Bearer", expiresInSeconds, refreshToken);
+        return new LoginResponse(accessToken, "Bearer", expiresInSeconds, refreshToken,
+                LocalDateTime.now().plusDays(30));
     }
 }

--- a/src/main/java/com/stockmanagement/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/stockmanagement/domain/user/dto/UserResponse.java
@@ -10,15 +10,22 @@ public record UserResponse(
         String username,
         String email,
         UserRole role,
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+        /** 포인트 잔액 — null이면 포인트 레코드 미생성 (첫 적립 전) */
+        Long pointBalance
 ) {
     public static UserResponse from(User user) {
+        return from(user, null);
+    }
+
+    public static UserResponse from(User user, Long pointBalance) {
         return new UserResponse(
                 user.getId(),
                 user.getUsername(),
                 user.getEmail(),
                 user.getRole(),
-                user.getCreatedAt()
+                user.getCreatedAt(),
+                pointBalance
         );
     }
 }

--- a/src/main/java/com/stockmanagement/domain/user/service/UserService.java
+++ b/src/main/java/com/stockmanagement/domain/user/service/UserService.java
@@ -118,11 +118,13 @@ public class UserService {
                 .getId();
     }
 
-    /** 현재 인증된 사용자 정보 조회. */
+    /** 현재 인증된 사용자 정보 조회 (포인트 잔액 포함). */
     public UserResponse getMe(String username) {
         User user = userRepository.findByUsername(username)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
-        return UserResponse.from(user);
+        Long pointBalance = userPointRepository.findByUserId(user.getId())
+                .map(up -> up.getBalance()).orElse(null);
+        return UserResponse.from(user, pointBalance);
     }
 
     /** 회원 탈퇴 — 논리 삭제 처리. username/email을 익명화하여 동일 정보로 재가입 가능. */

--- a/src/main/java/com/stockmanagement/domain/user/service/UserService.java
+++ b/src/main/java/com/stockmanagement/domain/user/service/UserService.java
@@ -8,6 +8,7 @@ import com.stockmanagement.domain.order.repository.OrderRepository;
 import com.stockmanagement.domain.point.entity.UserPoint;
 import com.stockmanagement.domain.point.repository.UserPointRepository;
 import com.stockmanagement.domain.product.review.repository.ReviewRepository;
+import com.stockmanagement.domain.shipment.repository.ShipmentRepository;
 import com.stockmanagement.domain.user.dto.ChangePasswordRequest;
 import com.stockmanagement.domain.user.dto.LoginRequest;
 import com.stockmanagement.domain.user.dto.LoginResponse;
@@ -30,6 +31,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -47,6 +49,7 @@ public class UserService {
     private final OrderRepository orderRepository;
     private final ReviewRepository reviewRepository;
     private final UserPointRepository userPointRepository;
+    private final ShipmentRepository shipmentRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
     private final LoginRateLimiter loginRateLimiter;
@@ -170,7 +173,7 @@ public class UserService {
         refreshTokenStore.revokeAll(username);
     }
 
-    /** 현재 인증된 사용자의 주문 목록 페이징 조회. hasReview 정보 포함. */
+    /** 현재 인증된 사용자의 주문 목록 페이징 조회. hasReview + shipmentStatus 정보 포함. */
     public Page<OrderResponse> getMyOrders(String username, Pageable pageable) {
         User user = userRepository.findByUsername(username)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
@@ -182,6 +185,10 @@ public class UserService {
         Set<Long> reviewedIds = allProductIds.isEmpty()
                 ? Set.of()
                 : new HashSet<>(reviewRepository.findReviewedProductIdsByUserId(user.getId(), allProductIds));
-        return orders.map(o -> OrderResponse.from(o, reviewedIds));
+        // 배송 상태 배치 조회 (N+1 방지)
+        List<Long> orderIds = orders.map(Order::getId).toList();
+        Map<Long, com.stockmanagement.domain.shipment.entity.ShipmentStatus> statusMap =
+                shipmentRepository.findStatusMapByOrderIds(orderIds);
+        return orders.map(o -> OrderResponse.from(o, reviewedIds, statusMap.get(o.getId())));
     }
 }

--- a/src/main/resources/db/migration/V35__add_order_cancel_reason.sql
+++ b/src/main/resources/db/migration/V35__add_order_cancel_reason.sql
@@ -1,0 +1,1 @@
+ALTER TABLE orders ADD COLUMN cancel_reason VARCHAR(255);

--- a/src/main/resources/db/migration/V36__add_shipment_estimated_delivery.sql
+++ b/src/main/resources/db/migration/V36__add_shipment_estimated_delivery.sql
@@ -1,0 +1,3 @@
+-- #40: 배송 예상 도착일 추가
+ALTER TABLE shipments
+    ADD COLUMN estimated_delivery_at DATE NULL COMMENT '택배사 예상 도착일 (출고 시 입력)';

--- a/src/main/resources/db/migration/V37__add_cart_item_saved_price.sql
+++ b/src/main/resources/db/migration/V37__add_cart_item_saved_price.sql
@@ -1,0 +1,2 @@
+ALTER TABLE cart_items
+    ADD COLUMN saved_price DECIMAL(12, 2) NULL COMMENT '장바구니 담은 시점의 단가 (가격 변동 감지용)';

--- a/src/test/java/com/stockmanagement/common/dto/ApiResponseTest.java
+++ b/src/test/java/com/stockmanagement/common/dto/ApiResponseTest.java
@@ -1,0 +1,96 @@
+package com.stockmanagement.common.dto;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.stockmanagement.common.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ApiResponse 단위 테스트")
+class ApiResponseTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    @DisplayName("ok() — success=true, data 포함, errorCode/errors null")
+    void ok_withData() throws Exception {
+        ApiResponse<String> response = ApiResponse.ok("hello");
+
+        assertThat(response.isSuccess()).isTrue();
+        assertThat(response.getData()).isEqualTo("hello");
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+        assertThat(response.getErrors()).isNull();
+
+        String json = objectMapper.writeValueAsString(response);
+        assertThat(json).contains("\"success\":true");
+        assertThat(json).contains("\"data\":\"hello\"");
+        assertThat(json).doesNotContain("errorCode");
+        assertThat(json).doesNotContain("errors");
+    }
+
+    @Test
+    @DisplayName("error(String) — errorCode 없이 message만 포함 (레거시 호환)")
+    void error_withMessageOnly() throws Exception {
+        ApiResponse<Void> response = ApiResponse.error("오류 발생");
+
+        assertThat(response.isSuccess()).isFalse();
+        assertThat(response.getMessage()).isEqualTo("오류 발생");
+        assertThat(response.getErrorCode()).isNull();
+
+        String json = objectMapper.writeValueAsString(response);
+        assertThat(json).contains("\"success\":false");
+        assertThat(json).contains("\"message\":\"오류 발생\"");
+        assertThat(json).doesNotContain("errorCode");
+    }
+
+    @Test
+    @DisplayName("error(ErrorCode, String) — errorCode 포함")
+    void error_withErrorCode() throws Exception {
+        ApiResponse<Void> response = ApiResponse.error(ErrorCode.ORDER_NOT_FOUND, "주문을 찾을 수 없습니다.");
+
+        assertThat(response.isSuccess()).isFalse();
+        assertThat(response.getErrorCode()).isEqualTo("ORDER_NOT_FOUND");
+        assertThat(response.getMessage()).isEqualTo("주문을 찾을 수 없습니다.");
+        assertThat(response.getErrors()).isNull();
+
+        String json = objectMapper.writeValueAsString(response);
+        assertThat(json).contains("\"errorCode\":\"ORDER_NOT_FOUND\"");
+        assertThat(json).contains("\"message\":\"주문을 찾을 수 없습니다.\"");
+        assertThat(json).doesNotContain("\"errors\"");
+    }
+
+    @Test
+    @DisplayName("validationError() — errors 필드에 필드별 에러 포함")
+    void validationError_withFieldErrors() throws Exception {
+        List<ApiResponse.FieldErrorDetail> errors = List.of(
+                new ApiResponse.FieldErrorDetail("email", "이메일 형식이 올바르지 않습니다."),
+                new ApiResponse.FieldErrorDetail("password", "비밀번호는 8자 이상이어야 합니다.")
+        );
+        ApiResponse<Void> response = ApiResponse.validationError(errors);
+
+        assertThat(response.isSuccess()).isFalse();
+        assertThat(response.getErrors()).hasSize(2);
+        assertThat(response.getErrors().get(0).field()).isEqualTo("email");
+        assertThat(response.getErrors().get(1).field()).isEqualTo("password");
+        assertThat(response.getErrorCode()).isNull();
+
+        String json = objectMapper.writeValueAsString(response);
+        assertThat(json).contains("\"errors\"");
+        assertThat(json).contains("\"field\":\"email\"");
+        assertThat(json).doesNotContain("\"errorCode\"");
+    }
+
+    @Test
+    @DisplayName("UNAUTHORIZED/FORBIDDEN ErrorCode — errorCode 이름 검증")
+    void securityErrorCodes() {
+        ApiResponse<Void> unauthorized = ApiResponse.error(ErrorCode.UNAUTHORIZED, "인증이 필요합니다.");
+        ApiResponse<Void> forbidden = ApiResponse.error(ErrorCode.FORBIDDEN, "접근 권한이 없습니다.");
+
+        assertThat(unauthorized.getErrorCode()).isEqualTo("UNAUTHORIZED");
+        assertThat(forbidden.getErrorCode()).isEqualTo("FORBIDDEN");
+    }
+}

--- a/src/test/java/com/stockmanagement/common/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/stockmanagement/common/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,94 @@
+package com.stockmanagement.common.exception;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.*;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * GlobalExceptionHandler 동작 검증 테스트.
+ *
+ * <p>standaloneSetup 방식으로 Spring 컨텍스트 없이 테스트.
+ * BusinessException errorCode 포함 여부, @Valid 필드별 errors 구조를 검증한다.
+ */
+@DisplayName("GlobalExceptionHandler 단위 테스트")
+class GlobalExceptionHandlerTest {
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new TestController())
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    // ===== 테스트용 컨트롤러 및 DTO =====
+
+    @RestController
+    static class TestController {
+
+        @GetMapping("/test/business-error")
+        public void throwBusiness() {
+            throw new BusinessException(ErrorCode.ORDER_NOT_FOUND);
+        }
+
+        @PostMapping("/test/validation")
+        public void withValidation(@RequestBody @Valid TestRequest request) {}
+    }
+
+    record TestRequest(
+            @NotBlank(message = "이름은 필수입니다.") String name,
+            @Email(message = "이메일 형식이 올바르지 않습니다.") @NotBlank(message = "이메일은 필수입니다.") String email
+    ) {}
+
+    // ===== 테스트 =====
+
+    @Test
+    @DisplayName("BusinessException → errorCode 포함 응답")
+    void businessException_includesErrorCode() throws Exception {
+        mockMvc.perform(get("/test/business-error"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.errorCode").value("ORDER_NOT_FOUND"))
+                .andExpect(jsonPath("$.message").isNotEmpty());
+    }
+
+    @Test
+    @DisplayName("@Valid 실패 → errors 배열에 필드별 에러 포함")
+    void validationError_returnsFieldErrors() throws Exception {
+        mockMvc.perform(post("/test/validation")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"\",\"email\":\"not-an-email\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.errors").isArray())
+                .andExpect(jsonPath("$.errors[*].field", hasItems("name", "email")))
+                .andExpect(jsonPath("$.errors[*].message", hasSize(greaterThan(0))))
+                .andExpect(jsonPath("$.errorCode").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("@Valid 실패 → message는 단일 문자열, errorCode는 없음")
+    void validationError_noErrorCode() throws Exception {
+        mockMvc.perform(post("/test/validation")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"\",\"email\":\"\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errors").isArray())
+                .andExpect(jsonPath("$.errors.length()", greaterThan(0)))
+                .andExpect(jsonPath("$.errorCode").doesNotExist());
+    }
+}

--- a/src/test/java/com/stockmanagement/domain/admin/controller/AdminControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/admin/controller/AdminControllerTest.java
@@ -73,10 +73,10 @@ class AdminControllerTest {
         }
 
         @Test
-        @DisplayName("인증 없음 → 403")
+        @DisplayName("인증 없음 → 401")
         void unauthenticated() throws Exception {
             mockMvc.perform(get("/api/admin/dashboard"))
-                    .andExpect(status().isForbidden());
+                    .andExpect(status().isUnauthorized());
         }
     }
 

--- a/src/test/java/com/stockmanagement/domain/coupon/controller/CouponControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/coupon/controller/CouponControllerTest.java
@@ -89,12 +89,12 @@ class CouponControllerTest {
         }
 
         @Test
-        @DisplayName("인증 없음 → 403")
+        @DisplayName("인증 없음 → 401")
         void unauthenticated() throws Exception {
             mockMvc.perform(post("/api/coupons")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(CREATE_JSON))
-                    .andExpect(status().isForbidden());
+                    .andExpect(status().isUnauthorized());
         }
     }
 
@@ -191,10 +191,10 @@ class CouponControllerTest {
         }
 
         @Test
-        @DisplayName("인증 없음 → 403")
+        @DisplayName("인증 없음 → 401")
         void unauthenticated() throws Exception {
             mockMvc.perform(get("/api/coupons/my"))
-                    .andExpect(status().isForbidden());
+                    .andExpect(status().isUnauthorized());
         }
     }
 
@@ -237,12 +237,12 @@ class CouponControllerTest {
         }
 
         @Test
-        @DisplayName("인증 없음 → 403")
+        @DisplayName("인증 없음 → 401")
         void unauthenticated() throws Exception {
             mockMvc.perform(post("/api/coupons/validate")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(VALIDATE_JSON))
-                    .andExpect(status().isForbidden());
+                    .andExpect(status().isUnauthorized());
         }
     }
 }

--- a/src/test/java/com/stockmanagement/domain/inventory/controller/InventoryControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/inventory/controller/InventoryControllerTest.java
@@ -100,10 +100,10 @@ class InventoryControllerTest {
         }
 
         @Test
-        @DisplayName("인증 없음 → 403")
+        @DisplayName("인증 없음 → 401")
         void unauthorizedWithoutAuth() throws Exception {
             mockMvc.perform(get("/api/inventory"))
-                    .andExpect(status().isForbidden());
+                    .andExpect(status().isUnauthorized());
         }
     }
 
@@ -125,10 +125,10 @@ class InventoryControllerTest {
         }
 
         @Test
-        @DisplayName("인증 없음 → 403")
+        @DisplayName("인증 없음 → 401")
         void unauthorizedWithoutAuth() throws Exception {
             mockMvc.perform(get("/api/inventory/1"))
-                    .andExpect(status().isForbidden());
+                    .andExpect(status().isUnauthorized());
         }
 
         @Test
@@ -164,10 +164,10 @@ class InventoryControllerTest {
         }
 
         @Test
-        @DisplayName("인증 없음 → 403")
+        @DisplayName("인증 없음 → 401")
         void unauthorizedWithoutAuth() throws Exception {
             mockMvc.perform(get("/api/inventory/1/transactions"))
-                    .andExpect(status().isForbidden());
+                    .andExpect(status().isUnauthorized());
         }
 
         @Test
@@ -215,12 +215,12 @@ class InventoryControllerTest {
         }
 
         @Test
-        @DisplayName("인증 없음 → 403")
+        @DisplayName("인증 없음 → 401")
         void unauthorizedWithoutAuth() throws Exception {
             mockMvc.perform(post("/api/inventory/1/receive")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(VALID_JSON))
-                    .andExpect(status().isForbidden());
+                    .andExpect(status().isUnauthorized());
         }
 
         @Test

--- a/src/test/java/com/stockmanagement/domain/order/cart/controller/CartControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/order/cart/controller/CartControllerTest.java
@@ -69,10 +69,10 @@ class CartControllerTest {
         }
 
         @Test
-        @DisplayName("인증 없음 → 403")
+        @DisplayName("인증 없음 → 401")
         void unauthenticated() throws Exception {
             mockMvc.perform(get("/api/cart"))
-                    .andExpect(status().isForbidden());
+                    .andExpect(status().isUnauthorized());
         }
     }
 
@@ -122,10 +122,10 @@ class CartControllerTest {
         }
 
         @Test
-        @DisplayName("인증 없음 → 403")
+        @DisplayName("인증 없음 → 401")
         void unauthenticated() throws Exception {
             mockMvc.perform(delete("/api/cart/items/1"))
-                    .andExpect(status().isForbidden());
+                    .andExpect(status().isUnauthorized());
         }
     }
 

--- a/src/test/java/com/stockmanagement/domain/order/cart/service/CartServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/order/cart/service/CartServiceTest.java
@@ -167,7 +167,7 @@ class CartServiceTest {
             cartService.checkout(1L, request);
 
             verify(orderService).create(any(), anyLong());
-            verify(cartRepository).deleteByUserId(1L);
+            verify(cartRepository).deleteByUserIdAndProductIdIn(eq(1L), any());
         }
 
         @Test

--- a/src/test/java/com/stockmanagement/domain/order/controller/OrderControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/order/controller/OrderControllerTest.java
@@ -85,12 +85,12 @@ class OrderControllerTest {
         }
 
         @Test
-        @DisplayName("인증 없음 → 403")
+        @DisplayName("인증 없음 → 401")
         void unauthorizedWithoutAuth() throws Exception {
             mockMvc.perform(post("/api/orders")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(VALID_JSON))
-                    .andExpect(status().isForbidden());
+                    .andExpect(status().isUnauthorized());
         }
 
         @Test
@@ -136,10 +136,10 @@ class OrderControllerTest {
         }
 
         @Test
-        @DisplayName("인증 없음 → 403")
+        @DisplayName("인증 없음 → 401")
         void unauthorizedWithoutAuth() throws Exception {
             mockMvc.perform(get("/api/orders/1"))
-                    .andExpect(status().isForbidden());
+                    .andExpect(status().isUnauthorized());
         }
 
         @Test
@@ -204,10 +204,10 @@ class OrderControllerTest {
         }
 
         @Test
-        @DisplayName("인증 없음 → 403")
+        @DisplayName("인증 없음 → 401")
         void unauthorizedWithoutAuth() throws Exception {
             mockMvc.perform(post("/api/orders/1/cancel"))
-                    .andExpect(status().isForbidden());
+                    .andExpect(status().isUnauthorized());
         }
 
         @Test
@@ -242,10 +242,10 @@ class OrderControllerTest {
         }
 
         @Test
-        @DisplayName("인증 없음 → 403")
+        @DisplayName("인증 없음 → 401")
         void unauthorizedWithoutAuth() throws Exception {
             mockMvc.perform(get("/api/orders/1/history"))
-                    .andExpect(status().isForbidden());
+                    .andExpect(status().isUnauthorized());
         }
 
         @Test

--- a/src/test/java/com/stockmanagement/domain/order/controller/OrderControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/order/controller/OrderControllerTest.java
@@ -196,7 +196,7 @@ class OrderControllerTest {
         @WithMockUser
         @DisplayName("인증된 사용자 — 주문 취소 성공 → 200")
         void cancelsOrder() throws Exception {
-            given(orderService.cancel(anyLong(), any(), anyBoolean())).willReturn(mock(OrderResponse.class));
+            given(orderService.cancel(anyLong(), any(), anyBoolean(), any())).willReturn(mock(OrderResponse.class));
 
             mockMvc.perform(post("/api/orders/1/cancel"))
                     .andExpect(status().isOk())
@@ -214,7 +214,7 @@ class OrderControllerTest {
         @WithMockUser
         @DisplayName("취소 불가 상태의 주문 → 409")
         void invalidStatus() throws Exception {
-            given(orderService.cancel(anyLong(), any(), anyBoolean()))
+            given(orderService.cancel(anyLong(), any(), anyBoolean(), any()))
                     .willThrow(new BusinessException(ErrorCode.INVALID_ORDER_STATUS));
 
             mockMvc.perform(post("/api/orders/1/cancel"))

--- a/src/test/java/com/stockmanagement/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/order/service/OrderServiceTest.java
@@ -19,6 +19,8 @@ import com.stockmanagement.domain.order.repository.OrderRepository;
 import com.stockmanagement.domain.order.repository.OrderStatusHistoryRepository;
 import com.stockmanagement.domain.product.entity.Product;
 import com.stockmanagement.domain.product.repository.ProductRepository;
+import com.stockmanagement.domain.shipment.entity.ShipmentStatus;
+import com.stockmanagement.domain.shipment.repository.ShipmentRepository;
 import com.stockmanagement.common.outbox.OutboxEventStore;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -37,6 +39,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.*;
@@ -72,6 +75,9 @@ class OrderServiceTest {
     @Mock
     private DeliveryAddressService deliveryAddressService;
 
+    @Mock
+    private ShipmentRepository shipmentRepository;
+
     @InjectMocks
     private OrderService orderService;
 
@@ -100,6 +106,8 @@ class OrderServiceTest {
                 .unitPrice(new BigDecimal("10000"))
                 .build();
         order.addItem(orderItem);
+
+        lenient().when(shipmentRepository.findStatusMapByOrderIds(any())).thenReturn(new java.util.HashMap<>());
     }
 
     // ===== create() =====

--- a/src/test/java/com/stockmanagement/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/order/service/OrderServiceTest.java
@@ -203,6 +203,29 @@ class OrderServiceTest {
         }
 
         @Test
+        @DisplayName("동일 상품 중복 포함 시 INVALID_INPUT 예외 발생")
+        void throwsWhenDuplicateProductId() {
+            OrderItemRequest item1 = mock(OrderItemRequest.class);
+            given(item1.getProductId()).willReturn(1L);
+            OrderItemRequest item2 = mock(OrderItemRequest.class);
+            given(item2.getProductId()).willReturn(1L); // 중복 상품
+
+            OrderCreateRequest request = mock(OrderCreateRequest.class);
+            given(request.getIdempotencyKey()).willReturn("idem-key-dup");
+            given(request.getItems()).willReturn(List.of(item1, item2));
+
+            given(orderRepository.findByIdempotencyKey("idem-key-dup")).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> orderService.create(request))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.INVALID_INPUT));
+
+            verify(orderRepository, never()).save(any());
+            verifyNoInteractions(inventoryService);
+        }
+
+        @Test
         @DisplayName("쿠폰 코드 포함 주문 생성 — discountAmount 적용")
         void createOrderWithCoupon() {
             OrderItemRequest itemRequest = mock(OrderItemRequest.class);

--- a/src/test/java/com/stockmanagement/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/order/service/OrderServiceTest.java
@@ -331,7 +331,7 @@ class OrderServiceTest {
         void cancelsPendingOrder() {
             given(orderRepository.findByIdWithItemsForUpdate(1L)).willReturn(Optional.of(order));
 
-            OrderResponse response = orderService.cancel(1L, 1L, false); // userId=1L, order.userId=1L
+            OrderResponse response = orderService.cancel(1L, 1L, false, null); // userId=1L, order.userId=1L
 
             assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELLED);
             verify(inventoryService).releaseReservation(any(), eq(1));
@@ -344,7 +344,7 @@ class OrderServiceTest {
             order.confirm(); // PENDING → CONFIRMED
             given(orderRepository.findByIdWithItemsForUpdate(1L)).willReturn(Optional.of(order));
 
-            assertThatThrownBy(() -> orderService.cancel(1L, 1L, false))
+            assertThatThrownBy(() -> orderService.cancel(1L, 1L, false, null))
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                             .isEqualTo(ErrorCode.INVALID_ORDER_STATUS));
@@ -357,7 +357,7 @@ class OrderServiceTest {
         void throwsWhenNotFound() {
             given(orderRepository.findByIdWithItemsForUpdate(99L)).willReturn(Optional.empty());
 
-            assertThatThrownBy(() -> orderService.cancel(99L, 1L, false))
+            assertThatThrownBy(() -> orderService.cancel(99L, 1L, false, null))
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                             .isEqualTo(ErrorCode.ORDER_NOT_FOUND));

--- a/src/test/java/com/stockmanagement/domain/payment/controller/PaymentControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/payment/controller/PaymentControllerTest.java
@@ -76,12 +76,12 @@ class PaymentControllerTest {
         }
 
         @Test
-        @DisplayName("인증 없음 → 403")
+        @DisplayName("인증 없음 → 401")
         void unauthorizedWithoutAuth() throws Exception {
             mockMvc.perform(post("/api/payments/prepare")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(VALID_JSON))
-                    .andExpect(status().isForbidden());
+                    .andExpect(status().isUnauthorized());
         }
 
         @Test
@@ -118,12 +118,12 @@ class PaymentControllerTest {
         }
 
         @Test
-        @DisplayName("인증 없음 → 403")
+        @DisplayName("인증 없음 → 401")
         void unauthorizedWithoutAuth() throws Exception {
             mockMvc.perform(post("/api/payments/confirm")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(VALID_JSON))
-                    .andExpect(status().isForbidden());
+                    .andExpect(status().isUnauthorized());
         }
 
         @Test
@@ -163,12 +163,12 @@ class PaymentControllerTest {
         }
 
         @Test
-        @DisplayName("인증 없음 → 403")
+        @DisplayName("인증 없음 → 401")
         void unauthorizedWithoutAuth() throws Exception {
             mockMvc.perform(post("/api/payments/pk-test/cancel")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(VALID_JSON))
-                    .andExpect(status().isForbidden());
+                    .andExpect(status().isUnauthorized());
         }
 
         @Test
@@ -233,10 +233,10 @@ class PaymentControllerTest {
         }
 
         @Test
-        @DisplayName("인증 없음 → 403")
+        @DisplayName("인증 없음 → 401")
         void unauthorizedWithoutAuth() throws Exception {
             mockMvc.perform(get("/api/payments/order/1"))
-                    .andExpect(status().isForbidden());
+                    .andExpect(status().isUnauthorized());
         }
     }
 
@@ -259,10 +259,10 @@ class PaymentControllerTest {
         }
 
         @Test
-        @DisplayName("인증 없음 → 403")
+        @DisplayName("인증 없음 → 401")
         void unauthorizedWithoutAuth() throws Exception {
             mockMvc.perform(get("/api/payments/pk-test"))
-                    .andExpect(status().isForbidden());
+                    .andExpect(status().isUnauthorized());
         }
 
         @Test

--- a/src/test/java/com/stockmanagement/domain/payment/controller/PaymentControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/payment/controller/PaymentControllerTest.java
@@ -65,7 +65,7 @@ class PaymentControllerTest {
         @DisplayName("인증된 사용자 — 결제 준비 성공 → 200")
         void preparesPayment() throws Exception {
             PaymentPrepareResponse response =
-                    new PaymentPrepareResponse("toss-order-001", BigDecimal.valueOf(10000), "상품명");
+                    new PaymentPrepareResponse("toss-order-001", BigDecimal.valueOf(10000), "상품명", null, null);
             given(paymentService.prepare(any(), any())).willReturn(response);
 
             mockMvc.perform(post("/api/payments/prepare")

--- a/src/test/java/com/stockmanagement/domain/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/payment/service/PaymentServiceTest.java
@@ -13,6 +13,9 @@ import com.stockmanagement.domain.payment.infrastructure.TossPaymentsClient;
 import com.stockmanagement.domain.payment.infrastructure.dto.TossConfirmResponse;
 import com.stockmanagement.domain.payment.infrastructure.dto.TossWebhookEvent;
 import com.stockmanagement.domain.payment.repository.PaymentRepository;
+import com.stockmanagement.domain.user.entity.User;
+import com.stockmanagement.domain.user.entity.UserRole;
+import com.stockmanagement.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -53,6 +56,9 @@ class PaymentServiceTest {
     @Mock
     private PaymentTransactionHelper transactionHelper;
 
+    @Mock
+    private UserRepository userRepository;
+
     @InjectMocks
     private PaymentService paymentService;
 
@@ -79,6 +85,10 @@ class PaymentServiceTest {
         // 기본: Redis에 캐시 없음, 선점 항상 성공
         lenient().when(idempotencyManager.getIfCompleted(anyString())).thenReturn(Optional.empty());
         lenient().when(idempotencyManager.tryAcquire(anyString())).thenReturn(true);
+
+        User user = User.builder().username("testuser").email("test@example.com")
+                .password("pw").role(UserRole.USER).build();
+        lenient().when(userRepository.findById(anyLong())).thenReturn(Optional.of(user));
     }
 
     // ===== prepare() =====

--- a/src/test/java/com/stockmanagement/domain/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/payment/service/PaymentServiceTest.java
@@ -176,6 +176,31 @@ class PaymentServiceTest {
             verify(paymentRepository, never()).save(any());
             assertThat(response.getTossOrderId()).isEqualTo("toss-order-001");
         }
+
+        @Test
+        @DisplayName("FAILED 결제가 존재하면 resetForRetry 후 기존 레코드 반환 (재결제)")
+        void resetsFailedPaymentForRetry() {
+            PaymentPrepareRequest request = mock(PaymentPrepareRequest.class);
+            given(request.getOrderId()).willReturn(1L);
+            given(request.getAmount()).willReturn(new BigDecimal("10000"));
+
+            // FAILED 결제 픽스처 생성
+            Payment failedPayment = Payment.builder()
+                    .orderId(1L)
+                    .tossOrderId("toss-order-old")
+                    .amount(new BigDecimal("10000"))
+                    .build();
+            failedPayment.fail("PAY_PROCESS_ABORTED", "사용자 취소");
+
+            given(orderRepository.findByIdWithItems(1L)).willReturn(Optional.of(pendingOrder));
+            given(paymentRepository.findByOrderId(pendingOrder.getId())).willReturn(Optional.of(failedPayment));
+
+            PaymentPrepareResponse response = paymentService.prepare(request, 1L);
+
+            // 새 Payment 저장 없이 기존 FAILED 레코드를 PENDING으로 초기화
+            verify(paymentRepository, never()).save(any());
+            assertThat(response.getAmount()).isEqualByComparingTo("10000");
+        }
     }
 
     // ===== confirm() =====

--- a/src/test/java/com/stockmanagement/domain/point/controller/PointControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/point/controller/PointControllerTest.java
@@ -62,10 +62,10 @@ class PointControllerTest {
         }
 
         @Test
-        @DisplayName("인증 없음 → 403")
+        @DisplayName("인증 없음 → 401")
         void unauthenticated() throws Exception {
             mockMvc.perform(get("/api/points/balance"))
-                    .andExpect(status().isForbidden());
+                    .andExpect(status().isUnauthorized());
         }
     }
 
@@ -87,10 +87,10 @@ class PointControllerTest {
         }
 
         @Test
-        @DisplayName("인증 없음 → 403")
+        @DisplayName("인증 없음 → 401")
         void unauthenticated() throws Exception {
             mockMvc.perform(get("/api/points/history"))
-                    .andExpect(status().isForbidden());
+                    .andExpect(status().isUnauthorized());
         }
     }
 }

--- a/src/test/java/com/stockmanagement/domain/product/category/controller/CategoryControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/product/category/controller/CategoryControllerTest.java
@@ -81,12 +81,12 @@ class CategoryControllerTest {
         }
 
         @Test
-        @DisplayName("인증 없음 → 403")
+        @DisplayName("인증 없음 → 401")
         void forbiddenWithoutAuth() throws Exception {
             mockMvc.perform(post("/api/categories")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(VALID_CREATE_JSON))
-                    .andExpect(status().isForbidden());
+                    .andExpect(status().isUnauthorized());
         }
     }
 

--- a/src/test/java/com/stockmanagement/domain/product/category/service/CategoryServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/product/category/service/CategoryServiceTest.java
@@ -17,7 +17,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.*;
@@ -174,6 +176,7 @@ class CategoryServiceTest {
         void returnsTreeWithChildren() {
             parent.getChildren().add(child);
             given(categoryRepository.findAll()).willReturn(List.of(parent, child));
+            given(productRepository.countMapByCategoryIds(any())).willReturn(new HashMap<>());
 
             List<CategoryResponse> tree = categoryService.getTree();
 

--- a/src/test/java/com/stockmanagement/domain/product/controller/ProductControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/product/controller/ProductControllerTest.java
@@ -88,12 +88,12 @@ class ProductControllerTest {
         }
 
         @Test
-        @DisplayName("인증 없음 → 403")
+        @DisplayName("인증 없음 → 401")
         void unauthorizedWithoutAuth() throws Exception {
             mockMvc.perform(post("/api/products")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(VALID_JSON))
-                    .andExpect(status().isForbidden());
+                    .andExpect(status().isUnauthorized());
         }
 
         @Test

--- a/src/test/java/com/stockmanagement/domain/product/controller/ProductControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/product/controller/ProductControllerTest.java
@@ -6,6 +6,7 @@ import com.stockmanagement.common.exception.BusinessException;
 import com.stockmanagement.common.exception.ErrorCode;
 import com.stockmanagement.domain.product.dto.ProductResponse;
 import com.stockmanagement.domain.product.service.ProductService;
+import com.stockmanagement.domain.user.service.UserService;
 import com.stockmanagement.common.security.JwtBlacklist;
 import com.stockmanagement.common.security.JwtTokenProvider;
 import org.junit.jupiter.api.DisplayName;
@@ -47,6 +48,9 @@ class ProductControllerTest {
 
     @MockBean
     private JwtTokenProvider jwtTokenProvider;
+
+    @MockBean
+    private UserService userService;
 
     @MockBean
     private JwtBlacklist jwtBlacklist;
@@ -111,9 +115,9 @@ class ProductControllerTest {
 
         @Test
         @WithMockUser
-        @DisplayName("인증된 사용자 — 상품 단건 조회 → 200")
+        @DisplayName("인증된 사용자 — 상품 단건 조회 → 200 (canReview 포함)")
         void returnsProduct() throws Exception {
-            given(productService.getById(1L)).willReturn(mock(ProductResponse.class));
+            given(productService.getByIdForUser(eq(1L), any())).willReturn(mock(ProductResponse.class));
 
             mockMvc.perform(get("/api/products/1"))
                     .andExpect(status().isOk())
@@ -133,7 +137,7 @@ class ProductControllerTest {
         @WithMockUser
         @DisplayName("존재하지 않는 상품 → 404")
         void returnsNotFound() throws Exception {
-            given(productService.getById(999L))
+            given(productService.getByIdForUser(eq(999L), any()))
                     .willThrow(new BusinessException(ErrorCode.PRODUCT_NOT_FOUND));
 
             mockMvc.perform(get("/api/products/999"))
@@ -152,7 +156,7 @@ class ProductControllerTest {
         @WithMockUser
         @DisplayName("인증된 사용자 — 상품 목록 페이징 조회 → 200")
         void returnsList() throws Exception {
-            given(productService.getList(any(Pageable.class), any()))
+            given(productService.getList(any(Pageable.class), any(), any()))
                     .willReturn(new PageImpl<>(List.of()));
 
             mockMvc.perform(get("/api/products"))

--- a/src/test/java/com/stockmanagement/domain/product/image/controller/ProductImageControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/product/image/controller/ProductImageControllerTest.java
@@ -66,7 +66,7 @@ class ProductImageControllerTest {
         }
 
         @Test
-        @DisplayName("비인증 — 403")
+        @DisplayName("비인증 — 401")
         void unauthenticated_403() throws Exception {
             String body = objectMapper.writeValueAsString(
                     Map.of("fileExtension", "jpg", "contentType", "image/jpeg", "imageType", "THUMBNAIL"));
@@ -74,7 +74,7 @@ class ProductImageControllerTest {
             mockMvc.perform(post(BASE_URL + "/presigned")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(body))
-                    .andExpect(status().isForbidden());
+                    .andExpect(status().isUnauthorized());
         }
     }
 

--- a/src/test/java/com/stockmanagement/domain/product/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/product/review/controller/ReviewControllerTest.java
@@ -124,7 +124,7 @@ class ReviewControllerTest {
         @Test
         @DisplayName("비로그인 사용자 — 리뷰 목록 조회 → 200")
         void publicGetsList() throws Exception {
-            given(reviewService.getList(anyLong(), any(Pageable.class)))
+            given(reviewService.getList(anyLong(), any(Pageable.class), any()))
                     .willReturn(new PageImpl<>(List.of(mock(ReviewResponse.class))));
 
             mockMvc.perform(get("/api/products/1/reviews"))

--- a/src/test/java/com/stockmanagement/domain/product/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/product/review/controller/ReviewControllerTest.java
@@ -78,12 +78,12 @@ class ReviewControllerTest {
         }
 
         @Test
-        @DisplayName("인증 없음 → 403")
+        @DisplayName("인증 없음 → 401")
         void unauthenticated() throws Exception {
             mockMvc.perform(post("/api/products/1/reviews")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(REVIEW_JSON))
-                    .andExpect(status().isForbidden());
+                    .andExpect(status().isUnauthorized());
         }
 
         @Test
@@ -147,10 +147,10 @@ class ReviewControllerTest {
         }
 
         @Test
-        @DisplayName("인증 없음 → 403")
+        @DisplayName("인증 없음 → 401")
         void unauthenticated() throws Exception {
             mockMvc.perform(delete("/api/products/1/reviews/1"))
-                    .andExpect(status().isForbidden());
+                    .andExpect(status().isUnauthorized());
         }
     }
 }

--- a/src/test/java/com/stockmanagement/domain/product/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/product/review/controller/ReviewControllerTest.java
@@ -4,6 +4,7 @@ import com.stockmanagement.common.config.SecurityConfig;
 import com.stockmanagement.common.exception.BusinessException;
 import com.stockmanagement.common.exception.ErrorCode;
 import com.stockmanagement.common.security.JwtBlacklist;
+import com.stockmanagement.domain.product.review.dto.RatingStatsResponse;
 import com.stockmanagement.domain.product.review.dto.ReviewResponse;
 import com.stockmanagement.domain.product.review.service.ReviewService;
 import com.stockmanagement.domain.user.service.UserService;
@@ -130,6 +131,33 @@ class ReviewControllerTest {
             mockMvc.perform(get("/api/products/1/reviews"))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true));
+        }
+    }
+
+    // ===== GET /api/products/{id}/reviews/stats =====
+
+    @Nested
+    @DisplayName("GET /api/products/{productId}/reviews/stats")
+    class GetRatingStats {
+
+        @Test
+        @DisplayName("비로그인 — 별점 분포 통계 조회 → 200")
+        void returnsStats() throws Exception {
+            given(reviewService.getRatingStats(1L)).willReturn(mock(RatingStatsResponse.class));
+
+            mockMvc.perform(get("/api/products/1/reviews/stats"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 상품 → 404")
+        void productNotFound() throws Exception {
+            given(reviewService.getRatingStats(999L))
+                    .willThrow(new BusinessException(ErrorCode.PRODUCT_NOT_FOUND));
+
+            mockMvc.perform(get("/api/products/999/reviews/stats"))
+                    .andExpect(status().isNotFound());
         }
     }
 

--- a/src/test/java/com/stockmanagement/domain/product/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/product/review/service/ReviewServiceTest.java
@@ -3,6 +3,7 @@ package com.stockmanagement.domain.product.review.service;
 import com.stockmanagement.common.exception.BusinessException;
 import com.stockmanagement.common.exception.ErrorCode;
 import com.stockmanagement.domain.order.repository.OrderRepository;
+import com.stockmanagement.domain.user.repository.UserRepository;
 import com.stockmanagement.domain.product.entity.Product;
 import com.stockmanagement.domain.product.repository.ProductRepository;
 import com.stockmanagement.domain.product.review.dto.ReviewCreateRequest;
@@ -28,6 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -37,8 +39,14 @@ class ReviewServiceTest {
     @Mock private ReviewRepository reviewRepository;
     @Mock private ProductRepository productRepository;
     @Mock private OrderRepository orderRepository;
+    @Mock private UserRepository userRepository;
 
     @InjectMocks private ReviewService reviewService;
+
+    @org.junit.jupiter.api.BeforeEach
+    void setUp() {
+        lenient().when(userRepository.findAllById(any())).thenReturn(List.of());
+    }
 
     private Product mockProduct(Long id) {
         Product p = Product.builder().name("테스트상품").price(java.math.BigDecimal.valueOf(10000)).sku("SKU-001").build();

--- a/src/test/java/com/stockmanagement/domain/product/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/product/review/service/ReviewServiceTest.java
@@ -117,10 +117,10 @@ class ReviewServiceTest {
             given(productRepository.existsById(1L)).willReturn(true);
             Review r = Review.builder().productId(1L).userId(2L).rating(4).title("보통").content("그냥 그래요").build();
             ReflectionTestUtils.setField(r, "id", 5L);
-            given(reviewRepository.findByProductIdOrderByCreatedAtDesc(any(), any(Pageable.class)))
+            given(reviewRepository.findByProductId(any(), any(Pageable.class)))
                     .willReturn(new PageImpl<>(List.of(r)));
 
-            Page<ReviewResponse> page = reviewService.getList(1L, Pageable.unpaged());
+            Page<ReviewResponse> page = reviewService.getList(1L, Pageable.unpaged(), null);
 
             assertThat(page.getContent()).hasSize(1);
             assertThat(page.getContent().get(0).getRating()).isEqualTo(4);

--- a/src/test/java/com/stockmanagement/domain/product/service/ProductServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/product/service/ProductServiceTest.java
@@ -167,7 +167,7 @@ class ProductServiceTest {
             Page<Product> page = new PageImpl<>(List.of(product), pageable, 1);
             given(productRepository.findByStatus(ProductStatus.ACTIVE, pageable)).willReturn(page);
 
-            Page<ProductResponse> result = productService.getList(pageable, null);
+            Page<ProductResponse> result = productService.getList(pageable, null, null);
 
             assertThat(result.getTotalElements()).isEqualTo(1);
             assertThat(result.getContent().get(0).getName()).isEqualTo("테스트 상품");
@@ -180,7 +180,7 @@ class ProductServiceTest {
             given(productRepository.findByStatus(ProductStatus.ACTIVE, pageable))
                     .willReturn(Page.empty());
 
-            Page<ProductResponse> result = productService.getList(pageable, null);
+            Page<ProductResponse> result = productService.getList(pageable, null, null);
 
             assertThat(result).isEmpty();
         }
@@ -192,7 +192,7 @@ class ProductServiceTest {
             given(productRepository.findByStatus(ProductStatus.ACTIVE, pageable))
                     .willReturn(Page.empty());
 
-            productService.getList(pageable, null);
+            productService.getList(pageable, null, null);
 
             verify(productRepository).findByStatus(ProductStatus.ACTIVE, pageable);
         }

--- a/src/test/java/com/stockmanagement/domain/product/wishlist/controller/WishlistControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/product/wishlist/controller/WishlistControllerTest.java
@@ -69,10 +69,10 @@ class WishlistControllerTest {
         }
 
         @Test
-        @DisplayName("인증 없음 → 403")
+        @DisplayName("인증 없음 → 401")
         void unauthenticated() throws Exception {
             mockMvc.perform(post("/api/wishlist/1"))
-                    .andExpect(status().isForbidden());
+                    .andExpect(status().isUnauthorized());
         }
 
         @Test
@@ -101,10 +101,10 @@ class WishlistControllerTest {
         }
 
         @Test
-        @DisplayName("인증 없음 → 403")
+        @DisplayName("인증 없음 → 401")
         void unauthenticated() throws Exception {
             mockMvc.perform(delete("/api/wishlist/1"))
-                    .andExpect(status().isForbidden());
+                    .andExpect(status().isUnauthorized());
         }
     }
 
@@ -126,10 +126,10 @@ class WishlistControllerTest {
         }
 
         @Test
-        @DisplayName("인증 없음 → 403")
+        @DisplayName("인증 없음 → 401")
         void unauthenticated() throws Exception {
             mockMvc.perform(get("/api/wishlist"))
-                    .andExpect(status().isForbidden());
+                    .andExpect(status().isUnauthorized());
         }
     }
 }

--- a/src/test/java/com/stockmanagement/domain/product/wishlist/controller/WishlistControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/product/wishlist/controller/WishlistControllerTest.java
@@ -20,8 +20,11 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.web.servlet.MockMvc;
 
+import org.springframework.data.domain.PageImpl;
+
 import java.util.List;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
@@ -117,8 +120,8 @@ class WishlistControllerTest {
         @Test
         @DisplayName("인증된 사용자 — 위시리스트 조회 → 200")
         void returnsList() throws Exception {
-            given(wishlistService.getList(anyLong()))
-                    .willReturn(List.of(mock(WishlistResponse.class)));
+            given(wishlistService.getList(anyLong(), any()))
+                    .willReturn(new PageImpl<>(List.of(mock(WishlistResponse.class))));
 
             mockMvc.perform(get("/api/wishlist").with(authentication(USER_AUTH)))
                     .andExpect(status().isOk())

--- a/src/test/java/com/stockmanagement/domain/product/wishlist/service/WishlistServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/product/wishlist/service/WishlistServiceTest.java
@@ -17,6 +17,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
@@ -107,7 +111,7 @@ class WishlistServiceTest {
     }
 
     @Nested
-    @DisplayName("getList() — 위시리스트 조회")
+    @DisplayName("getList() — 위시리스트 페이징 조회")
     class GetList {
 
         @Test
@@ -115,14 +119,16 @@ class WishlistServiceTest {
         void success() {
             WishlistItem item = mockItem(5L, 1L, 10L);
             Product product = mockProduct(10L);
-            given(wishlistRepository.findByUserIdOrderByCreatedAtDesc(1L)).willReturn(List.of(item));
+            Pageable pageable = PageRequest.of(0, 20);
+            given(wishlistRepository.findByUserIdOrderByCreatedAtDesc(1L, pageable))
+                    .willReturn(new PageImpl<>(List.of(item)));
             given(productRepository.findAllById(List.of(10L))).willReturn(List.of(product));
             given(inventoryRepository.findAllByProductIdIn(List.of(10L))).willReturn(List.of());
 
-            List<WishlistResponse> list = wishlistService.getList(1L);
+            var page = wishlistService.getList(1L, pageable);
 
-            assertThat(list).hasSize(1);
-            assertThat(list.get(0).getProductName()).isEqualTo("상품A");
+            assertThat(page.getContent()).hasSize(1);
+            assertThat(page.getContent().get(0).getProductName()).isEqualTo("상품A");
         }
     }
 }

--- a/src/test/java/com/stockmanagement/domain/product/wishlist/service/WishlistServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/product/wishlist/service/WishlistServiceTest.java
@@ -2,6 +2,7 @@ package com.stockmanagement.domain.product.wishlist.service;
 
 import com.stockmanagement.common.exception.BusinessException;
 import com.stockmanagement.common.exception.ErrorCode;
+import com.stockmanagement.domain.inventory.repository.InventoryRepository;
 import com.stockmanagement.domain.product.entity.Product;
 import com.stockmanagement.domain.product.repository.ProductRepository;
 import com.stockmanagement.domain.product.wishlist.dto.WishlistResponse;
@@ -32,6 +33,7 @@ class WishlistServiceTest {
 
     @Mock private WishlistRepository wishlistRepository;
     @Mock private ProductRepository productRepository;
+    @Mock private InventoryRepository inventoryRepository;
 
     @InjectMocks private WishlistService wishlistService;
 
@@ -56,6 +58,7 @@ class WishlistServiceTest {
         void success() {
             given(productRepository.findById(10L)).willReturn(Optional.of(mockProduct(10L)));
             given(wishlistRepository.existsByUserIdAndProductId(1L, 10L)).willReturn(false);
+            given(inventoryRepository.findByProductId(10L)).willReturn(Optional.empty());
             WishlistItem saved = mockItem(5L, 1L, 10L);
             given(wishlistRepository.save(any())).willReturn(saved);
 
@@ -114,6 +117,7 @@ class WishlistServiceTest {
             Product product = mockProduct(10L);
             given(wishlistRepository.findByUserIdOrderByCreatedAtDesc(1L)).willReturn(List.of(item));
             given(productRepository.findAllById(List.of(10L))).willReturn(List.of(product));
+            given(inventoryRepository.findAllByProductIdIn(List.of(10L))).willReturn(List.of());
 
             List<WishlistResponse> list = wishlistService.getList(1L);
 

--- a/src/test/java/com/stockmanagement/domain/refund/controller/RefundControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/refund/controller/RefundControllerTest.java
@@ -71,12 +71,12 @@ class RefundControllerTest {
         }
 
         @Test
-        @DisplayName("인증 없음 → 403")
+        @DisplayName("인증 없음 → 401")
         void unauthenticated() throws Exception {
             mockMvc.perform(post("/api/refunds")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(REFUND_JSON))
-                    .andExpect(status().isForbidden());
+                    .andExpect(status().isUnauthorized());
         }
 
         @Test
@@ -111,10 +111,10 @@ class RefundControllerTest {
         }
 
         @Test
-        @DisplayName("인증 없음 → 403")
+        @DisplayName("인증 없음 → 401")
         void unauthenticated() throws Exception {
             mockMvc.perform(get("/api/refunds/1"))
-                    .andExpect(status().isForbidden());
+                    .andExpect(status().isUnauthorized());
         }
 
         @Test
@@ -157,10 +157,10 @@ class RefundControllerTest {
         }
 
         @Test
-        @DisplayName("인증 없음 → 403")
+        @DisplayName("인증 없음 → 401")
         void unauthenticated() throws Exception {
             mockMvc.perform(get("/api/refunds/payments/1"))
-                    .andExpect(status().isForbidden());
+                    .andExpect(status().isUnauthorized());
         }
     }
 }

--- a/src/test/java/com/stockmanagement/domain/refund/controller/RefundControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/refund/controller/RefundControllerTest.java
@@ -6,6 +6,7 @@ import com.stockmanagement.common.exception.ErrorCode;
 import com.stockmanagement.common.security.JwtBlacklist;
 import com.stockmanagement.domain.refund.dto.RefundResponse;
 import com.stockmanagement.domain.refund.service.RefundService;
+import com.stockmanagement.domain.user.service.UserService;
 import com.stockmanagement.common.security.JwtTokenProvider;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -40,6 +41,7 @@ class RefundControllerTest {
     private MockMvc mockMvc;
 
     @MockBean private RefundService refundService;
+    @MockBean private UserService userService;
     @MockBean private JwtTokenProvider jwtTokenProvider;
     @MockBean private JwtBlacklist jwtBlacklist;
 

--- a/src/test/java/com/stockmanagement/domain/shipment/controller/ShipmentControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/shipment/controller/ShipmentControllerTest.java
@@ -54,10 +54,10 @@ class ShipmentControllerTest {
         }
 
         @Test
-        @DisplayName("인증 없음 → 403")
+        @DisplayName("인증 없음 → 401")
         void unauthenticated() throws Exception {
             mockMvc.perform(get("/api/shipments/orders/1"))
-                    .andExpect(status().isForbidden());
+                    .andExpect(status().isUnauthorized());
         }
 
         @Test

--- a/src/test/java/com/stockmanagement/domain/shipment/controller/ShipmentControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/shipment/controller/ShipmentControllerTest.java
@@ -7,6 +7,7 @@ import com.stockmanagement.common.security.JwtBlacklist;
 import com.stockmanagement.domain.shipment.dto.ShipmentResponse;
 import com.stockmanagement.domain.shipment.service.ShipmentService;
 import com.stockmanagement.common.security.JwtTokenProvider;
+import com.stockmanagement.domain.user.service.UserService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -14,9 +15,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
@@ -35,6 +39,34 @@ class ShipmentControllerTest {
     @MockBean private ShipmentService shipmentService;
     @MockBean private JwtTokenProvider jwtTokenProvider;
     @MockBean private JwtBlacklist jwtBlacklist;
+    @MockBean private UserService userService;
+
+    // ===== GET /api/shipments/my =====
+
+    @Nested
+    @DisplayName("GET /api/shipments/my")
+    class GetMyShipments {
+
+        @Test
+        @WithMockUser
+        @DisplayName("인증된 사용자 — 내 배송 목록 → 200")
+        void returnsMyShipments() throws Exception {
+            given(userService.resolveUserId(any())).willReturn(1L);
+            given(shipmentService.getMyShipments(anyLong(), any()))
+                    .willReturn(new PageImpl<>(List.of(mock(ShipmentResponse.class))));
+
+            mockMvc.perform(get("/api/shipments/my"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true));
+        }
+
+        @Test
+        @DisplayName("인증 없음 → 401")
+        void unauthenticated() throws Exception {
+            mockMvc.perform(get("/api/shipments/my"))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
 
     // ===== GET /api/shipments/orders/{orderId} =====
 

--- a/src/test/java/com/stockmanagement/domain/shipment/service/ShipmentServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/shipment/service/ShipmentServiceTest.java
@@ -58,7 +58,7 @@ class ShipmentServiceTest {
         preparingShipment = Shipment.builder().orderId(1L).build();
         // 테스트용 SHIPPED 배송 — ReflectionTestUtils로 status 세팅
         shippedShipment = Shipment.builder().orderId(2L).build();
-        shippedShipment.ship("CJ대한통운", "123456789");
+        shippedShipment.ship("CJ대한통운", "123456789", null);
     }
 
     @Nested

--- a/src/test/java/com/stockmanagement/domain/user/address/controller/DeliveryAddressControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/user/address/controller/DeliveryAddressControllerTest.java
@@ -75,12 +75,12 @@ class DeliveryAddressControllerTest {
         }
 
         @Test
-        @DisplayName("인증 없음 → 403")
+        @DisplayName("인증 없음 → 401")
         void unauthenticated() throws Exception {
             mockMvc.perform(post("/api/delivery-addresses")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(VALID_JSON))
-                    .andExpect(status().isForbidden());
+                    .andExpect(status().isUnauthorized());
         }
 
         @Test
@@ -112,10 +112,10 @@ class DeliveryAddressControllerTest {
         }
 
         @Test
-        @DisplayName("인증 없음 → 403")
+        @DisplayName("인증 없음 → 401")
         void unauthenticated() throws Exception {
             mockMvc.perform(get("/api/delivery-addresses"))
-                    .andExpect(status().isForbidden());
+                    .andExpect(status().isUnauthorized());
         }
     }
 
@@ -133,10 +133,10 @@ class DeliveryAddressControllerTest {
         }
 
         @Test
-        @DisplayName("인증 없음 → 403")
+        @DisplayName("인증 없음 → 401")
         void unauthenticated() throws Exception {
             mockMvc.perform(delete("/api/delivery-addresses/1"))
-                    .andExpect(status().isForbidden());
+                    .andExpect(status().isUnauthorized());
         }
     }
 

--- a/src/test/java/com/stockmanagement/domain/user/controller/AuthControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/user/controller/AuthControllerTest.java
@@ -57,7 +57,7 @@ class AuthControllerTest {
         @Test
         @DisplayName("회원가입 성공 (인증 불필요) → 201")
         void signupSuccess() throws Exception {
-            UserResponse response = new UserResponse(1L, "testuser", "test@example.com", UserRole.USER, null);
+            UserResponse response = new UserResponse(1L, "testuser", "test@example.com", UserRole.USER, null, null);
             given(userService.signup(any())).willReturn(response);
 
             mockMvc.perform(post("/api/auth/signup")

--- a/src/test/java/com/stockmanagement/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/user/controller/UserControllerTest.java
@@ -85,10 +85,10 @@ class UserControllerTest {
         }
 
         @Test
-        @DisplayName("인증 없음 → 403")
+        @DisplayName("인증 없음 → 401")
         void unauthorizedWithoutAuth() throws Exception {
             mockMvc.perform(get("/api/users/me"))
-                    .andExpect(status().isForbidden());
+                    .andExpect(status().isUnauthorized());
         }
     }
 
@@ -110,10 +110,10 @@ class UserControllerTest {
         }
 
         @Test
-        @DisplayName("인증 없음 → 403")
+        @DisplayName("인증 없음 → 401")
         void unauthorizedWithoutAuth() throws Exception {
             mockMvc.perform(delete("/api/users/me"))
-                    .andExpect(status().isForbidden());
+                    .andExpect(status().isUnauthorized());
         }
     }
 
@@ -136,10 +136,10 @@ class UserControllerTest {
         }
 
         @Test
-        @DisplayName("인증 없음 → 403")
+        @DisplayName("인증 없음 → 401")
         void unauthorizedWithoutAuth() throws Exception {
             mockMvc.perform(get("/api/users/me/orders"))
-                    .andExpect(status().isForbidden());
+                    .andExpect(status().isUnauthorized());
         }
     }
 }

--- a/src/test/java/com/stockmanagement/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/user/controller/UserControllerTest.java
@@ -5,6 +5,7 @@ import com.stockmanagement.domain.order.dto.OrderResponse;
 import com.stockmanagement.domain.user.dto.UserResponse;
 import com.stockmanagement.domain.user.entity.UserRole;
 import com.stockmanagement.domain.user.service.UserService;
+import com.stockmanagement.domain.product.review.service.ReviewService;
 import com.stockmanagement.common.security.JwtBlacklist;
 import com.stockmanagement.common.security.JwtTokenProvider;
 import org.junit.jupiter.api.DisplayName;
@@ -53,6 +54,9 @@ class UserControllerTest {
     private JwtTokenProvider jwtTokenProvider;
 
     @MockBean
+    private ReviewService reviewService;
+
+    @MockBean
     private JwtBlacklist jwtBlacklist;
 
     /** String principal을 가진 인증 토큰 생성 헬퍼 */
@@ -70,7 +74,7 @@ class UserControllerTest {
         @Test
         @DisplayName("인증된 사용자 — 내 정보 조회 → 200")
         void returnsMyInfo() throws Exception {
-            UserResponse response = new UserResponse(1L, "testuser", "test@example.com", UserRole.USER, null);
+            UserResponse response = new UserResponse(1L, "testuser", "test@example.com", UserRole.USER, null, null);
             given(userService.getMe("testuser")).willReturn(response);
 
             mockMvc.perform(get("/api/users/me")

--- a/src/test/java/com/stockmanagement/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/user/service/UserServiceTest.java
@@ -4,6 +4,7 @@ import com.stockmanagement.common.exception.BusinessException;
 import com.stockmanagement.common.exception.ErrorCode;
 import com.stockmanagement.domain.order.dto.OrderResponse;
 import com.stockmanagement.domain.order.repository.OrderRepository;
+import com.stockmanagement.domain.shipment.repository.ShipmentRepository;
 import com.stockmanagement.domain.point.entity.UserPoint;
 import com.stockmanagement.domain.point.repository.UserPointRepository;
 import com.stockmanagement.domain.user.dto.ChangePasswordRequest;
@@ -33,6 +34,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.*;
@@ -66,6 +68,9 @@ class UserServiceTest {
     @Mock
     private RefreshTokenStore refreshTokenStore;
 
+    @Mock
+    private ShipmentRepository shipmentRepository;
+
     @InjectMocks
     private UserService userService;
 
@@ -80,6 +85,7 @@ class UserServiceTest {
                 .email("test@example.com")
                 .role(UserRole.USER)
                 .build();
+        lenient().when(shipmentRepository.findStatusMapByOrderIds(any())).thenReturn(new java.util.HashMap<>());
     }
 
     // ===== signup() =====

--- a/src/test/java/com/stockmanagement/integration/AdminIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/AdminIntegrationTest.java
@@ -48,10 +48,10 @@ class AdminIntegrationTest extends AbstractIntegrationTest {
         }
 
         @Test
-        @DisplayName("인증 없음 → 403")
+        @DisplayName("인증 없음 → 401")
         void unauthenticatedForbidden() throws Exception {
             mockMvc.perform(get("/api/admin/dashboard"))
-                    .andExpect(status().isForbidden());
+                    .andExpect(status().isUnauthorized());
         }
     }
 

--- a/src/test/java/com/stockmanagement/integration/AuthIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/AuthIntegrationTest.java
@@ -146,10 +146,10 @@ class AuthIntegrationTest extends AbstractIntegrationTest {
         }
 
         @Test
-        @DisplayName("토큰 없음 → 403")
+        @DisplayName("토큰 없음 → 401")
         void getMe_withoutToken_forbidden() throws Exception {
             mockMvc.perform(get("/api/users/me"))
-                    .andExpect(status().isForbidden());
+                    .andExpect(status().isUnauthorized());
         }
     }
 }

--- a/src/test/java/com/stockmanagement/integration/InventoryIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/InventoryIntegrationTest.java
@@ -205,10 +205,10 @@ class InventoryIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
-    @DisplayName("미인증 이력 조회 → 403")
+    @DisplayName("미인증 이력 조회 → 401")
     void getTransactions_unauthenticated_403() throws Exception {
         mockMvc.perform(get("/api/inventory/1/transactions"))
-                .andExpect(status().isForbidden());
+                .andExpect(status().isUnauthorized());
     }
 
     // ===== 재고 목록 검색 =====
@@ -408,10 +408,10 @@ class InventoryIntegrationTest extends AbstractIntegrationTest {
         }
 
         @Test
-        @DisplayName("미인증 요청 → 403")
+        @DisplayName("미인증 요청 → 401")
         void unauthenticated_403() throws Exception {
             mockMvc.perform(get("/api/inventory"))
-                    .andExpect(status().isForbidden());
+                    .andExpect(status().isUnauthorized());
         }
     }
 }

--- a/src/test/java/com/stockmanagement/integration/UserIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/UserIntegrationTest.java
@@ -37,10 +37,10 @@ class UserIntegrationTest extends AbstractIntegrationTest {
         }
 
         @Test
-        @DisplayName("인증 없음 → 403")
+        @DisplayName("인증 없음 → 401")
         void unauthenticatedForbidden() throws Exception {
             mockMvc.perform(get("/api/users/me/orders"))
-                    .andExpect(status().isForbidden());
+                    .andExpect(status().isUnauthorized());
         }
     }
 
@@ -69,10 +69,10 @@ class UserIntegrationTest extends AbstractIntegrationTest {
         }
 
         @Test
-        @DisplayName("인증 없음 → 403")
+        @DisplayName("인증 없음 → 401")
         void unauthenticatedForbidden() throws Exception {
             mockMvc.perform(delete("/api/users/me"))
-                    .andExpect(status().isForbidden());
+                    .andExpect(status().isUnauthorized());
         }
     }
 }

--- a/src/test/java/com/stockmanagement/integration/WishlistIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/WishlistIntegrationTest.java
@@ -68,9 +68,9 @@ class WishlistIntegrationTest extends AbstractIntegrationTest {
         mockMvc.perform(get("/api/wishlist")
                         .header("Authorization", "Bearer " + userToken))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data").isArray())
-                .andExpect(jsonPath("$.data.length()").value(1))
-                .andExpect(jsonPath("$.data[0].productId").value(productId));
+                .andExpect(jsonPath("$.data.content").isArray())
+                .andExpect(jsonPath("$.data.content.length()").value(1))
+                .andExpect(jsonPath("$.data.content[0].productId").value(productId));
     }
 
     @Test
@@ -92,7 +92,8 @@ class WishlistIntegrationTest extends AbstractIntegrationTest {
         mockMvc.perform(get("/api/wishlist")
                         .header("Authorization", "Bearer " + userToken))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data").isEmpty());
+                .andExpect(jsonPath("$.data.content").isArray())
+                .andExpect(jsonPath("$.data.totalElements").value(0));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- **#80** `PaymentService.prepare()`가 `totalAmount`(원가 합계)를 그대로 사용해 쿠폰·포인트 할인이 결제 금액에 미반영되던 버그 수정
- **#81** 주문 요청에 동일 `productId`가 2회 이상 포함될 때 `Collectors.toMap`이 `IllegalStateException`을 던져 500 에러로 노출되던 버그 수정

## Changes

### #80 — Payment 금액에 쿠폰·포인트 할인 미반영
- `Order.getPayableAmount()` 추가: `totalAmount - discountAmount - usedPoints` (최소 0)
- `PaymentService.prepare()` 금액 검증 및 `Payment` 엔티티 생성 시 `getPayableAmount()` 적용
- `OrderResponse`에 `payableAmount` 필드 추가 (클라이언트 결제창 표시용)

### #81 — 중복 productId 입력 시 500 에러
- `OrderService.create()` / `preview()`: `HashSet` size 비교로 중복 `productId` 사전 차단 → `INVALID_INPUT(400)` 반환
- `OrderServiceTest`에 중복 상품 케이스 테스트 추가

## Test plan

- [x] `./gradlew test` — **624개 테스트 전체 통과**