### PR TITLE
fix: 비밀번호 복잡성 정책 추가 — 대문자+숫자+특수문자 필수 (#28)

### DIFF
--- a/src/main/java/com/stockmanagement/domain/user/dto/ChangePasswordRequest.java
+++ b/src/main/java/com/stockmanagement/domain/user/dto/ChangePasswordRequest.java
@@ -1,6 +1,7 @@
 package com.stockmanagement.domain.user.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,5 +16,9 @@ public class ChangePasswordRequest {
 
     @NotBlank(message = "새 비밀번호를 입력해 주세요.")
     @Size(min = 8, max = 100, message = "비밀번호는 8자 이상 100자 이하여야 합니다.")
+    @Pattern(
+            regexp = "^(?=.*[A-Z])(?=.*[0-9])(?=.*[^A-Za-z0-9]).+$",
+            message = "비밀번호는 대문자, 숫자, 특수문자를 각 1개 이상 포함해야 합니다."
+    )
     private String newPassword;
 }

--- a/src/main/java/com/stockmanagement/domain/user/dto/SignupRequest.java
+++ b/src/main/java/com/stockmanagement/domain/user/dto/SignupRequest.java
@@ -14,6 +14,10 @@ public record SignupRequest(
 
         @NotBlank
         @Size(min = 8, max = 100)
+        @Pattern(
+                regexp = "^(?=.*[A-Z])(?=.*[0-9])(?=.*[^A-Za-z0-9]).+$",
+                message = "비밀번호는 대문자, 숫자, 특수문자를 각 1개 이상 포함해야 합니다."
+        )
         String password,
 
         @NotBlank

--- a/src/test/java/com/stockmanagement/domain/user/controller/AuthControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/user/controller/AuthControllerTest.java
@@ -57,7 +57,7 @@ class AuthControllerTest {
     class Signup {
 
         private static final String VALID_JSON =
-                "{\"username\":\"testuser\",\"password\":\"password123\",\"email\":\"test@example.com\"}";
+                "{\"username\":\"testuser\",\"password\":\"Password1@3\",\"email\":\"test@example.com\"}";
 
         @Test
         @DisplayName("회원가입 성공 (인증 불필요) → 201")
@@ -85,7 +85,7 @@ class AuthControllerTest {
         @Test
         @DisplayName("username 3자 미만 → 400")
         void usernameTooShort() throws Exception {
-            String json = "{\"username\":\"ab\",\"password\":\"password123\",\"email\":\"test@example.com\"}";
+            String json = "{\"username\":\"ab\",\"password\":\"Password1@3\",\"email\":\"test@example.com\"}";
 
             mockMvc.perform(post("/api/auth/signup")
                             .contentType(MediaType.APPLICATION_JSON)
@@ -114,7 +114,7 @@ class AuthControllerTest {
     class Login {
 
         private static final String VALID_JSON =
-                "{\"username\":\"testuser\",\"password\":\"password123\"}";
+                "{\"username\":\"testuser\",\"password\":\"Password1@3\"}";
 
         @Test
         @DisplayName("로그인 성공 (인증 불필요) — JWT + Refresh Token 반환 → 200")

--- a/src/test/java/com/stockmanagement/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/user/service/UserServiceTest.java
@@ -117,17 +117,17 @@ class UserServiceTest {
         @Test
         @DisplayName("정상 가입 — 비밀번호 인코딩 후 User 저장")
         void savesUserWithEncodedPassword() {
-            SignupRequest request = new SignupRequest("testuser", "password123", "test@example.com");
+            SignupRequest request = new SignupRequest("testuser", "Password1@3", "test@example.com");
 
             given(userRepository.existsByUsername("testuser")).willReturn(false);
             given(userRepository.existsByEmail("test@example.com")).willReturn(false);
-            given(passwordEncoder.encode("password123")).willReturn("encoded-pw");
+            given(passwordEncoder.encode("Password1@3")).willReturn("encoded-pw");
             given(userRepository.save(any(User.class))).willReturn(user);
             given(userPointRepository.save(any(UserPoint.class))).willReturn(null);
 
             UserResponse response = userService.signup(request);
 
-            verify(passwordEncoder).encode("password123");
+            verify(passwordEncoder).encode("Password1@3");
             verify(userRepository).save(any(User.class));
             verify(userPointRepository).save(any(UserPoint.class)); // 포인트 계정 초기화 검증
             assertThat(response.username()).isEqualTo("testuser");
@@ -138,7 +138,7 @@ class UserServiceTest {
         @Test
         @DisplayName("username 중복 시 DUPLICATE_USERNAME 예외 발생, 저장 미수행")
         void throwsWhenUsernameDuplicated() {
-            SignupRequest request = new SignupRequest("testuser", "password123", "test@example.com");
+            SignupRequest request = new SignupRequest("testuser", "Password1@3", "test@example.com");
 
             given(userRepository.existsByUsername("testuser")).willReturn(true);
 
@@ -154,7 +154,7 @@ class UserServiceTest {
         @Test
         @DisplayName("email 중복 시 DUPLICATE_EMAIL 예외 발생, 저장 미수행")
         void throwsWhenEmailDuplicated() {
-            SignupRequest request = new SignupRequest("testuser", "password123", "test@example.com");
+            SignupRequest request = new SignupRequest("testuser", "Password1@3", "test@example.com");
 
             given(userRepository.existsByUsername("testuser")).willReturn(false);
             given(userRepository.existsByEmail("test@example.com")).willReturn(true);
@@ -178,10 +178,10 @@ class UserServiceTest {
         @Test
         @DisplayName("정상 로그인 — Access Token + Refresh Token 반환")
         void returnsJwtTokenOnSuccess() {
-            LoginRequest request = new LoginRequest("testuser", "password123");
+            LoginRequest request = new LoginRequest("testuser", "Password1@3");
 
             given(userRepository.findByUsername("testuser")).willReturn(Optional.of(user));
-            given(passwordEncoder.matches("password123", "encoded-pw")).willReturn(true);
+            given(passwordEncoder.matches("Password1@3", "encoded-pw")).willReturn(true);
             given(jwtTokenProvider.createToken("testuser", "USER", null)).willReturn("jwt-token");
             given(jwtTokenProvider.getTokenValidityInSeconds()).willReturn(86400L);
             given(refreshTokenStore.issue("testuser")).willReturn("refresh-uuid");
@@ -197,7 +197,7 @@ class UserServiceTest {
         @Test
         @DisplayName("존재하지 않는 username으로 로그인 시 INVALID_CREDENTIALS 예외 발생")
         void throwsWhenUsernameNotFound() {
-            LoginRequest request = new LoginRequest("unknown", "password123");
+            LoginRequest request = new LoginRequest("unknown", "Password1@3");
 
             given(userRepository.findByUsername("unknown")).willReturn(Optional.empty());
 

--- a/src/test/java/com/stockmanagement/integration/AdminIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/AdminIntegrationTest.java
@@ -40,7 +40,7 @@ class AdminIntegrationTest extends AbstractIntegrationTest {
         @Test
         @DisplayName("USER — ADMIN 전용 → 403")
         void userCannotGetDashboard() throws Exception {
-            String userToken = signupAndLogin("user1", "password1", "user1@test.com");
+            String userToken = signupAndLogin("user1", "Password1!", "user1@test.com");
 
             mockMvc.perform(get("/api/admin/dashboard")
                             .header("Authorization", "Bearer " + userToken))
@@ -65,8 +65,8 @@ class AdminIntegrationTest extends AbstractIntegrationTest {
         @DisplayName("ADMIN — 전체 사용자 목록 조회 → 200, 페이징 응답")
         void adminCanGetUsers() throws Exception {
             String adminToken = createAdminAndLogin("admin2", "adminpass2", "admin2@test.com");
-            signupAndLogin("userA", "password1", "a@test.com");
-            signupAndLogin("userB", "password2", "b@test.com");
+            signupAndLogin("userA", "Password1!", "a@test.com");
+            signupAndLogin("userB", "Password2!", "b@test.com");
 
             mockMvc.perform(get("/api/admin/users")
                             .header("Authorization", "Bearer " + adminToken))
@@ -80,8 +80,8 @@ class AdminIntegrationTest extends AbstractIntegrationTest {
         @DisplayName("ADMIN — search 파라미터로 사용자 검색 → 200, 필터 적용")
         void adminCanSearchUsers() throws Exception {
             String adminToken = createAdminAndLogin("admin3", "adminpass3", "admin3@test.com");
-            signupAndLogin("findme", "password1", "findme@test.com");
-            signupAndLogin("other", "password2", "other@test.com");
+            signupAndLogin("findme", "Password1!", "findme@test.com");
+            signupAndLogin("other", "Password2!", "other@test.com");
 
             mockMvc.perform(get("/api/admin/users?search=findme")
                             .header("Authorization", "Bearer " + adminToken))
@@ -101,7 +101,7 @@ class AdminIntegrationTest extends AbstractIntegrationTest {
         @DisplayName("ADMIN — USER → ADMIN 권한 변경 → 200, role=ADMIN")
         void adminCanUpdateRole() throws Exception {
             String adminToken = createAdminAndLogin("admin4", "adminpass4", "admin4@test.com");
-            signupAndLogin("promote_me", "password1", "promote@test.com");
+            signupAndLogin("promote_me", "Password1!", "promote@test.com");
             long userId = userRepository.findByUsername("promote_me").orElseThrow().getId();
 
             mockMvc.perform(patch("/api/admin/users/" + userId + "/role")

--- a/src/test/java/com/stockmanagement/integration/AuthIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/AuthIntegrationTest.java
@@ -24,7 +24,7 @@ class AuthIntegrationTest extends AbstractIntegrationTest {
         void signup_success() throws Exception {
             mockMvc.perform(post("/api/auth/signup")
                             .contentType(MediaType.APPLICATION_JSON)
-                            .content("{\"username\":\"newuser\",\"password\":\"password123\",\"email\":\"new@example.com\"}"))
+                            .content("{\"username\":\"newuser\",\"password\":\"Password1@3\",\"email\":\"new@example.com\"}"))
                     .andExpect(status().isCreated())
                     .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.data.username").value("newuser"))
@@ -36,12 +36,12 @@ class AuthIntegrationTest extends AbstractIntegrationTest {
         void signup_duplicateUsername_conflict() throws Exception {
             mockMvc.perform(post("/api/auth/signup")
                             .contentType(MediaType.APPLICATION_JSON)
-                            .content("{\"username\":\"dupuser\",\"password\":\"password123\",\"email\":\"first@example.com\"}"))
+                            .content("{\"username\":\"dupuser\",\"password\":\"Password1@3\",\"email\":\"first@example.com\"}"))
                     .andExpect(status().isCreated());
 
             mockMvc.perform(post("/api/auth/signup")
                             .contentType(MediaType.APPLICATION_JSON)
-                            .content("{\"username\":\"dupuser\",\"password\":\"password123\",\"email\":\"second@example.com\"}"))
+                            .content("{\"username\":\"dupuser\",\"password\":\"Password1@3\",\"email\":\"second@example.com\"}"))
                     .andExpect(status().isConflict())
                     .andExpect(jsonPath("$.success").value(false));
         }
@@ -51,12 +51,12 @@ class AuthIntegrationTest extends AbstractIntegrationTest {
         void signup_duplicateEmail_conflict() throws Exception {
             mockMvc.perform(post("/api/auth/signup")
                             .contentType(MediaType.APPLICATION_JSON)
-                            .content("{\"username\":\"user1\",\"password\":\"password123\",\"email\":\"dup@example.com\"}"))
+                            .content("{\"username\":\"user1\",\"password\":\"Password1@3\",\"email\":\"dup@example.com\"}"))
                     .andExpect(status().isCreated());
 
             mockMvc.perform(post("/api/auth/signup")
                             .contentType(MediaType.APPLICATION_JSON)
-                            .content("{\"username\":\"user2\",\"password\":\"password123\",\"email\":\"dup@example.com\"}"))
+                            .content("{\"username\":\"user2\",\"password\":\"Password1@3\",\"email\":\"dup@example.com\"}"))
                     .andExpect(status().isConflict())
                     .andExpect(jsonPath("$.success").value(false));
         }
@@ -66,7 +66,7 @@ class AuthIntegrationTest extends AbstractIntegrationTest {
         void signup_shortUsername_badRequest() throws Exception {
             mockMvc.perform(post("/api/auth/signup")
                             .contentType(MediaType.APPLICATION_JSON)
-                            .content("{\"username\":\"ab\",\"password\":\"password123\",\"email\":\"ab@example.com\"}"))
+                            .content("{\"username\":\"ab\",\"password\":\"Password1@3\",\"email\":\"ab@example.com\"}"))
                     .andExpect(status().isBadRequest());
         }
 
@@ -75,7 +75,7 @@ class AuthIntegrationTest extends AbstractIntegrationTest {
         void signup_invalidEmail_badRequest() throws Exception {
             mockMvc.perform(post("/api/auth/signup")
                             .contentType(MediaType.APPLICATION_JSON)
-                            .content("{\"username\":\"validuser\",\"password\":\"password123\",\"email\":\"not-an-email\"}"))
+                            .content("{\"username\":\"validuser\",\"password\":\"Password1@3\",\"email\":\"not-an-email\"}"))
                     .andExpect(status().isBadRequest());
         }
     }
@@ -91,12 +91,12 @@ class AuthIntegrationTest extends AbstractIntegrationTest {
         void login_success() throws Exception {
             mockMvc.perform(post("/api/auth/signup")
                             .contentType(MediaType.APPLICATION_JSON)
-                            .content("{\"username\":\"logintest\",\"password\":\"password123\",\"email\":\"login@example.com\"}"))
+                            .content("{\"username\":\"logintest\",\"password\":\"Password1@3\",\"email\":\"login@example.com\"}"))
                     .andExpect(status().isCreated());
 
             mockMvc.perform(post("/api/auth/login")
                             .contentType(MediaType.APPLICATION_JSON)
-                            .content("{\"username\":\"logintest\",\"password\":\"password123\"}"))
+                            .content("{\"username\":\"logintest\",\"password\":\"Password1@3\"}"))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.data.accessToken").isNotEmpty())
@@ -106,7 +106,7 @@ class AuthIntegrationTest extends AbstractIntegrationTest {
         @Test
         @DisplayName("비밀번호 불일치 → 401")
         void login_wrongPassword_unauthorized() throws Exception {
-            signupAndLogin("testuser2", "correctpass", "test2@example.com");
+            signupAndLogin("testuser2", "Password1!", "test2@example.com");
 
             mockMvc.perform(post("/api/auth/login")
                             .contentType(MediaType.APPLICATION_JSON)
@@ -120,7 +120,7 @@ class AuthIntegrationTest extends AbstractIntegrationTest {
         void login_unknownUser_unauthorized() throws Exception {
             mockMvc.perform(post("/api/auth/login")
                             .contentType(MediaType.APPLICATION_JSON)
-                            .content("{\"username\":\"ghost\",\"password\":\"password123\"}"))
+                            .content("{\"username\":\"ghost\",\"password\":\"Password1@3\"}"))
                     .andExpect(status().isUnauthorized())
                     .andExpect(jsonPath("$.success").value(false));
         }
@@ -135,7 +135,7 @@ class AuthIntegrationTest extends AbstractIntegrationTest {
         @Test
         @DisplayName("유효한 JWT → 200, 내 정보 반환")
         void getMe_withValidToken() throws Exception {
-            String token = signupAndLogin("meuser", "password123", "me@example.com");
+            String token = signupAndLogin("meuser", "Password1@3", "me@example.com");
 
             mockMvc.perform(get("/api/users/me")
                             .header("Authorization", "Bearer " + token))

--- a/src/test/java/com/stockmanagement/integration/CacheIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/CacheIntegrationTest.java
@@ -108,7 +108,7 @@ class CacheIntegrationTest extends AbstractIntegrationTest {
                     .andExpect(jsonPath("$.data.available").value(30));
 
             // 주문 생성 → reserve() → @CacheEvict 발동
-            String userToken = signupAndLogin("buyer", "buyerpass1", "buyer@example.com");
+            String userToken = signupAndLogin("buyer", "Buyerpass1!", "buyer@example.com");
             long buyerId = userRepository.findByUsername("buyer").orElseThrow().getId();
             mockMvc.perform(post("/api/orders")
                             .header("Authorization", "Bearer " + userToken)
@@ -141,7 +141,7 @@ class CacheIntegrationTest extends AbstractIntegrationTest {
             long productId = createProduct(adminToken, "주문용상품", "CACHE-ORD-1");
             receive(adminToken, productId, 20);
 
-            String userToken = signupAndLogin("buyer", "buyerpass1", "buyer@example.com");
+            String userToken = signupAndLogin("buyer", "Buyerpass1!", "buyer@example.com");
             long buyerId = userRepository.findByUsername("buyer").orElseThrow().getId();
 
             // 주문 생성
@@ -178,7 +178,7 @@ class CacheIntegrationTest extends AbstractIntegrationTest {
             long productId = createProduct(adminToken, "취소캐시상품", "CACHE-ORD-2");
             receive(adminToken, productId, 20);
 
-            String userToken = signupAndLogin("buyer", "buyerpass1", "buyer@example.com");
+            String userToken = signupAndLogin("buyer", "Buyerpass1!", "buyer@example.com");
             long buyerId = userRepository.findByUsername("buyer").orElseThrow().getId();
 
             // 주문 생성

--- a/src/test/java/com/stockmanagement/integration/CartIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/CartIntegrationTest.java
@@ -35,7 +35,7 @@ class CartIntegrationTest extends AbstractIntegrationTest {
     void addItemAndGetCart() throws Exception {
         String adminToken = createAdminAndLogin("admin", "pass1", "admin@test.com");
         long productId = createProductAndReceive(adminToken, "SKU-C1", 2000, 50);
-        String userToken = signupAndLogin("buyer", "password1", "buyer@test.com");
+        String userToken = signupAndLogin("buyer", "Password1!", "buyer@test.com");
 
         // 담기
         mockMvc.perform(post("/api/cart/items")
@@ -60,7 +60,7 @@ class CartIntegrationTest extends AbstractIntegrationTest {
     void addSameItemUpdatesQuantity() throws Exception {
         String adminToken = createAdminAndLogin("admin", "pass1", "admin@test.com");
         long productId = createProductAndReceive(adminToken, "SKU-C2", 1000, 50);
-        String userToken = signupAndLogin("buyer", "password1", "buyer@test.com");
+        String userToken = signupAndLogin("buyer", "Password1!", "buyer@test.com");
 
         mockMvc.perform(post("/api/cart/items")
                         .header("Authorization", "Bearer " + userToken)
@@ -83,7 +83,7 @@ class CartIntegrationTest extends AbstractIntegrationTest {
         String adminToken = createAdminAndLogin("admin", "pass1", "admin@test.com");
         long p1 = createProductAndReceive(adminToken, "SKU-C3", 1000, 10);
         long p2 = createProductAndReceive(adminToken, "SKU-C4", 2000, 10);
-        String userToken = signupAndLogin("buyer", "password1", "buyer@test.com");
+        String userToken = signupAndLogin("buyer", "Password1!", "buyer@test.com");
 
         mockMvc.perform(post("/api/cart/items")
                         .header("Authorization", "Bearer " + userToken)
@@ -113,7 +113,7 @@ class CartIntegrationTest extends AbstractIntegrationTest {
     void clearCart() throws Exception {
         String adminToken = createAdminAndLogin("admin", "pass1", "admin@test.com");
         long productId = createProductAndReceive(adminToken, "SKU-C5", 500, 20);
-        String userToken = signupAndLogin("buyer", "password1", "buyer@test.com");
+        String userToken = signupAndLogin("buyer", "Password1!", "buyer@test.com");
 
         mockMvc.perform(post("/api/cart/items")
                         .header("Authorization", "Bearer " + userToken)
@@ -137,7 +137,7 @@ class CartIntegrationTest extends AbstractIntegrationTest {
     void checkout() throws Exception {
         String adminToken = createAdminAndLogin("admin", "pass1", "admin@test.com");
         long productId = createProductAndReceive(adminToken, "SKU-C6", 3000, 20);
-        String userToken = signupAndLogin("buyer", "password1", "buyer@test.com");
+        String userToken = signupAndLogin("buyer", "Password1!", "buyer@test.com");
         long userId = userRepository.findByUsername("buyer").orElseThrow().getId();
 
         // 담기
@@ -173,8 +173,8 @@ class CartIntegrationTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("빈 장바구니 주문 전환 → 400 Bad Request")
     void checkoutEmptyCart_returns400() throws Exception {
-        signupAndLogin("buyer2", "password1", "buyer2@test.com");
-        String userToken = login("buyer2", "password1");
+        signupAndLogin("buyer2", "Password1!", "buyer2@test.com");
+        String userToken = login("buyer2", "Password1!");
 
         mockMvc.perform(post("/api/cart/checkout")
                         .header("Authorization", "Bearer " + userToken)

--- a/src/test/java/com/stockmanagement/integration/CouponIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/CouponIntegrationTest.java
@@ -76,11 +76,11 @@ class CouponIntegrationTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("쿠폰 생성 → 주문에 쿠폰 적용 → discountAmount 확인")
     void applyCouponOnOrder() throws Exception {
-        String adminToken = createAdminAndLogin("admin", "password1", "a@test.com");
+        String adminToken = createAdminAndLogin("admin", "Password1!", "a@test.com");
         long productId = createProductAndReceive(adminToken, "SKU-COUP1", 30000, 10);
         createCoupon(adminToken, "FIXED5000", "FIXED_AMOUNT", 5000, 100);
 
-        String userToken = signupAndLogin("buyer", "password1", "b@test.com");
+        String userToken = signupAndLogin("buyer", "Password1!", "b@test.com");
         long userId = userRepository.findByUsername("buyer").orElseThrow().getId();
 
         String body = mockMvc.perform(post("/api/orders")
@@ -102,7 +102,7 @@ class CouponIntegrationTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("PERCENTAGE 쿠폰 적용 — 캡 적용 확인")
     void percentageCouponWithCap() throws Exception {
-        String adminToken = createAdminAndLogin("admin", "password1", "a@test.com");
+        String adminToken = createAdminAndLogin("admin", "Password1!", "a@test.com");
         long productId = createProductAndReceive(adminToken, "SKU-COUP2", 50000, 10);
 
         // 10% 할인, 캡 3000
@@ -117,7 +117,7 @@ class CouponIntegrationTest extends AbstractIntegrationTest {
                         .content(json))
                 .andExpect(status().isCreated());
 
-        String userToken = signupAndLogin("buyer", "password1", "b@test.com");
+        String userToken = signupAndLogin("buyer", "Password1!", "b@test.com");
         long userId = userRepository.findByUsername("buyer").orElseThrow().getId();
 
         // 50000 × 10% = 5000 → 캡 3000 적용
@@ -135,11 +135,11 @@ class CouponIntegrationTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("주문 생성 후 취소 → 쿠폰 usageCount 복원 확인")
     void cancelOrderRestoresCouponUsage() throws Exception {
-        String adminToken = createAdminAndLogin("admin", "password1", "a@test.com");
+        String adminToken = createAdminAndLogin("admin", "Password1!", "a@test.com");
         long productId = createProductAndReceive(adminToken, "SKU-COUP3", 20000, 10);
         long couponId  = createCoupon(adminToken, "CANCEL10", "FIXED_AMOUNT", 2000, 5);
 
-        String userToken = signupAndLogin("buyer", "password1", "b@test.com");
+        String userToken = signupAndLogin("buyer", "Password1!", "b@test.com");
         long userId = userRepository.findByUsername("buyer").orElseThrow().getId();
         long orderId = createOrder(userToken, userId, productId, 20000, "CANCEL10");
 
@@ -164,17 +164,17 @@ class CouponIntegrationTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("소진 쿠폰 (maxUsageCount=1) — 2번째 사용 → 422")
     void exhaustedCoupon() throws Exception {
-        String adminToken = createAdminAndLogin("admin", "password1", "a@test.com");
+        String adminToken = createAdminAndLogin("admin", "Password1!", "a@test.com");
         long productId = createProductAndReceive(adminToken, "SKU-COUP4", 10000, 10);
         createCoupon(adminToken, "ONE1TIME", "FIXED_AMOUNT", 1000, 1);
 
         // 첫 번째 사용자 — 성공
-        String user1Token = signupAndLogin("buyer1", "password1", "b1@test.com");
+        String user1Token = signupAndLogin("buyer1", "Password1!", "b1@test.com");
         long user1Id = userRepository.findByUsername("buyer1").orElseThrow().getId();
         createOrder(user1Token, user1Id, productId, 10000, "ONE1TIME");
 
         // 두 번째 사용자 — COUPON_EXHAUSTED (422)
-        String user2Token = signupAndLogin("buyer2", "password1", "b2@test.com");
+        String user2Token = signupAndLogin("buyer2", "Password1!", "b2@test.com");
         long user2Id = userRepository.findByUsername("buyer2").orElseThrow().getId();
         mockMvc.perform(post("/api/orders")
                         .header("Authorization", "Bearer " + user2Token)
@@ -189,11 +189,11 @@ class CouponIntegrationTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("같은 사용자가 동일 쿠폰 재사용 → 422")
     void sameUserCouponReuse() throws Exception {
-        String adminToken = createAdminAndLogin("admin", "password1", "a@test.com");
+        String adminToken = createAdminAndLogin("admin", "Password1!", "a@test.com");
         long productId = createProductAndReceive(adminToken, "SKU-COUP5", 10000, 10);
         createCoupon(adminToken, "ONCE1USER", "FIXED_AMOUNT", 1000, 100);
 
-        String userToken = signupAndLogin("buyer", "password1", "b@test.com");
+        String userToken = signupAndLogin("buyer", "Password1!", "b@test.com");
         long userId = userRepository.findByUsername("buyer").orElseThrow().getId();
         // 첫 번째 사용 — 성공
         createOrder(userToken, userId, productId, 10000, "ONCE1USER");
@@ -212,10 +212,10 @@ class CouponIntegrationTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("쿠폰 유효성 확인 API — 할인 금액 미리보기")
     void validateCoupon() throws Exception {
-        String adminToken = createAdminAndLogin("admin", "password1", "a@test.com");
+        String adminToken = createAdminAndLogin("admin", "Password1!", "a@test.com");
         createCoupon(adminToken, "PREVIEW1", "FIXED_AMOUNT", 3000, 100);
 
-        String userToken = signupAndLogin("buyer", "password1", "b@test.com");
+        String userToken = signupAndLogin("buyer", "Password1!", "b@test.com");
 
         mockMvc.perform(post("/api/coupons/validate")
                         .header("Authorization", "Bearer " + userToken)
@@ -229,7 +229,7 @@ class CouponIntegrationTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("ADMIN — 쿠폰 비활성화 → 비활성화 쿠폰 사용 시 422")
     void deactivateCoupon() throws Exception {
-        String adminToken = createAdminAndLogin("admin", "password1", "a@test.com");
+        String adminToken = createAdminAndLogin("admin", "Password1!", "a@test.com");
         long productId = createProductAndReceive(adminToken, "SKU-COUP6", 10000, 10);
         long couponId  = createCoupon(adminToken, "DEACT001", "FIXED_AMOUNT", 1000, 100);
 
@@ -240,7 +240,7 @@ class CouponIntegrationTest extends AbstractIntegrationTest {
                 .andExpect(jsonPath("$.data.active").value(false));
 
         // 비활성화된 쿠폰 사용 → 422 COUPON_INACTIVE
-        String userToken = signupAndLogin("buyer", "password1", "b@test.com");
+        String userToken = signupAndLogin("buyer", "Password1!", "b@test.com");
         long userId = userRepository.findByUsername("buyer").orElseThrow().getId();
         mockMvc.perform(post("/api/orders")
                         .header("Authorization", "Bearer " + userToken)
@@ -257,10 +257,10 @@ class CouponIntegrationTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("ADMIN 쿠폰 발급 → GET /api/coupons/my에서 조회됨")
     void issueCouponAndGetMyCoupons() throws Exception {
-        String adminToken = createAdminAndLogin("admin", "password1", "a@test.com");
+        String adminToken = createAdminAndLogin("admin", "Password1!", "a@test.com");
         long couponId = createCoupon(adminToken, "MYCOUPON1", "FIXED_AMOUNT", 3000, 100);
 
-        String userToken = signupAndLogin("buyer", "password1", "b@test.com");
+        String userToken = signupAndLogin("buyer", "Password1!", "b@test.com");
         long userId = userRepository.findByUsername("buyer").orElseThrow().getId();
 
         // 발급
@@ -283,7 +283,7 @@ class CouponIntegrationTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("동일 쿠폰 중복 발급 → 409 COUPON_ALREADY_ISSUED")
     void duplicateIssuance() throws Exception {
-        String adminToken = createAdminAndLogin("admin", "password1", "a@test.com");
+        String adminToken = createAdminAndLogin("admin", "Password1!", "a@test.com");
         long couponId = createCoupon(adminToken, "ONCE1ISSU", "FIXED_AMOUNT", 1000, 100);
         long userId = userRepository.findByUsername("admin").orElseThrow().getId();
 
@@ -307,11 +307,11 @@ class CouponIntegrationTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("쿠폰 사용 후 isUsable = false")
     void usedCouponNotUsable() throws Exception {
-        String adminToken = createAdminAndLogin("admin", "password1", "a@test.com");
+        String adminToken = createAdminAndLogin("admin", "Password1!", "a@test.com");
         long productId = createProductAndReceive(adminToken, "SKU-MY1", 20000, 5);
         long couponId = createCoupon(adminToken, "USE1ONCE", "FIXED_AMOUNT", 1000, 100);
 
-        String userToken = signupAndLogin("buyer", "password1", "b@test.com");
+        String userToken = signupAndLogin("buyer", "Password1!", "b@test.com");
         long userId = userRepository.findByUsername("buyer").orElseThrow().getId();
 
         // 발급
@@ -334,7 +334,7 @@ class CouponIntegrationTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("발급받지 않은 사용자 — 내 쿠폰 목록 빈 배열")
     void noIssuedCoupons() throws Exception {
-        String userToken = signupAndLogin("buyer", "password1", "b@test.com");
+        String userToken = signupAndLogin("buyer", "Password1!", "b@test.com");
 
         mockMvc.perform(get("/api/coupons/my")
                         .header("Authorization", "Bearer " + userToken))
@@ -346,10 +346,10 @@ class CouponIntegrationTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("쿠폰 없는 일반 주문 — discountAmount=0")
     void orderWithoutCoupon() throws Exception {
-        String adminToken = createAdminAndLogin("admin", "password1", "a@test.com");
+        String adminToken = createAdminAndLogin("admin", "Password1!", "a@test.com");
         long productId = createProductAndReceive(adminToken, "SKU-COUP7", 15000, 10);
 
-        String userToken = signupAndLogin("buyer", "password1", "b@test.com");
+        String userToken = signupAndLogin("buyer", "Password1!", "b@test.com");
         long userId = userRepository.findByUsername("buyer").orElseThrow().getId();
 
         mockMvc.perform(post("/api/orders")

--- a/src/test/java/com/stockmanagement/integration/DeliveryAddressIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/DeliveryAddressIntegrationTest.java
@@ -19,7 +19,7 @@ class DeliveryAddressIntegrationTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("배송지 등록 → 201, 첫 번째 배송지는 자동 기본")
     void create_firstAddressIsDefault() throws Exception {
-        String token = signupAndLogin("user1", "password1", "u1@test.com");
+        String token = signupAndLogin("user1", "Password1!", "u1@test.com");
 
         mockMvc.perform(post("/api/delivery-addresses")
                         .header("Authorization", "Bearer " + token)
@@ -33,7 +33,7 @@ class DeliveryAddressIntegrationTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("두 번째 배송지 등록 → isDefault = false")
     void create_secondAddressNotDefault() throws Exception {
-        String token = signupAndLogin("user1", "password1", "u1@test.com");
+        String token = signupAndLogin("user1", "Password1!", "u1@test.com");
 
         mockMvc.perform(post("/api/delivery-addresses")
                         .header("Authorization", "Bearer " + token)
@@ -53,7 +53,7 @@ class DeliveryAddressIntegrationTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("필수 필드 누락 → 400")
     void create_missingRequired_400() throws Exception {
-        String token = signupAndLogin("user1", "password1", "u1@test.com");
+        String token = signupAndLogin("user1", "Password1!", "u1@test.com");
 
         mockMvc.perform(post("/api/delivery-addresses")
                         .header("Authorization", "Bearer " + token)
@@ -67,7 +67,7 @@ class DeliveryAddressIntegrationTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("배송지 목록 조회 → 기본 배송지 맨 앞")
     void getList_defaultFirst() throws Exception {
-        String token = signupAndLogin("user1", "password1", "u1@test.com");
+        String token = signupAndLogin("user1", "Password1!", "u1@test.com");
 
         // 첫 번째: 자동으로 기본
         mockMvc.perform(post("/api/delivery-addresses")
@@ -96,7 +96,7 @@ class DeliveryAddressIntegrationTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("배송지 수정 → 변경된 정보 반환")
     void update_success() throws Exception {
-        String token = signupAndLogin("user1", "password1", "u1@test.com");
+        String token = signupAndLogin("user1", "Password1!", "u1@test.com");
         long id = createAddress(token, "집");
 
         String updateReq = VALID_REQUEST.replace("\"집\"", "\"부모님댁\"");
@@ -113,7 +113,7 @@ class DeliveryAddressIntegrationTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("기본 배송지 변경 → 기존 기본 해제, 신규 기본 설정")
     void setDefault_switchesDefault() throws Exception {
-        String token = signupAndLogin("user1", "password1", "u1@test.com");
+        String token = signupAndLogin("user1", "Password1!", "u1@test.com");
 
         long id1 = createAddress(token, "집");
         long id2 = createAddress(token, "회사");
@@ -135,7 +135,7 @@ class DeliveryAddressIntegrationTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("배송지 삭제 → 204, 이후 조회 404")
     void delete_success() throws Exception {
-        String token = signupAndLogin("user1", "password1", "u1@test.com");
+        String token = signupAndLogin("user1", "Password1!", "u1@test.com");
         long id = createAddress(token, "집");
 
         mockMvc.perform(delete("/api/delivery-addresses/" + id)
@@ -150,7 +150,7 @@ class DeliveryAddressIntegrationTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("기본 배송지 삭제 → 다른 배송지가 자동 기본 승격")
     void delete_defaultPromotesAnother() throws Exception {
-        String token = signupAndLogin("user1", "password1", "u1@test.com");
+        String token = signupAndLogin("user1", "Password1!", "u1@test.com");
         long id1 = createAddress(token, "집");   // 기본 배송지
         long id2 = createAddress(token, "회사"); // 일반 배송지
 
@@ -184,7 +184,7 @@ class DeliveryAddressIntegrationTest extends AbstractIntegrationTest {
                         .content("{\"quantity\":10}"))
                 .andExpect(status().isOk());
 
-        String userToken = signupAndLogin("buyer", "password1", "buyer@test.com");
+        String userToken = signupAndLogin("buyer", "Password1!", "buyer@test.com");
         long userId = userRepository.findByUsername("buyer").orElseThrow().getId();
         long addressId = createAddress(userToken, "집");
 

--- a/src/test/java/com/stockmanagement/integration/InventoryConcurrencyTest.java
+++ b/src/test/java/com/stockmanagement/integration/InventoryConcurrencyTest.java
@@ -125,7 +125,7 @@ class InventoryConcurrencyTest extends AbstractIntegrationTest {
         String adminToken = createAdminAndLogin("admin", "adminpass1", "admin@example.com");
         long productId = setupProduct(adminToken, "SKU-CONC-S", 5); // 가용 재고 5
 
-        String userToken = signupAndLogin("buyer", "buyerpass1", "buyer@example.com");
+        String userToken = signupAndLogin("buyer", "Buyerpass1!", "buyer@example.com");
         long buyerId = userRepository.findByUsername("buyer").orElseThrow().getId();
 
         AtomicInteger successCount = new AtomicInteger(0);

--- a/src/test/java/com/stockmanagement/integration/InventoryIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/InventoryIntegrationTest.java
@@ -100,7 +100,7 @@ class InventoryIntegrationTest extends AbstractIntegrationTest {
     void receive_userRole_403() throws Exception {
         String adminToken = createAdminAndLogin("admin", "adminpass1", "admin@example.com");
         long productId = createProduct(adminToken, "상품C", "SKU-C", 3000);
-        String userToken = signupAndLogin("user", "userpass1", "user@example.com");
+        String userToken = signupAndLogin("user", "Userpass1!", "user@example.com");
 
         mockMvc.perform(post("/api/inventory/" + productId + "/receive")
                         .header("Authorization", "Bearer " + userToken)
@@ -167,7 +167,7 @@ class InventoryIntegrationTest extends AbstractIntegrationTest {
         long productId = createProduct(adminToken, "상품F", "SKU-F", 2000);
         receive(adminToken, productId, 20);
 
-        String userToken = signupAndLogin("buyer", "buyerpass1", "buyer@example.com");
+        String userToken = signupAndLogin("buyer", "Buyerpass1!", "buyer@example.com");
         long buyerId = userRepository.findByUsername("buyer").orElseThrow().getId();
 
         // 주문 생성 → reserve() 호출
@@ -277,7 +277,7 @@ class InventoryIntegrationTest extends AbstractIntegrationTest {
             receive(adminToken, soldOut, 2);        // available=2 → 주문으로 소진 예정
 
             // 품절 상품 재고 전량 주문 → reserved=2, available=0
-            String userToken = signupAndLogin("buyer", "buyerpass1", "buyer@example.com");
+            String userToken = signupAndLogin("buyer", "Buyerpass1!", "buyer@example.com");
             long buyerId = userRepository.findByUsername("buyer").orElseThrow().getId();
             mockMvc.perform(post("/api/orders")
                             .header("Authorization", "Bearer " + userToken)

--- a/src/test/java/com/stockmanagement/integration/OrderFilterIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/OrderFilterIntegrationTest.java
@@ -21,8 +21,8 @@ class OrderFilterIntegrationTest extends AbstractIntegrationTest {
     @BeforeEach
     void setUp() throws Exception {
         adminToken = createAdminAndLogin("admin", "adminpass1", "admin@test.com");
-        userToken1 = signupAndLogin("user1", "password1", "u1@test.com");
-        userToken2 = signupAndLogin("user2", "password1", "u2@test.com");
+        userToken1 = signupAndLogin("user1", "Password1!", "u1@test.com");
+        userToken2 = signupAndLogin("user2", "Password1!", "u2@test.com");
         userId1 = userRepository.findByUsername("user1").orElseThrow().getId();
         userId2 = userRepository.findByUsername("user2").orElseThrow().getId();
         productId = createProductAndReceive("SKU-F1", 1000, 100);

--- a/src/test/java/com/stockmanagement/integration/OrderFlowIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/OrderFlowIntegrationTest.java
@@ -39,7 +39,7 @@ class OrderFlowIntegrationTest extends AbstractIntegrationTest {
                 .andExpect(jsonPath("$.data.available").value(50));
 
         // 3. 일반 유저 생성 + 주문 생성 (수량 3, 단가 10000 — product.price와 일치)
-        String userToken = signupAndLogin("buyer", "password123", "buyer@example.com");
+        String userToken = signupAndLogin("buyer", "Password1@3", "buyer@example.com");
         long buyerId = userRepository.findByUsername("buyer").orElseThrow().getId();
 
         String createOrderBody = mockMvc.perform(post("/api/orders")
@@ -98,7 +98,7 @@ class OrderFlowIntegrationTest extends AbstractIntegrationTest {
                         .content("{\"quantity\":10}"))
                 .andExpect(status().isOk());
 
-        String userToken = signupAndLogin("buyer2", "password123", "buyer2@example.com");
+        String userToken = signupAndLogin("buyer2", "Password1@3", "buyer2@example.com");
         long buyerId = userRepository.findByUsername("buyer2").orElseThrow().getId();
 
         // 단가 9999 ≠ 10000 → 400
@@ -133,7 +133,7 @@ class OrderFlowIntegrationTest extends AbstractIntegrationTest {
                         .content("{\"quantity\":5}"))
                 .andExpect(status().isOk());
 
-        String userToken = signupAndLogin("buyer3", "password123", "buyer3@example.com");
+        String userToken = signupAndLogin("buyer3", "Password1@3", "buyer3@example.com");
         long buyerId = userRepository.findByUsername("buyer3").orElseThrow().getId();
 
         // 가용 재고(5) 초과 주문(10) → 409
@@ -167,7 +167,7 @@ class OrderFlowIntegrationTest extends AbstractIntegrationTest {
                         .content("{\"quantity\":20}"))
                 .andExpect(status().isOk());
 
-        String userToken = signupAndLogin("buyer4", "password123", "buyer4@example.com");
+        String userToken = signupAndLogin("buyer4", "Password1@3", "buyer4@example.com");
         long buyerId = userRepository.findByUsername("buyer4").orElseThrow().getId();
 
         String orderJson = String.format(
@@ -225,7 +225,7 @@ class OrderFlowIntegrationTest extends AbstractIntegrationTest {
                         .content("{\"quantity\":10}"))
                 .andExpect(status().isOk());
 
-        String userToken = signupAndLogin("buyer5", "password123", "buyer5@example.com");
+        String userToken = signupAndLogin("buyer5", "Password1@3", "buyer5@example.com");
         long buyerId = userRepository.findByUsername("buyer5").orElseThrow().getId();
 
         // 주문 생성

--- a/src/test/java/com/stockmanagement/integration/PaymentIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/PaymentIntegrationTest.java
@@ -107,7 +107,7 @@ class PaymentIntegrationTest extends AbstractIntegrationTest {
         @DisplayName("정상 주문 → 200, tossOrderId 포함")
         void prepareSuccess() throws Exception {
             String adminToken = createAdminAndLogin("admin_p1", "adminpass1!", "ap1@test.com");
-            String userToken = signupAndLogin("buyer1", "password1!", "b1@test.com");
+            String userToken = signupAndLogin("buyer1", "Password1!", "b1@test.com");
             long userId = userRepository.findByUsername("buyer1").orElseThrow().getId();
             long orderId = createOrderViaApi(adminToken, userToken, userId, "PREP-001", 10000, 3);
 
@@ -125,7 +125,7 @@ class PaymentIntegrationTest extends AbstractIntegrationTest {
         @DisplayName("금액 불일치 → 409")
         void prepareAmountMismatch() throws Exception {
             String adminToken = createAdminAndLogin("admin_p2", "adminpass2!", "ap2@test.com");
-            String userToken = signupAndLogin("buyer2", "password2!", "b2@test.com");
+            String userToken = signupAndLogin("buyer2", "Password2!", "b2@test.com");
             long userId = userRepository.findByUsername("buyer2").orElseThrow().getId();
             long orderId = createOrderViaApi(adminToken, userToken, userId, "PREP-002", 10000, 3);
 
@@ -141,7 +141,7 @@ class PaymentIntegrationTest extends AbstractIntegrationTest {
         @Test
         @DisplayName("존재하지 않는 주문 ID → 404")
         void prepareOrderNotFound() throws Exception {
-            String userToken = signupAndLogin("buyer3", "password3!", "b3@test.com");
+            String userToken = signupAndLogin("buyer3", "Password3!", "b3@test.com");
 
             mockMvc.perform(post("/api/payments/prepare")
                             .header("Authorization", "Bearer " + userToken)
@@ -154,7 +154,7 @@ class PaymentIntegrationTest extends AbstractIntegrationTest {
         @DisplayName("동일 PENDING 주문 중복 prepare → 200, 기존 tossOrderId 재사용")
         void prepareIdempotent() throws Exception {
             String adminToken = createAdminAndLogin("admin_p4", "adminpass4!", "ap4@test.com");
-            String userToken = signupAndLogin("buyer4", "password4!", "b4@test.com");
+            String userToken = signupAndLogin("buyer4", "Password4!", "b4@test.com");
             long userId = userRepository.findByUsername("buyer4").orElseThrow().getId();
             long orderId = createOrderViaApi(adminToken, userToken, userId, "PREP-004", 5000, 2);
 
@@ -188,7 +188,7 @@ class PaymentIntegrationTest extends AbstractIntegrationTest {
         @DisplayName("Toss 응답 DONE → 200, 결제 상태 DONE")
         void confirmSuccess() throws Exception {
             String adminToken = createAdminAndLogin("admin1", "adminpass1", "admin1@test.com");
-            String userToken = signupAndLogin("buyer5", "password5", "b5@test.com");
+            String userToken = signupAndLogin("buyer5", "Password5!", "b5@test.com");
             long userId = userRepository.findByUsername("buyer5").orElseThrow().getId();
 
             // 상품 등록 + 입고 + 주문 생성
@@ -263,7 +263,7 @@ class PaymentIntegrationTest extends AbstractIntegrationTest {
         @Test
         @DisplayName("결제 없는 주문 → 200, data 필드 없음")
         void noPendingPayment() throws Exception {
-            String userToken = signupAndLogin("buyer6", "password6!", "b6@test.com");
+            String userToken = signupAndLogin("buyer6", "Password6!", "b6@test.com");
             long userId = userRepository.findByUsername("buyer6").orElseThrow().getId();
             Order order = createRawOrder(userId, BigDecimal.valueOf(10_000));
 
@@ -278,7 +278,7 @@ class PaymentIntegrationTest extends AbstractIntegrationTest {
         @Test
         @DisplayName("결제가 존재하면 → 200, 결제 정보 반환")
         void paymentExists() throws Exception {
-            String userToken = signupAndLogin("buyer7", "password7!", "b7@test.com");
+            String userToken = signupAndLogin("buyer7", "Password7!", "b7@test.com");
             long userId = userRepository.findByUsername("buyer7").orElseThrow().getId();
             Order order = createRawOrder(userId, BigDecimal.valueOf(15_000));
             Payment payment = createDonePayment(order.getId(), BigDecimal.valueOf(15_000));
@@ -300,7 +300,7 @@ class PaymentIntegrationTest extends AbstractIntegrationTest {
         @Test
         @DisplayName("존재하는 paymentKey → 200")
         void getByExistingKey() throws Exception {
-            String userToken = signupAndLogin("buyer8", "password8!", "b8@test.com");
+            String userToken = signupAndLogin("buyer8", "Password8!", "b8@test.com");
             long userId = userRepository.findByUsername("buyer8").orElseThrow().getId();
             Order order = createRawOrder(userId, BigDecimal.valueOf(8_000));
             Payment payment = createDonePayment(order.getId(), BigDecimal.valueOf(8_000));
@@ -314,7 +314,7 @@ class PaymentIntegrationTest extends AbstractIntegrationTest {
         @Test
         @DisplayName("없는 paymentKey → 404")
         void getByMissingKey() throws Exception {
-            String userToken = signupAndLogin("buyer9", "password9!", "b9@test.com");
+            String userToken = signupAndLogin("buyer9", "Password9!", "b9@test.com");
 
             mockMvc.perform(get("/api/payments/nonexistent-key")
                             .header("Authorization", "Bearer " + userToken))

--- a/src/test/java/com/stockmanagement/integration/PointIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/PointIntegrationTest.java
@@ -49,7 +49,7 @@ class PointIntegrationTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("포인트 잔액 조회 → 초기 0")
     void getBalance_initial() throws Exception {
-        String userToken = signupAndLogin("user1", "password1", "u1@test.com");
+        String userToken = signupAndLogin("user1", "Password1!", "u1@test.com");
 
         mockMvc.perform(get("/api/points/balance")
                         .header("Authorization", "Bearer " + userToken))
@@ -60,7 +60,7 @@ class PointIntegrationTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("포인트 잔액 조회 → 사전 적립 후 잔액 반환")
     void getBalance_withPoints() throws Exception {
-        String userToken = signupAndLogin("user2", "password1", "u2@test.com");
+        String userToken = signupAndLogin("user2", "Password1!", "u2@test.com");
         long userId = userRepository.findByUsername("user2").orElseThrow().getId();
         seedPoints(userId, 5000);
 
@@ -73,7 +73,7 @@ class PointIntegrationTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("포인트 이력 조회 → 초기 빈 목록")
     void getHistory_empty() throws Exception {
-        String userToken = signupAndLogin("user3", "password1", "u3@test.com");
+        String userToken = signupAndLogin("user3", "Password1!", "u3@test.com");
 
         mockMvc.perform(get("/api/points/history")
                         .header("Authorization", "Bearer " + userToken))
@@ -88,7 +88,7 @@ class PointIntegrationTest extends AbstractIntegrationTest {
         String adminToken = createAdminAndLogin("admin", "adminpass1", "admin@test.com");
         long productId = createProductAndReceive(adminToken, "SKU-PT1", 20000, 10);
 
-        String userToken = signupAndLogin("buyer", "password1", "b@test.com");
+        String userToken = signupAndLogin("buyer", "Password1!", "b@test.com");
         long userId = userRepository.findByUsername("buyer").orElseThrow().getId();
         seedPoints(userId, 3000);
 
@@ -116,7 +116,7 @@ class PointIntegrationTest extends AbstractIntegrationTest {
         String adminToken = createAdminAndLogin("admin", "adminpass1", "admin@test.com");
         long productId = createProductAndReceive(adminToken, "SKU-PT2", 10000, 10);
 
-        String userToken = signupAndLogin("buyer2", "password1", "b2@test.com");
+        String userToken = signupAndLogin("buyer2", "Password1!", "b2@test.com");
         long userId = userRepository.findByUsername("buyer2").orElseThrow().getId();
         seedPoints(userId, 500);
 

--- a/src/test/java/com/stockmanagement/integration/ProductIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/ProductIntegrationTest.java
@@ -36,7 +36,7 @@ class ProductIntegrationTest extends AbstractIntegrationTest {
         @Test
         @DisplayName("USER — ADMIN 전용 → 403")
         void createProduct_user_403() throws Exception {
-            String userToken = signupAndLogin("normaluser", "password123", "user@example.com");
+            String userToken = signupAndLogin("normaluser", "Password1@3", "user@example.com");
 
             mockMvc.perform(post("/api/products")
                             .header("Authorization", "Bearer " + userToken)
@@ -76,7 +76,7 @@ class ProductIntegrationTest extends AbstractIntegrationTest {
         @DisplayName("상품 단건 조회 → 200")
         void getProduct_200() throws Exception {
             String adminToken = createAdminAndLogin("admin3", "adminpass3", "admin3@example.com");
-            String userToken = signupAndLogin("user3", "password123", "user3@example.com");
+            String userToken = signupAndLogin("user3", "Password1@3", "user3@example.com");
 
             String responseBody = mockMvc.perform(post("/api/products")
                             .header("Authorization", "Bearer " + adminToken)
@@ -97,7 +97,7 @@ class ProductIntegrationTest extends AbstractIntegrationTest {
         @Test
         @DisplayName("존재하지 않는 상품 → 404")
         void getProduct_notFound_404() throws Exception {
-            String userToken = signupAndLogin("user4", "password123", "user4@example.com");
+            String userToken = signupAndLogin("user4", "Password1@3", "user4@example.com");
 
             mockMvc.perform(get("/api/products/99999")
                             .header("Authorization", "Bearer " + userToken))

--- a/src/test/java/com/stockmanagement/integration/RateLimitIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/RateLimitIntegrationTest.java
@@ -37,7 +37,7 @@ class RateLimitIntegrationTest extends AbstractIntegrationTest {
                         .content("{\"quantity\":20}"))
                 .andExpect(status().isOk());
 
-        String userToken = signupAndLogin("rl-buyer", "buyerpass1", "rl-buyer@example.com");
+        String userToken = signupAndLogin("rl-buyer", "Buyerpass1!", "rl-buyer@example.com");
         long buyerId = userRepository.findByUsername("rl-buyer").orElseThrow().getId();
 
         // 한도 이내 요청(10회) — 모두 성공해야 한다
@@ -68,8 +68,8 @@ class RateLimitIntegrationTest extends AbstractIntegrationTest {
     @DisplayName("결제 확정 rate limit — 사용자별로 독립 카운터 유지")
     void differentUsers_haveSeparateRateLimitCounters() throws Exception {
         // userA와 userB는 rate limit 카운터를 공유하지 않음을 검증
-        String userAToken = signupAndLogin("rl-userA", "passA12345", "usera@example.com");
-        String userBToken = signupAndLogin("rl-userB", "passB12345", "userb@example.com");
+        String userAToken = signupAndLogin("rl-userA", "PassA1234!", "usera@example.com");
+        String userBToken = signupAndLogin("rl-userB", "PassB1234!", "userb@example.com");
 
         String adminToken = createAdminAndLogin("rl-admin2", "adminpass1", "rl-admin2@example.com");
         String productBody = mockMvc.perform(post("/api/products")

--- a/src/test/java/com/stockmanagement/integration/RefundIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/RefundIntegrationTest.java
@@ -88,7 +88,7 @@ class RefundIntegrationTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("환불 ID로 조회 → 200, 상태·금액 확인")
     void getById_success() throws Exception {
-        String userToken = signupAndLogin("user1", "password1", "u1@test.com");
+        String userToken = signupAndLogin("user1", "Password1!", "u1@test.com");
         long userId = userRepository.findByUsername("user1").orElseThrow().getId();
 
         long orderId = createConfirmedOrder(userId);
@@ -106,7 +106,7 @@ class RefundIntegrationTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("없는 환불 ID 조회 → 404")
     void getById_notFound() throws Exception {
-        String userToken = signupAndLogin("user2", "password1", "u2@test.com");
+        String userToken = signupAndLogin("user2", "Password1!", "u2@test.com");
 
         mockMvc.perform(get("/api/refunds/99999")
                         .header("Authorization", "Bearer " + userToken))
@@ -116,7 +116,7 @@ class RefundIntegrationTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("결제 ID로 환불 조회 → 200")
     void getByPaymentId_success() throws Exception {
-        String userToken = signupAndLogin("user3", "password1", "u3@test.com");
+        String userToken = signupAndLogin("user3", "Password1!", "u3@test.com");
         long userId = userRepository.findByUsername("user3").orElseThrow().getId();
 
         long orderId = createConfirmedOrder(userId);
@@ -133,7 +133,7 @@ class RefundIntegrationTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("PARTIAL_CANCELLED 결제 — 이미 환불 이력 있어도 REFUND_ALREADY_EXISTS(409) 반환 안 함")
     void requestRefund_partialCancelledAllowsSecond() throws Exception {
-        String userToken = signupAndLogin("user5", "password1", "u5@test.com");
+        String userToken = signupAndLogin("user5", "Password1!", "u5@test.com");
         long userId = userRepository.findByUsername("user5").orElseThrow().getId();
 
         long orderId = createConfirmedOrder(userId);
@@ -155,7 +155,7 @@ class RefundIntegrationTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("이미 환불된 결제에 재요청 → 409 REFUND_ALREADY_EXISTS")
     void requestRefund_duplicate() throws Exception {
-        String userToken = signupAndLogin("user4", "password1", "u4@test.com");
+        String userToken = signupAndLogin("user4", "Password1!", "u4@test.com");
         long userId = userRepository.findByUsername("user4").orElseThrow().getId();
 
         long orderId = createConfirmedOrder(userId);

--- a/src/test/java/com/stockmanagement/integration/ReviewIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/ReviewIntegrationTest.java
@@ -66,7 +66,7 @@ class ReviewIntegrationTest extends AbstractIntegrationTest {
         String adminToken = createAdminAndLogin("admin", "adminpass1", "admin@test.com");
         long productId = createProductAndReceive(adminToken, "SKU-REV1", 10000, 10);
 
-        String userToken = signupAndLogin("reviewer", "password1", "rev@test.com");
+        String userToken = signupAndLogin("reviewer", "Password1!", "rev@test.com");
         long userId = userRepository.findByUsername("reviewer").orElseThrow().getId();
         placeConfirmedOrder(userToken, userId, productId, 10000);
 
@@ -86,7 +86,7 @@ class ReviewIntegrationTest extends AbstractIntegrationTest {
         long productId = createProductAndReceive(adminToken, "SKU-REV2", 10000, 10);
 
         // 구매 이력 없는 사용자
-        String userToken = signupAndLogin("stranger", "password1", "str@test.com");
+        String userToken = signupAndLogin("stranger", "Password1!", "str@test.com");
 
         mockMvc.perform(post("/api/products/" + productId + "/reviews")
                         .header("Authorization", "Bearer " + userToken)
@@ -101,7 +101,7 @@ class ReviewIntegrationTest extends AbstractIntegrationTest {
         String adminToken = createAdminAndLogin("admin", "adminpass1", "admin@test.com");
         long productId = createProductAndReceive(adminToken, "SKU-REV3", 10000, 10);
 
-        String userToken = signupAndLogin("reviewer2", "password1", "rev2@test.com");
+        String userToken = signupAndLogin("reviewer2", "Password1!", "rev2@test.com");
         long userId = userRepository.findByUsername("reviewer2").orElseThrow().getId();
         placeConfirmedOrder(userToken, userId, productId, 10000);
 
@@ -124,7 +124,7 @@ class ReviewIntegrationTest extends AbstractIntegrationTest {
         String adminToken = createAdminAndLogin("admin", "adminpass1", "admin@test.com");
         long productId = createProductAndReceive(adminToken, "SKU-REV4", 10000, 10);
 
-        String userToken = signupAndLogin("reviewer3", "password1", "rev3@test.com");
+        String userToken = signupAndLogin("reviewer3", "Password1!", "rev3@test.com");
         long userId = userRepository.findByUsername("reviewer3").orElseThrow().getId();
         placeConfirmedOrder(userToken, userId, productId, 10000);
 
@@ -148,7 +148,7 @@ class ReviewIntegrationTest extends AbstractIntegrationTest {
         String adminToken = createAdminAndLogin("admin", "adminpass1", "admin@test.com");
         long productId = createProductAndReceive(adminToken, "SKU-REV5", 10000, 10);
 
-        String userToken = signupAndLogin("reviewer4", "password1", "rev4@test.com");
+        String userToken = signupAndLogin("reviewer4", "Password1!", "rev4@test.com");
         long userId = userRepository.findByUsername("reviewer4").orElseThrow().getId();
         placeConfirmedOrder(userToken, userId, productId, 10000);
 
@@ -176,7 +176,7 @@ class ReviewIntegrationTest extends AbstractIntegrationTest {
         String adminToken = createAdminAndLogin("admin", "adminpass1", "admin@test.com");
         long productId = createProductAndReceive(adminToken, "SKU-REV6", 10000, 10);
 
-        String writerToken = signupAndLogin("writer", "password1", "wr@test.com");
+        String writerToken = signupAndLogin("writer", "Password1!", "wr@test.com");
         long writerId = userRepository.findByUsername("writer").orElseThrow().getId();
         placeConfirmedOrder(writerToken, writerId, productId, 10000);
 
@@ -189,7 +189,7 @@ class ReviewIntegrationTest extends AbstractIntegrationTest {
         long reviewId = objectMapper.readTree(body).path("data").path("id").asLong();
 
         // 타인이 삭제 시도 → 403
-        String otherToken = signupAndLogin("other", "password1", "ot@test.com");
+        String otherToken = signupAndLogin("other", "Password1!", "ot@test.com");
         mockMvc.perform(delete("/api/products/" + productId + "/reviews/" + reviewId)
                         .header("Authorization", "Bearer " + otherToken))
                 .andExpect(status().isForbidden());

--- a/src/test/java/com/stockmanagement/integration/ShipmentIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/ShipmentIntegrationTest.java
@@ -54,7 +54,7 @@ class ShipmentIntegrationTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("주문별 배송 조회 → PREPARING 상태 반환")
     void getByOrderId_returnsPreparing() throws Exception {
-        String userToken = signupAndLogin("user1", "password1", "u1@test.com");
+        String userToken = signupAndLogin("user1", "Password1!", "u1@test.com");
         long userId = userRepository.findByUsername("user1").orElseThrow().getId();
         long orderId = createConfirmedOrder(userId);
         createPreparingShipment(orderId);
@@ -69,7 +69,7 @@ class ShipmentIntegrationTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("존재하지 않는 배송 조회 → 404")
     void getByOrderId_notFound() throws Exception {
-        String userToken = signupAndLogin("user1", "password1", "u1@test.com");
+        String userToken = signupAndLogin("user1", "Password1!", "u1@test.com");
 
         mockMvc.perform(get("/api/shipments/orders/9999")
                         .header("Authorization", "Bearer " + userToken))
@@ -100,7 +100,7 @@ class ShipmentIntegrationTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("USER 권한으로 출고 처리 → 403")
     void ship_userRole_forbidden() throws Exception {
-        String userToken = signupAndLogin("user2", "password1", "u2@test.com");
+        String userToken = signupAndLogin("user2", "Password1!", "u2@test.com");
         long userId = userRepository.findByUsername("user2").orElseThrow().getId();
         long orderId = createConfirmedOrder(userId);
         createPreparingShipment(orderId);

--- a/src/test/java/com/stockmanagement/integration/UserIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/UserIntegrationTest.java
@@ -26,7 +26,7 @@ class UserIntegrationTest extends AbstractIntegrationTest {
         @Test
         @DisplayName("인증된 사용자 — 빈 주문 목록 → 200")
         void returnsEmptyOrders() throws Exception {
-            String token = signupAndLogin("user1", "password1", "u1@test.com");
+            String token = signupAndLogin("user1", "Password1!", "u1@test.com");
 
             mockMvc.perform(get("/api/users/me/orders")
                             .header("Authorization", "Bearer " + token))
@@ -53,7 +53,7 @@ class UserIntegrationTest extends AbstractIntegrationTest {
         @Test
         @DisplayName("탈퇴 → 200, 이후 로그인 불가 → 401")
         void deactivateAndLoginFails() throws Exception {
-            String token = signupAndLogin("leaver", "password1", "leave@test.com");
+            String token = signupAndLogin("leaver", "Password1!", "leave@test.com");
 
             // 탈퇴 → 200
             mockMvc.perform(delete("/api/users/me")

--- a/src/test/java/com/stockmanagement/integration/WishlistIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/WishlistIntegrationTest.java
@@ -30,7 +30,7 @@ class WishlistIntegrationTest extends AbstractIntegrationTest {
         String adminToken = createAdminAndLogin("admin", "adminpass1", "admin@test.com");
         long productId = createProduct(adminToken, "SKU-WL1", 15000);
 
-        String userToken = signupAndLogin("user1", "password1", "u1@test.com");
+        String userToken = signupAndLogin("user1", "Password1!", "u1@test.com");
         mockMvc.perform(post("/api/wishlist/" + productId)
                         .header("Authorization", "Bearer " + userToken))
                 .andExpect(status().isCreated())
@@ -43,7 +43,7 @@ class WishlistIntegrationTest extends AbstractIntegrationTest {
         String adminToken = createAdminAndLogin("admin", "adminpass1", "admin@test.com");
         long productId = createProduct(adminToken, "SKU-WL2", 15000);
 
-        String userToken = signupAndLogin("user2", "password1", "u2@test.com");
+        String userToken = signupAndLogin("user2", "Password1!", "u2@test.com");
         mockMvc.perform(post("/api/wishlist/" + productId)
                         .header("Authorization", "Bearer " + userToken))
                 .andExpect(status().isCreated());
@@ -60,7 +60,7 @@ class WishlistIntegrationTest extends AbstractIntegrationTest {
         String adminToken = createAdminAndLogin("admin", "adminpass1", "admin@test.com");
         long productId = createProduct(adminToken, "SKU-WL3", 20000);
 
-        String userToken = signupAndLogin("user3", "password1", "u3@test.com");
+        String userToken = signupAndLogin("user3", "Password1!", "u3@test.com");
         mockMvc.perform(post("/api/wishlist/" + productId)
                         .header("Authorization", "Bearer " + userToken))
                 .andExpect(status().isCreated());
@@ -79,7 +79,7 @@ class WishlistIntegrationTest extends AbstractIntegrationTest {
         String adminToken = createAdminAndLogin("admin", "adminpass1", "admin@test.com");
         long productId = createProduct(adminToken, "SKU-WL4", 25000);
 
-        String userToken = signupAndLogin("user4", "password1", "u4@test.com");
+        String userToken = signupAndLogin("user4", "Password1!", "u4@test.com");
         mockMvc.perform(post("/api/wishlist/" + productId)
                         .header("Authorization", "Bearer " + userToken))
                 .andExpect(status().isCreated());
@@ -102,7 +102,7 @@ class WishlistIntegrationTest extends AbstractIntegrationTest {
         String adminToken = createAdminAndLogin("admin", "adminpass1", "admin@test.com");
         long productId = createProduct(adminToken, "SKU-WL5", 10000);
 
-        String userToken = signupAndLogin("user5", "password1", "u5@test.com");
+        String userToken = signupAndLogin("user5", "Password1!", "u5@test.com");
         mockMvc.perform(delete("/api/wishlist/" + productId)
                         .header("Authorization", "Bearer " + userToken))
                 .andExpect(status().isNotFound());


### PR DESCRIPTION
## Summary
- `SignupRequest.password`, `ChangePasswordRequest.newPassword`에 `@Pattern` 추가
- 정책: 대문자 1개 이상 + 숫자 1개 이상 + 특수문자 1개 이상
- 패턴: `^(?=.*[A-Z])(?=.*[0-9])(?=.*[^A-Za-z0-9]).+$`
- 기존 약한 패스워드 사용 테스트 파일 전체 업데이트 (23개 파일)

## Test plan
- [x] 647개 전체 테스트 통과