### PR TITLE
fix: add @Size(max=10000) to description field in ProductCreateRequest and ProductUpdateRequest

### DIFF
--- a/src/main/java/com/stockmanagement/domain/product/dto/ProductCreateRequest.java
+++ b/src/main/java/com/stockmanagement/domain/product/dto/ProductCreateRequest.java
@@ -20,6 +20,7 @@ public class ProductCreateRequest {
     private String name;
 
     /** 선택 입력 — null 허용 */
+    @Size(max = 10000, message = "상품 설명은 10000자를 초과할 수 없습니다.")
     private String description;
 
     @NotNull(message = "가격은 필수입니다.")

--- a/src/main/java/com/stockmanagement/domain/product/dto/ProductUpdateRequest.java
+++ b/src/main/java/com/stockmanagement/domain/product/dto/ProductUpdateRequest.java
@@ -23,6 +23,7 @@ public class ProductUpdateRequest {
     private String name;
 
     /** 선택 입력 — null 전달 시 기존 설명이 null로 갱신됨 */
+    @Size(max = 10000, message = "상품 설명은 10000자를 초과할 수 없습니다.")
     private String description;
 
     @NotNull(message = "가격은 필수입니다.")


### PR DESCRIPTION
Fixes #56

Added @Size(max = 10000) validation annotation to the description field in 
ProductCreateRequest and ProductUpdateRequest to prevent oversized inputs 
from causing memory and DB overhead.