### PR TITLE
fix: CacheConfig allowIfSubType 전환 — Redis 역직렬화 수정 (#57)

### DIFF
--- a/src/main/java/com/stockmanagement/common/config/CacheConfig.java
+++ b/src/main/java/com/stockmanagement/common/config/CacheConfig.java
@@ -43,11 +43,12 @@ public class CacheConfig {
                 .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
                 .activateDefaultTyping(
                         BasicPolymorphicTypeValidator.builder()
-                                .allowIfBaseType("com.stockmanagement.")
-                                .allowIfBaseType("java.util.")
-                                .allowIfBaseType("java.time.")
-                                .allowIfBaseType("java.lang.")
-                                .allowIfBaseType("org.springframework.data.domain.")
+                                // allowIfSubType: BASE TYPE이 아닌 ACTUAL TYPE 기준으로 허용
+                                // (Redis는 Object로 저장하므로 allowIfBaseType("java.lang.")는 동작하지 않음)
+                                .allowIfSubType("com.stockmanagement.")
+                                .allowIfSubType("java.util.")
+                                .allowIfSubType("java.time.")
+                                .allowIfSubType("org.springframework.data.domain.")
                                 .build(),
                         ObjectMapper.DefaultTyping.NON_FINAL,
                         JsonTypeInfo.As.WRAPPER_ARRAY


### PR DESCRIPTION
## Summary
- `allowIfBaseType` → `allowIfSubType` 전환
- Redis는 값을 `Object`로 저장하므로 BASE TYPE 기준의 `allowIfBaseType("com.stockmanagement.")` 는 동작하지 않음
- ACTUAL TYPE 기준의 `allowIfSubType` 사용으로 `InventoryResponse`, `CategoryResponse` 등 도메인 DTO 역직렬화 허용
- 기존 `allowIfBaseType("java.lang.")` (너무 넓음) 대신 필요한 패키지만 명시적으로 허용

## Test plan
- [x] `CacheIntegrationTest.InventoryCache.cacheHit_returnsSameData` 통과 확인 (기존 500 → 200)
- [x] 647개 전체 테스트 통과