### PR TITLE
fix: Flyway 마이그레이션 ENGINE=InnoDB CHARSET=utf8mb4 명시 (#61)

### DIFF
--- a/src/main/resources/db/migration/V10__create_cart_tables.sql
+++ b/src/main/resources/db/migration/V10__create_cart_tables.sql
@@ -10,4 +10,4 @@ CREATE TABLE cart_items (
 
     UNIQUE KEY uk_cart_user_product (user_id, product_id),
     CONSTRAINT fk_cart_product FOREIGN KEY (product_id) REFERENCES products (id)
-);
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;

--- a/src/main/resources/db/migration/V11__create_shipment_tables.sql
+++ b/src/main/resources/db/migration/V11__create_shipment_tables.sql
@@ -13,4 +13,4 @@ CREATE TABLE shipments (
     updated_at       DATETIME(6)  NOT NULL,
 
     CONSTRAINT fk_shipment_order FOREIGN KEY (order_id) REFERENCES orders (id)
-);
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;

--- a/src/main/resources/db/migration/V12__create_delivery_address_tables.sql
+++ b/src/main/resources/db/migration/V12__create_delivery_address_tables.sql
@@ -15,7 +15,7 @@ CREATE TABLE delivery_addresses (
 
     KEY idx_delivery_address_user (user_id),
     CONSTRAINT fk_delivery_address_user FOREIGN KEY (user_id) REFERENCES users (id)
-);
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;
 
 -- orders 테이블에 배송지 FK 컬럼 추가 (nullable — 배송지 선택은 선택 사항)
 -- ON DELETE SET NULL: 배송지 삭제 시 주문의 배송지 정보를 null로 설정 (주문 이력 보존)

--- a/src/main/resources/db/migration/V13__create_coupon_tables.sql
+++ b/src/main/resources/db/migration/V13__create_coupon_tables.sql
@@ -18,7 +18,7 @@ CREATE TABLE coupons
     created_at           DATETIME(6)    NOT NULL,
     updated_at           DATETIME(6)    NOT NULL,
     KEY idx_coupons_code (code)
-);
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;
 
 -- ===== 쿠폰 사용 이력 테이블 =====
 CREATE TABLE coupon_usages
@@ -33,7 +33,7 @@ CREATE TABLE coupon_usages
     CONSTRAINT fk_coupon_usage_coupon FOREIGN KEY (coupon_id) REFERENCES coupons (id),
     CONSTRAINT fk_coupon_usage_user FOREIGN KEY (user_id) REFERENCES users (id),
     CONSTRAINT fk_coupon_usage_order FOREIGN KEY (order_id) REFERENCES orders (id)
-);
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;
 
 -- ===== orders 테이블에 쿠폰 연동 컬럼 추가 =====
 ALTER TABLE orders

--- a/src/main/resources/db/migration/V15__create_batch_tables.sql
+++ b/src/main/resources/db/migration/V15__create_batch_tables.sql
@@ -9,7 +9,7 @@ CREATE TABLE daily_order_stats (
     cancelled_orders INT            NOT NULL DEFAULT 0 COMMENT '전일 취소 주문 수',
     total_revenue    DECIMAL(19, 2) NOT NULL DEFAULT 0 COMMENT '전일 매출액 (CONFIRMED 기준, 쿠폰 할인 차감)',
     created_at       DATETIME(6)    NOT NULL COMMENT '집계 생성 시각'
-);
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;
 
 -- 일별 재고 스냅샷 (InventorySnapshotScheduler가 매일 자정 5분에 전체 재고 캡처)
 CREATE TABLE daily_inventory_snapshots (
@@ -25,4 +25,4 @@ CREATE TABLE daily_inventory_snapshots (
     UNIQUE KEY uk_snapshot_inv_date (inventory_id, snapshot_date),
     CONSTRAINT fk_snapshot_inventory
         FOREIGN KEY (inventory_id) REFERENCES inventory (id) ON DELETE CASCADE
-);
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;

--- a/src/main/resources/db/migration/V17__product_images.sql
+++ b/src/main/resources/db/migration/V17__product_images.sql
@@ -10,4 +10,4 @@ CREATE TABLE product_images (
     created_at  DATETIME(6)  NOT NULL,
     CONSTRAINT fk_product_image FOREIGN KEY (product_id)
         REFERENCES products(id) ON DELETE CASCADE
-);
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;

--- a/src/main/resources/db/migration/V22__create_user_coupons_table.sql
+++ b/src/main/resources/db/migration/V22__create_user_coupons_table.sql
@@ -8,4 +8,4 @@ CREATE TABLE user_coupons
     UNIQUE KEY uk_user_coupons (user_id, coupon_id),
     CONSTRAINT fk_user_coupon_user   FOREIGN KEY (user_id)   REFERENCES users (id),
     CONSTRAINT fk_user_coupon_coupon FOREIGN KEY (coupon_id) REFERENCES coupons (id)
-);
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;

--- a/src/main/resources/db/migration/V4__create_payment_tables.sql
+++ b/src/main/resources/db/migration/V4__create_payment_tables.sql
@@ -39,4 +39,4 @@ CREATE TABLE payments
     PRIMARY KEY (id),
     UNIQUE KEY uk_payments_toss_order_id (toss_order_id),
     CONSTRAINT fk_payments_order FOREIGN KEY (order_id) REFERENCES orders (id)
-);
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;

--- a/src/main/resources/db/migration/V9__add_order_status_history.sql
+++ b/src/main/resources/db/migration/V9__add_order_status_history.sql
@@ -10,4 +10,4 @@ CREATE TABLE order_status_history (
 
     CONSTRAINT fk_osh_order FOREIGN KEY (order_id) REFERENCES orders(id) ON DELETE CASCADE,
     INDEX idx_osh_order_id (order_id)
-);
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;


### PR DESCRIPTION
## Summary
- 기존 마이그레이션(V4, V9~V13, V15, V17, V22) CREATE TABLE 끝에 `ENGINE=InnoDB DEFAULT CHARSET=utf8mb4` 추가
- 서버 기본 charset과 무관하게 일관된 인코딩/스토리지 엔진 보장
- Flyway는 이미 적용된 마이그레이션은 재실행하지 않으므로 신규 설치 환경에만 적용

## Test plan
- [x] 647개 전체 테스트 통과