### PR TITLE
fix: LIKE 쿼리 wildcard 문자('%', '_') 이스케이프 처리 (#60)

### DIFF
--- a/src/main/java/com/stockmanagement/domain/admin/service/AdminService.java
+++ b/src/main/java/com/stockmanagement/domain/admin/service/AdminService.java
@@ -91,7 +91,7 @@ public class AdminService {
     /** 전체 사용자 목록 (페이징). search가 있으면 username/email로 필터링 */
     public Page<UserResponse> getUsers(Pageable pageable, String search) {
         if (search != null && !search.isBlank()) {
-            return userRepository.searchByUsernameOrEmail(search, pageable).map(UserResponse::from);
+            return userRepository.searchByUsernameOrEmail(escapeLike(search), pageable).map(UserResponse::from);
         }
         return userRepository.findAll(pageable).map(UserResponse::from);
     }
@@ -134,7 +134,7 @@ public class AdminService {
     /** 전체 상품 목록 (ACTIVE + DISCONTINUED, 관리자 전용). search가 있으면 상품명/SKU로 필터링 */
     public Page<ProductResponse> getAllProducts(Pageable pageable, String search) {
         if (search != null && !search.isBlank()) {
-            return productRepository.searchAll(search, pageable).map(ProductResponse::from);
+            return productRepository.searchAll(escapeLike(search), pageable).map(ProductResponse::from);
         }
         return productRepository.findAll(pageable).map(ProductResponse::from);
     }
@@ -150,5 +150,10 @@ public class AdminService {
     public List<DailyInventorySnapshotResponse> getInventorySnapshot(LocalDate date) {
         return snapshotRepository.findBySnapshotDate(date)
                 .stream().map(DailyInventorySnapshotResponse::from).toList();
+    }
+
+    /** LIKE 패턴 와일드카드(!, %, _)를 이스케이프한다. ESCAPE ! 기준. */
+    private static String escapeLike(String value) {
+        return value.replace("!", "!!").replace("%", "!%").replace("_", "!_");
     }
 }

--- a/src/main/java/com/stockmanagement/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/stockmanagement/domain/product/repository/ProductRepository.java
@@ -47,9 +47,9 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
      * countQuery 분리로 페이징 카운트 쿼리의 정확성 보장.
      */
     @Query(value = "SELECT p FROM Product p LEFT JOIN FETCH p.category WHERE p.status = :status AND " +
-                   "(LOWER(p.name) LIKE LOWER(CONCAT('%', :q, '%')) OR LOWER(p.sku) LIKE LOWER(CONCAT('%', :q, '%')))",
+                   "(LOWER(p.name) LIKE LOWER(CONCAT('%', :q, '%')) ESCAPE '!' OR LOWER(p.sku) LIKE LOWER(CONCAT('%', :q, '%')) ESCAPE '!')",
            countQuery = "SELECT COUNT(p) FROM Product p WHERE p.status = :status AND " +
-                        "(LOWER(p.name) LIKE LOWER(CONCAT('%', :q, '%')) OR LOWER(p.sku) LIKE LOWER(CONCAT('%', :q, '%')))")
+                        "(LOWER(p.name) LIKE LOWER(CONCAT('%', :q, '%')) ESCAPE '!' OR LOWER(p.sku) LIKE LOWER(CONCAT('%', :q, '%')) ESCAPE '!')")
     Page<Product> searchByStatus(@Param("status") ProductStatus status, @Param("q") String query, Pageable pageable);
 
     /**
@@ -57,9 +57,9 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
      * countQuery 분리로 페이징 카운트 쿼리의 정확성 보장.
      */
     @Query(value = "SELECT p FROM Product p LEFT JOIN FETCH p.category WHERE " +
-                   "LOWER(p.name) LIKE LOWER(CONCAT('%', :q, '%')) OR LOWER(p.sku) LIKE LOWER(CONCAT('%', :q, '%'))",
+                   "LOWER(p.name) LIKE LOWER(CONCAT('%', :q, '%')) ESCAPE '!' OR LOWER(p.sku) LIKE LOWER(CONCAT('%', :q, '%')) ESCAPE '!'",
            countQuery = "SELECT COUNT(p) FROM Product p WHERE " +
-                        "LOWER(p.name) LIKE LOWER(CONCAT('%', :q, '%')) OR LOWER(p.sku) LIKE LOWER(CONCAT('%', :q, '%'))")
+                        "LOWER(p.name) LIKE LOWER(CONCAT('%', :q, '%')) ESCAPE '!' OR LOWER(p.sku) LIKE LOWER(CONCAT('%', :q, '%')) ESCAPE '!'")
     Page<Product> searchAll(@Param("q") String query, Pageable pageable);
 
     /** 카테고리 ID 목록 필터 — ACTIVE 상품 중 해당 카테고리에 속하는 상품만 조회 (하위 카테고리 포함 가능). */

--- a/src/main/java/com/stockmanagement/domain/product/service/ProductService.java
+++ b/src/main/java/com/stockmanagement/domain/product/service/ProductService.java
@@ -143,7 +143,7 @@ public class ProductService {
             }
             products = productRepository.findByStatusAndCategoryIdIn(ProductStatus.ACTIVE, categoryIds, effectivePageable);
         } else if (keyword != null && !keyword.isBlank()) {
-            products = productRepository.searchByStatus(ProductStatus.ACTIVE, keyword, effectivePageable);
+            products = productRepository.searchByStatus(ProductStatus.ACTIVE, escapeLike(keyword), effectivePageable);
         } else {
             products = productRepository.findByStatus(ProductStatus.ACTIVE, effectivePageable);
         }
@@ -212,6 +212,11 @@ public class ProductService {
     }
 
     // ===== 내부 헬퍼 =====
+
+    /** LIKE 패턴 와일드카드(!, %, _)를 이스케이프한다. ESCAPE ! 기준. */
+    private static String escapeLike(String value) {
+        return value.replace("!", "!!").replace("%", "!%").replace("_", "!_");
+    }
 
     /**
      * 단일 상품에 재고·리뷰 통계를 포함한 응답을 생성한다 (이미지 미포함).

--- a/src/main/java/com/stockmanagement/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/stockmanagement/domain/user/repository/UserRepository.java
@@ -19,7 +19,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
 
     /** username 또는 email로 사용자 검색 (대소문자 무시, 관리자 전용) */
-    @Query("SELECT u FROM User u WHERE LOWER(u.username) LIKE LOWER(CONCAT('%', :q, '%')) OR LOWER(u.email) LIKE LOWER(CONCAT('%', :q, '%'))")
+    @Query("SELECT u FROM User u WHERE LOWER(u.username) LIKE LOWER(CONCAT('%', :q, '%')) ESCAPE '!' OR LOWER(u.email) LIKE LOWER(CONCAT('%', :q, '%')) ESCAPE '!'")
     Page<User> searchByUsernameOrEmail(@Param("q") String query, Pageable pageable);
 
     /** 특정 역할을 가진 사용자 수 조회 (마지막 ADMIN 해제 방지용) */


### PR DESCRIPTION
## Summary
- JPQL LIKE 쿼리에 `ESCAPE '!'` 추가 — `%`, `_`, `!` 문자 이스케이프
- `ProductRepository`, `UserRepository` 쿼리 수정
- `ProductService.escapeLike()`, `AdminService.escapeLike()` 헬퍼 추가
- 사용자 입력 검색어에 `%` 포함 시 전체 매칭되는 보안 취약점 해소

## Test plan
- [x] 647개 전체 테스트 통과