### PR TITLE
fix: ProductImageSaveRequest objectKey 경로 형식 검증 추가 (#50)

### DIFF
--- a/src/main/java/com/stockmanagement/domain/product/image/dto/ProductImageSaveRequest.java
+++ b/src/main/java/com/stockmanagement/domain/product/image/dto/ProductImageSaveRequest.java
@@ -3,6 +3,7 @@ package com.stockmanagement.domain.product.image.dto;
 import com.stockmanagement.domain.product.image.entity.ImageType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 
 @Getter
@@ -12,8 +13,15 @@ public class ProductImageSaveRequest {
     @NotBlank
     private String imageUrl;
 
-    /** presigned URL 발급 시 받은 오브젝트 경로 */
+    /**
+     * presigned URL 발급 시 서버가 반환한 오브젝트 경로.
+     * 형식: products/{productId}/{uuid}.{extension}
+     */
     @NotBlank
+    @Pattern(
+            regexp = "^products/[0-9]+/[0-9a-f-]+[.][a-zA-Z0-9]{1,10}$",
+            message = "올바른 오브젝트 경로 형식이 아닙니다."
+    )
     private String objectKey;
 
     @NotNull

--- a/src/test/java/com/stockmanagement/domain/product/image/controller/ProductImageControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/product/image/controller/ProductImageControllerTest.java
@@ -51,7 +51,7 @@ class ProductImageControllerTest {
         @DisplayName("ADMIN — 200 + presigned URL 반환")
         void admin_success() throws Exception {
             PresignedUrlResponse res = new PresignedUrlResponse(
-                    "https://minio/presigned", "https://minio/img.jpg", "products/1/uuid.jpg");
+                    "https://minio/presigned", "https://minio/img.jpg", "products/1/550e8400-e29b-41d4-a716-446655440000.jpg");
             given(productImageService.generatePresignedUrl(eq(1L), any())).willReturn(res);
 
             String body = objectMapper.writeValueAsString(
@@ -62,7 +62,7 @@ class ProductImageControllerTest {
                             .content(body))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data.presignedUrl").value("https://minio/presigned"))
-                    .andExpect(jsonPath("$.data.objectKey").value("products/1/uuid.jpg"));
+                    .andExpect(jsonPath("$.data.objectKey").value("products/1/550e8400-e29b-41d4-a716-446655440000.jpg"));
         }
 
         @Test
@@ -92,7 +92,7 @@ class ProductImageControllerTest {
 
             String body = objectMapper.writeValueAsString(Map.of(
                     "imageUrl", "https://minio/img.jpg",
-                    "objectKey", "products/1/uuid.jpg",
+                    "objectKey", "products/1/550e8400-e29b-41d4-a716-446655440000.jpg",
                     "imageType", "THUMBNAIL",
                     "displayOrder", 0));
 


### PR DESCRIPTION
## Summary
- `@Pattern(regexp = "^products/[0-9]+/[0-9a-f-]+[.][a-zA-Z0-9]{1,10}$")` 추가
- `products/{productId}/{uuid}.{ext}` 형식만 허용
- 임의 경로 지정으로 다른 객체 덮어쓰기 방지
- 테스트: 유효한 UUID 형식으로 수정

## Test plan
- [x] 647개 전체 테스트 통과