### PR TITLE
fix: PresignedUrlRequest contentType MIME 타입 허용 목록 검증 (#46)

### DIFF
--- a/src/main/java/com/stockmanagement/domain/product/image/dto/PresignedUrlRequest.java
+++ b/src/main/java/com/stockmanagement/domain/product/image/dto/PresignedUrlRequest.java
@@ -14,8 +14,12 @@ public class PresignedUrlRequest {
     @Pattern(regexp = "^[a-zA-Z0-9]{1,10}$", message = "허용되지 않는 파일 확장자입니다.")
     private String fileExtension;
 
-    /** 업로드할 파일의 MIME 타입 (예: image/jpeg) */
+    /** 업로드할 파일의 MIME 타입 — 허용: image/jpeg, image/png, image/webp, image/gif */
     @NotBlank
+    @Pattern(
+            regexp = "^image/(jpeg|jpg|png|webp|gif)$",
+            message = "허용된 이미지 MIME 타입이 아닙니다. (image/jpeg, image/png, image/webp, image/gif)"
+    )
     private String contentType;
 
     @NotNull


### PR DESCRIPTION
## Summary
- `@Pattern(regexp = "^image/(jpeg|jpg|png|webp|gif)$")` 추가
- 허용 이미지 MIME 타입: jpeg/jpg/png/webp/gif
- 임의 Content-Type으로 객체 저장 악용 방지

## Test plan
- [x] 647개 전체 테스트 통과