### PR TITLE
fix: replace null username with [탈퇴사용자] for deleted users in ReviewService

### DIFF
--- a/src/main/java/com/stockmanagement/domain/product/review/service/ReviewService.java
+++ b/src/main/java/com/stockmanagement/domain/product/review/service/ReviewService.java
@@ -80,7 +80,7 @@ public class ReviewService {
                 ? reviewRepository.findByProductIdAndRating(productId, rating, pageable)
                 : reviewRepository.findByProductId(productId, pageable);
         Map<Long, String> usernameMap = buildUsernameMap(reviews.map(Review::getUserId).toList());
-        return reviews.map(r -> ReviewResponse.from(r, usernameMap.get(r.getUserId())));
+        return reviews.map(r -> ReviewResponse.from(r, usernameMap.getOrDefault(r.getUserId(), "[탈퇴사용자]")));
     }
 
     /** 특정 사용자의 리뷰 목록을 페이징 조회한다. 별점 필터 지원. */


### PR DESCRIPTION
Fixes #55

When a user deletes their account, their username was returning null in reviews
due to @SQLRestriction filtering them out of the repository query.

Fixed by using getOrDefault() to return [탈퇴사용자] when the userId 
is not found in the usernameMap.