### PR TITLE
fix: ProductSearchRequest sort 단독 파라미터는 ES 진입 조건 제외 (#53)

### DIFF
--- a/src/main/java/com/stockmanagement/domain/product/dto/ProductSearchRequest.java
+++ b/src/main/java/com/stockmanagement/domain/product/dto/ProductSearchRequest.java
@@ -56,13 +56,12 @@ public class ProductSearchRequest {
 
     /**
      * Elasticsearch 검색 조건 존재 여부.
-     * sort만 지정한 경우도 ES로 처리한다.
+     * sort 단독은 ES 진입 조건이 아님 — 실제 검색 필터가 있을 때만 ES 사용.
      */
     public boolean hasSearchCondition() {
         return (q != null && !q.isBlank())
                 || minPrice != null
                 || maxPrice != null
-                || (category != null && !category.isBlank())
-                || (sort != null && !sort.isBlank());
+                || (category != null && !category.isBlank());
     }
 }


### PR DESCRIPTION
## Summary
- `hasSearchCondition()`에서 `sort` 필드 제거
- 이전: `sort=price_asc` 단독 요청도 ES로 진입 (불필요한 ES 호출)
- 수정: `q`, `minPrice`, `maxPrice`, `category` 중 하나 이상 있을 때만 ES 사용

## Test plan
- [x] 647개 전체 테스트 통과