### PR TITLE
fix: 코드 품질·검증 개선 (#41, #106, #108, #111, #127, #154, #157, #158)

### DIFF
--- a/src/main/java/com/stockmanagement/common/exception/ErrorCode.java
+++ b/src/main/java/com/stockmanagement/common/exception/ErrorCode.java
@@ -101,6 +101,7 @@ public enum ErrorCode {
     DUPLICATE_USERNAME(HttpStatus.CONFLICT, "이미 사용 중인 아이디입니다."),
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 올바르지 않습니다."),
+    SAME_PASSWORD(HttpStatus.BAD_REQUEST, "현재 비밀번호와 동일한 비밀번호로는 변경할 수 없습니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않거나 만료된 Refresh Token입니다."),
 
     // ===== Admin Setting =====

--- a/src/main/java/com/stockmanagement/domain/coupon/entity/Coupon.java
+++ b/src/main/java/com/stockmanagement/domain/coupon/entity/Coupon.java
@@ -44,15 +44,15 @@ public class Coupon {
     private DiscountType discountType;
 
     /** 할인 금액(FIXED_AMOUNT) 또는 할인율(PERCENTAGE, 0~100). */
-    @Column(nullable = false, precision = 19, scale = 2)
+    @Column(nullable = false, precision = 15, scale = 2)
     private BigDecimal discountValue;
 
     /** 최소 주문 금액 조건. null이면 제한 없음. */
-    @Column(precision = 19, scale = 2)
+    @Column(precision = 15, scale = 2)
     private BigDecimal minimumOrderAmount;
 
     /** 퍼센트 할인 시 최대 할인 금액 상한. null이면 제한 없음. */
-    @Column(precision = 19, scale = 2)
+    @Column(precision = 15, scale = 2)
     private BigDecimal maxDiscountAmount;
 
     /** 전체 사용 가능 횟수 제한. null이면 무제한. */

--- a/src/main/java/com/stockmanagement/domain/coupon/entity/CouponUsage.java
+++ b/src/main/java/com/stockmanagement/domain/coupon/entity/CouponUsage.java
@@ -31,7 +31,7 @@ public class CouponUsage {
     private Long orderId;
 
     /** 실제 할인된 금액 (쿠폰 계산 결과). */
-    @Column(nullable = false, precision = 19, scale = 2)
+    @Column(nullable = false, precision = 15, scale = 2)
     private BigDecimal discountAmount;
 
     @Column(nullable = false)

--- a/src/main/java/com/stockmanagement/domain/inventory/dto/InventoryAdjustRequest.java
+++ b/src/main/java/com/stockmanagement/domain/inventory/dto/InventoryAdjustRequest.java
@@ -1,6 +1,7 @@
 package com.stockmanagement.domain.inventory.dto;
 
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -17,6 +18,7 @@ public class InventoryAdjustRequest {
     @NotNull(message = "조정 수량은 필수입니다.")
     private Integer quantity;
 
-    /** 조정 사유 (선택) */
+    /** 조정 사유 (선택) — InventoryTransaction.note 컬럼 length=255 */
+    @Size(max = 255)
     private String note;
 }

--- a/src/main/java/com/stockmanagement/domain/inventory/dto/InventoryReceiveRequest.java
+++ b/src/main/java/com/stockmanagement/domain/inventory/dto/InventoryReceiveRequest.java
@@ -2,6 +2,7 @@ package com.stockmanagement.domain.inventory.dto;
 
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -19,6 +20,7 @@ public class InventoryReceiveRequest {
     @Min(value = 1, message = "입고 수량은 1 이상이어야 합니다.")
     private Integer quantity;
 
-    /** 입고 사유 또는 메모 (선택) — 추후 이력 관리 시 활용 */
+    /** 입고 사유 또는 메모 (선택) — InventoryTransaction.note 컬럼 length=255 */
+    @Size(max = 255)
     private String note;
 }

--- a/src/main/java/com/stockmanagement/domain/order/cart/entity/CartItem.java
+++ b/src/main/java/com/stockmanagement/domain/order/cart/entity/CartItem.java
@@ -41,7 +41,7 @@ public class CartItem {
     private int quantity;
 
     /** 장바구니 담은 시점의 단가 — 현재 가격과 비교하여 가격 변동 감지에 사용 */
-    @Column(precision = 12, scale = 2)
+    @Column(precision = 15, scale = 2)
     private BigDecimal savedPrice;
 
     @CreationTimestamp

--- a/src/main/java/com/stockmanagement/domain/order/cart/repository/CartRepository.java
+++ b/src/main/java/com/stockmanagement/domain/order/cart/repository/CartRepository.java
@@ -3,6 +3,8 @@ package com.stockmanagement.domain.order.cart.repository;
 import com.stockmanagement.domain.order.cart.entity.CartItem;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Collection;
 import java.util.List;
@@ -21,9 +23,13 @@ public interface CartRepository extends JpaRepository<CartItem, Long> {
     @EntityGraph(attributePaths = "product")
     Optional<CartItem> findByUserIdAndProductId(Long userId, Long productId);
 
-    /** 사용자의 장바구니 전체 삭제 */
+    /** 사용자의 장바구니 전체 삭제 — 벌크 DELETE (파생 삭제 메서드의 N+1 방지) */
+    @Modifying
+    @Query("DELETE FROM CartItem c WHERE c.userId = :userId")
     void deleteByUserId(Long userId);
 
     /** 사용자의 장바구니에서 특정 상품들만 삭제 (선택 결제 후 나머지 유지) */
+    @Modifying
+    @Query("DELETE FROM CartItem c WHERE c.userId = :userId AND c.product.id IN :productIds")
     void deleteByUserIdAndProductIdIn(Long userId, Collection<Long> productIds);
 }

--- a/src/main/java/com/stockmanagement/domain/order/entity/DailyOrderStats.java
+++ b/src/main/java/com/stockmanagement/domain/order/entity/DailyOrderStats.java
@@ -44,7 +44,7 @@ public class DailyOrderStats {
     private int cancelledOrders;
 
     /** 전일 매출액 (CONFIRMED 기준, 쿠폰 할인 차감) */
-    @Column(nullable = false, precision = 19, scale = 2)
+    @Column(nullable = false, precision = 15, scale = 2)
     private BigDecimal totalRevenue;
 
     @CreationTimestamp

--- a/src/main/java/com/stockmanagement/domain/order/entity/Order.java
+++ b/src/main/java/com/stockmanagement/domain/order/entity/Order.java
@@ -50,7 +50,7 @@ public class Order {
     private OrderStatus status;
 
     /** 주문 총액 — 생성 시 OrderItems 합계로 산출 */
-    @Column(nullable = false, precision = 12, scale = 2)
+    @Column(nullable = false, precision = 15, scale = 2)
     private BigDecimal totalAmount;
 
     /**
@@ -78,7 +78,7 @@ public class Order {
     private Long couponId;
 
     /** 쿠폰 할인 금액 (기본 0). */
-    @Column(nullable = false, precision = 19, scale = 2)
+    @Column(nullable = false, precision = 15, scale = 2)
     private BigDecimal discountAmount;
 
     /** 주문 시 사용한 포인트 (기본 0). */

--- a/src/main/java/com/stockmanagement/domain/order/entity/OrderItem.java
+++ b/src/main/java/com/stockmanagement/domain/order/entity/OrderItem.java
@@ -48,11 +48,11 @@ public class OrderItem {
     private int quantity;
 
     /** 주문 당시 단가 — 이후 상품 가격 변경과 무관하게 보존 */
-    @Column(nullable = false, precision = 12, scale = 2)
+    @Column(nullable = false, precision = 15, scale = 2)
     private BigDecimal unitPrice;
 
     /** 소계 = unitPrice × quantity */
-    @Column(nullable = false, precision = 12, scale = 2)
+    @Column(nullable = false, precision = 15, scale = 2)
     private BigDecimal subtotal;
 
     @CreationTimestamp

--- a/src/main/java/com/stockmanagement/domain/payment/entity/Payment.java
+++ b/src/main/java/com/stockmanagement/domain/payment/entity/Payment.java
@@ -54,7 +54,7 @@ public class Payment {
     private String tossOrderId;
 
     /** Payment amount agreed at prepare time; used for server-side amount verification. */
-    @Column(nullable = false, precision = 12, scale = 2)
+    @Column(nullable = false, precision = 15, scale = 2)
     private BigDecimal amount;
 
     @Enumerated(EnumType.STRING)
@@ -72,7 +72,7 @@ public class Payment {
     private LocalDateTime approvedAt;
 
     /** 누적 취소 금액. 전액 취소 시 amount와 동일, 부분 취소 시 취소된 부분 합계. */
-    @Column(precision = 12, scale = 2)
+    @Column(precision = 15, scale = 2)
     private BigDecimal cancelledAmount;
 
     /** Reason provided by the caller when cancelling the payment. */

--- a/src/main/java/com/stockmanagement/domain/product/dto/ProductCreateRequest.java
+++ b/src/main/java/com/stockmanagement/domain/product/dto/ProductCreateRequest.java
@@ -20,6 +20,7 @@ public class ProductCreateRequest {
     private String name;
 
     /** 선택 입력 — null 허용 */
+    @Size(max = 10000)
     private String description;
 
     @NotNull(message = "가격은 필수입니다.")

--- a/src/main/java/com/stockmanagement/domain/product/dto/ProductUpdateRequest.java
+++ b/src/main/java/com/stockmanagement/domain/product/dto/ProductUpdateRequest.java
@@ -23,6 +23,7 @@ public class ProductUpdateRequest {
     private String name;
 
     /** 선택 입력 — null 전달 시 기존 설명이 null로 갱신됨 */
+    @Size(max = 10000)
     private String description;
 
     @NotNull(message = "가격은 필수입니다.")

--- a/src/main/java/com/stockmanagement/domain/product/entity/Product.java
+++ b/src/main/java/com/stockmanagement/domain/product/entity/Product.java
@@ -42,7 +42,7 @@ public class Product {
     private String description;
 
     /** 판매가 — 소수점 2자리까지 허용 (최대 12자리) */
-    @Column(nullable = false, precision = 12, scale = 2)
+    @Column(nullable = false, precision = 15, scale = 2)
     private BigDecimal price;
 
     /** Stock Keeping Unit — 상품을 고유하게 식별하는 관리 코드 */

--- a/src/main/java/com/stockmanagement/domain/product/review/dto/ReviewCreateRequest.java
+++ b/src/main/java/com/stockmanagement/domain/product/review/dto/ReviewCreateRequest.java
@@ -17,5 +17,6 @@ public class ReviewCreateRequest {
     private String title;
 
     @NotBlank
+    @Size(max = 5000)
     private String content;
 }

--- a/src/main/java/com/stockmanagement/domain/product/review/dto/ReviewUpdateRequest.java
+++ b/src/main/java/com/stockmanagement/domain/product/review/dto/ReviewUpdateRequest.java
@@ -18,5 +18,6 @@ public class ReviewUpdateRequest {
     private String title;
 
     @NotBlank
+    @Size(max = 5000)
     private String content;
 }

--- a/src/main/java/com/stockmanagement/domain/product/review/service/ReviewService.java
+++ b/src/main/java/com/stockmanagement/domain/product/review/service/ReviewService.java
@@ -80,7 +80,7 @@ public class ReviewService {
                 ? reviewRepository.findByProductIdAndRating(productId, rating, pageable)
                 : reviewRepository.findByProductId(productId, pageable);
         Map<Long, String> usernameMap = buildUsernameMap(reviews.map(Review::getUserId).toList());
-        return reviews.map(r -> ReviewResponse.from(r, usernameMap.get(r.getUserId())));
+        return reviews.map(r -> ReviewResponse.from(r, usernameMap.getOrDefault(r.getUserId(), "[탈퇴사용자]")));
     }
 
     /** 특정 사용자의 리뷰 목록을 페이징 조회한다. 별점 필터 지원. */

--- a/src/main/java/com/stockmanagement/domain/refund/dto/RefundRequest.java
+++ b/src/main/java/com/stockmanagement/domain/refund/dto/RefundRequest.java
@@ -2,6 +2,7 @@ package com.stockmanagement.domain.refund.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -13,5 +14,6 @@ public class RefundRequest {
     private Long paymentId;
 
     @NotBlank
+    @Size(max = 300)
     private String reason;
 }

--- a/src/main/java/com/stockmanagement/domain/refund/entity/Refund.java
+++ b/src/main/java/com/stockmanagement/domain/refund/entity/Refund.java
@@ -31,7 +31,7 @@ public class Refund {
     @Column(name = "user_id", nullable = false, updatable = false)
     private Long userId;
 
-    @Column(nullable = false, precision = 19, scale = 2)
+    @Column(nullable = false, precision = 15, scale = 2)
     private BigDecimal amount;
 
     @Column(nullable = false, length = 300)

--- a/src/main/java/com/stockmanagement/domain/user/service/UserService.java
+++ b/src/main/java/com/stockmanagement/domain/user/service/UserService.java
@@ -199,6 +199,9 @@ public class UserService {
         if (!passwordEncoder.matches(request.getCurrentPassword(), user.getPassword())) {
             throw new BusinessException(ErrorCode.INVALID_CREDENTIALS);
         }
+        if (request.getCurrentPassword().equals(request.getNewPassword())) {
+            throw new BusinessException(ErrorCode.SAME_PASSWORD);
+        }
         user.updatePassword(passwordEncoder.encode(request.getNewPassword()));
         // 비밀번호 변경 시 모든 기기 Refresh Token 일괄 폐기 (전체 로그아웃 효과)
         refreshTokenStore.revokeAll(username);

--- a/src/main/resources/db/migration/V40__unify_decimal_precision.sql
+++ b/src/main/resources/db/migration/V40__unify_decimal_precision.sql
@@ -1,0 +1,33 @@
+-- DECIMAL precision 불일치 통일: DECIMAL(12,2) / DECIMAL(19,2) → DECIMAL(15,2)
+-- 최대 999억원까지 표현 가능 (운영 요건 충족)
+ALTER TABLE products
+    MODIFY COLUMN price DECIMAL(15, 2) NOT NULL;
+
+ALTER TABLE orders
+    MODIFY COLUMN total_amount    DECIMAL(15, 2) NOT NULL,
+    MODIFY COLUMN discount_amount DECIMAL(15, 2) NOT NULL;
+
+ALTER TABLE order_items
+    MODIFY COLUMN unit_price DECIMAL(15, 2) NOT NULL,
+    MODIFY COLUMN subtotal   DECIMAL(15, 2) NOT NULL;
+
+ALTER TABLE payments
+    MODIFY COLUMN amount           DECIMAL(15, 2) NOT NULL,
+    MODIFY COLUMN cancelled_amount DECIMAL(15, 2);
+
+ALTER TABLE coupons
+    MODIFY COLUMN discount_value        DECIMAL(15, 2) NOT NULL,
+    MODIFY COLUMN minimum_order_amount  DECIMAL(15, 2),
+    MODIFY COLUMN max_discount_amount   DECIMAL(15, 2);
+
+ALTER TABLE coupon_usages
+    MODIFY COLUMN discount_amount DECIMAL(15, 2) NOT NULL;
+
+ALTER TABLE daily_order_stats
+    MODIFY COLUMN total_revenue DECIMAL(15, 2) NOT NULL;
+
+ALTER TABLE refunds
+    MODIFY COLUMN amount DECIMAL(15, 2) NOT NULL;
+
+ALTER TABLE cart_items
+    MODIFY COLUMN saved_price DECIMAL(15, 2);

--- a/src/test/java/com/stockmanagement/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/user/service/UserServiceTest.java
@@ -373,6 +373,24 @@ class UserServiceTest {
 
             verify(refreshTokenStore, never()).revokeAll(anyString());
         }
+
+        @Test
+        @DisplayName("현재/신규 비밀번호 동일 — SAME_PASSWORD 예외 발생")
+        void throwsWhenSamePassword() {
+            ChangePasswordRequest request = new ChangePasswordRequest();
+            org.springframework.test.util.ReflectionTestUtils.setField(request, "currentPassword", "same-pw");
+            org.springframework.test.util.ReflectionTestUtils.setField(request, "newPassword", "same-pw");
+
+            given(userRepository.findByUsername("testuser")).willReturn(Optional.of(user));
+            given(passwordEncoder.matches("same-pw", "encoded-pw")).willReturn(true);
+
+            assertThatThrownBy(() -> userService.changePassword("testuser", request, "test-token"))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.SAME_PASSWORD));
+
+            verify(refreshTokenStore, never()).revokeAll(anyString());
+        }
     }
 
     // ===== deactivate() =====


### PR DESCRIPTION
## Summary

- **#41** DECIMAL precision 통일 — V40 migration, 14개 컬럼 DECIMAL(15,2) 표준화, 엔티티 9개 동기화
- **#108** ChangePasswordRequest 동일 비밀번호 변경 차단 — SAME_PASSWORD ErrorCode 추가
- **#127** InventoryReceiveRequest / InventoryAdjustRequest note @Size(max=255) 추가
- **#111** RefundRequest.reason @Size(max=300) 추가
- **#154** ReviewCreateRequest / ReviewUpdateRequest content @Size(max=5000) 추가
- **#158** ProductCreateRequest / ProductUpdateRequest description @Size(max=10000) 추가
- **#157** 탈퇴 사용자 리뷰 username null 노출 → "[탈퇴사용자]" 기본값 반환
- **#106** CartRepository.deleteByUserId() N+1 DELETE → @Modifying 벌크 DELETE 전환

## Test plan

- [x] 637개 테스트 전체 통과 확인
- [x] UserServiceTest — 동일 비밀번호 변경 시 SAME_PASSWORD 예외 검증
- [x] CartIntegrationTest — 벌크 DELETE 정상 동작 확인