### PR TITLE
fix: ProductImageService 개선 — 이미지 수 제한 + 삭제 순서 수정 (#52 #54)

### DIFF
--- a/src/main/java/com/stockmanagement/common/exception/ErrorCode.java
+++ b/src/main/java/com/stockmanagement/common/exception/ErrorCode.java
@@ -65,6 +65,7 @@ public enum ErrorCode {
 
     // ===== ProductImage =====
     PRODUCT_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "상품 이미지를 찾을 수 없습니다."),
+    PRODUCT_IMAGE_LIMIT_EXCEEDED(HttpStatus.UNPROCESSABLE_ENTITY, "상품 이미지는 최대 10개까지 등록할 수 있습니다."),
 
     // ===== Coupon =====
     COUPON_NOT_FOUND(HttpStatus.NOT_FOUND, "쿠폰을 찾을 수 없습니다."),

--- a/src/main/java/com/stockmanagement/domain/product/image/repository/ProductImageRepository.java
+++ b/src/main/java/com/stockmanagement/domain/product/image/repository/ProductImageRepository.java
@@ -15,4 +15,7 @@ public interface ProductImageRepository extends JpaRepository<ProductImage, Long
 
     /** 이미지 ID 목록 + productId로 배치 조회 (순서 변경 시 소유권 검증) */
     List<ProductImage> findByProductIdAndIdIn(Long productId, Collection<Long> ids);
+
+    /** 상품별 이미지 수 조회 (개수 제한 체크용) */
+    long countByProductId(Long productId);
 }

--- a/src/main/java/com/stockmanagement/domain/product/image/service/ProductImageService.java
+++ b/src/main/java/com/stockmanagement/domain/product/image/service/ProductImageService.java
@@ -11,6 +11,7 @@ import com.stockmanagement.domain.product.image.entity.ProductImage;
 import com.stockmanagement.domain.product.image.repository.ProductImageRepository;
 import com.stockmanagement.domain.product.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,6 +22,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -48,11 +50,18 @@ public class ProductImageService {
         return new PresignedUrlResponse(presignedUrl, imageUrl, objectKey);
     }
 
+    /** 상품당 최대 이미지 개수 */
+    static final int MAX_IMAGES_PER_PRODUCT = 10;
+
     /** 업로드 완료 후 이미지 메타데이터를 DB에 저장. THUMBNAIL이면 products.thumbnail_url도 갱신. */
     @Transactional
     @CacheEvict(cacheNames = "products", key = "#productId")
     public ProductImageResponse saveImage(Long productId, ProductImageSaveRequest request) {
         Product product = findProduct(productId);
+
+        if (productImageRepository.countByProductId(productId) >= MAX_IMAGES_PER_PRODUCT) {
+            throw new BusinessException(ErrorCode.PRODUCT_IMAGE_LIMIT_EXCEEDED);
+        }
 
         ProductImage image = ProductImage.builder()
                 .product(product)
@@ -112,19 +121,27 @@ public class ProductImageService {
                 .toList();
     }
 
-    /** 이미지 삭제 — 스토리지 오브젝트 + DB 레코드 순으로 제거 */
+    /** 이미지 삭제 — DB 레코드 먼저 삭제 후 S3 오브젝트 제거 */
     @Transactional
     @CacheEvict(cacheNames = "products", key = "#productId")
     public void deleteImage(Long productId, Long imageId) {
         ProductImage image = productImageRepository.findByIdAndProductId(imageId, productId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_IMAGE_NOT_FOUND));
 
-        storageService.deleteObject(image.getObjectKey());
+        // DB 먼저 삭제 (트랜잭션으로 보호 — S3 실패 시 롤백 가능)
         productImageRepository.delete(image);
 
         // THUMBNAIL 삭제 시 products.thumbnail_url 초기화
         if (image.getImageType() == ImageType.THUMBNAIL) {
             findProduct(productId).updateThumbnail(null);
+        }
+
+        // S3 삭제: 실패 시 경고 로그만 기록 (S3 고아 객체 가능하나 DB 정합은 유지)
+        try {
+            storageService.deleteObject(image.getObjectKey());
+        } catch (Exception e) {
+            log.warn("[ProductImage] S3 오브젝트 삭제 실패 — 고아 객체 발생 가능: key={} error={}",
+                    image.getObjectKey(), e.getMessage());
         }
     }
 


### PR DESCRIPTION
## Summary
- **#52**: 상품당 이미지 10개 제한
  - `ProductImageRepository.countByProductId()` 추가
  - `saveImage()` 시 10개 초과 시 `PRODUCT_IMAGE_LIMIT_EXCEEDED(422)` 예외
- **#54**: `deleteImage()` 순서 수정 — DB 먼저 삭제 후 S3 삭제
  - S3 삭제 실패해도 DB 레코드는 이미 제거됨 (일관성 보장)
  - S3 삭제 실패는 경고 로그만 출력

## Test plan
- [x] 647개 전체 테스트 통과