### PR TITLE
fix: Outbox 개선 — 릴레이 카운터 분리 + SHIPMENT_CREATE 멱등성 (#59 #13)

### DIFF
--- a/src/main/java/com/stockmanagement/common/outbox/OutboxEventProcessor.java
+++ b/src/main/java/com/stockmanagement/common/outbox/OutboxEventProcessor.java
@@ -52,20 +52,25 @@ class OutboxEventProcessor {
      * <p>이미 발행된 이벤트는 건너뛴다 (멱등성).
      * 발행 성공 시 {@code publishedAt}을 기록하고, 실패 시 {@code retryCount}를 증가시킨다.
      */
+    /**
+     * @return true = 발행 성공 또는 이미 발행됨, false = 발행 실패
+     */
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void processOne(Long outboxId) {
+    public boolean processOne(Long outboxId) {
         OutboxEvent outbox = repository.findById(outboxId).orElse(null);
         if (outbox == null || outbox.getPublishedAt() != null) {
-            return; // 삭제됐거나 이미 발행된 경우 (다른 인스턴스가 먼저 처리)
+            return true; // 삭제됐거나 이미 발행된 경우 (다른 인스턴스가 먼저 처리)
         }
 
         try {
             dispatch(outbox);
             outbox.markPublished();
+            return true;
         } catch (Exception e) {
             log.error("[Outbox] 이벤트 발행 실패 id={} type={} retry={} error={}",
                     outbox.getId(), outbox.getEventType(), outbox.getRetryCount(), e.getMessage());
             outbox.recordFailure();
+            return false;
         }
     }
 
@@ -82,8 +87,17 @@ class OutboxEventProcessor {
         switch (outbox.getEventType()) {
             case SHIPMENT_CREATE -> {
                 Long orderId = toLong(p.get("orderId"));
-                shipmentService.createForOrder(orderId);
-                log.info("[Outbox] 배송 레코드 생성 완료: orderId={}", orderId);
+                try {
+                    shipmentService.createForOrder(orderId);
+                    log.info("[Outbox] 배송 레코드 생성 완료: orderId={}", orderId);
+                } catch (com.stockmanagement.common.exception.BusinessException e) {
+                    if (e.getErrorCode() == com.stockmanagement.common.exception.ErrorCode.SHIPMENT_ALREADY_EXISTS) {
+                        // 이미 생성된 배송 — 멱등성 처리 (false dead letter 누적 방지)
+                        log.warn("[Outbox] 배송 레코드 이미 존재, 중복 생성 스킵: orderId={}", orderId);
+                        return;
+                    }
+                    throw e;
+                }
             }
             case POINT_EARN -> {
                 Long userId = toLong(p.get("userId"));

--- a/src/main/java/com/stockmanagement/common/outbox/OutboxEventRelayScheduler.java
+++ b/src/main/java/com/stockmanagement/common/outbox/OutboxEventRelayScheduler.java
@@ -42,6 +42,7 @@ public class OutboxEventRelayScheduler {
     private int batchSize;
 
     private Counter relayedCounter;
+    private Counter failedCounter;
 
     @PostConstruct
     void registerMetrics() {
@@ -50,7 +51,10 @@ public class OutboxEventRelayScheduler {
                 .description("MAX_RETRY 초과로 영구 발행 실패된 Outbox 이벤트 수")
                 .register(meterRegistry);
         relayedCounter = Counter.builder("outbox.relayed")
-                .description("relay에 성공(processOne 호출)한 Outbox 이벤트 누적 수")
+                .description("relay에 성공한 Outbox 이벤트 누적 수")
+                .register(meterRegistry);
+        failedCounter = Counter.builder("outbox.relay_failed")
+                .description("relay에 실패한 Outbox 이벤트 누적 수")
                 .register(meterRegistry);
     }
 
@@ -74,8 +78,12 @@ public class OutboxEventRelayScheduler {
 
         // 건별 독립 트랜잭션: 중간 실패가 이전 성공 커밋을 롤백하지 않음
         for (OutboxEvent outbox : pending) {
-            processor.processOne(outbox.getId());
-            relayedCounter.increment();
+            boolean success = processor.processOne(outbox.getId());
+            if (success) {
+                relayedCounter.increment();
+            } else {
+                failedCounter.increment();
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- **#59**: `OutboxEventProcessor.processOne()` 반환 타입 `void` → `boolean`
  - 성공 시 `true`, 실패 시 `false` 반환
  - `OutboxEventRelayScheduler`에서 `successCounter`/`failedCounter` 분리
- **#13**: SHIPMENT_CREATE 이벤트 멱등성 처리
  - `createForOrder()` 호출 시 `SHIPMENT_ALREADY_EXISTS` 예외 catch
  - 이미 배송 레코드가 있으면 false dead letter 방지 (정상 스킵)

## Test plan
- [x] 647개 전체 테스트 통과