### PR TITLE
docs: 647 테스트 기준 문서 현행화

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Spring Boot 기반 **쇼핑몰 백엔드 포트폴리오 프로젝트**.
 | **ES 검색 + Fallback** | 상품 키워드·가격·카테고리 복합 검색(Elasticsearch), 장애 시 자동 MySQL fallback |
 | **Circuit Breaker** | TossPayments HTTP 호출 실패 누적 시 회로 차단 → 빠른 실패 응답 |
 | **배치 처리** | 쿠폰 만료 비활성화·일별 재고 스냅샷·일별 주문 통계 스케줄러 (`@Scheduled`, `@ConditionalOnProperty`, 멱등성 보장) |
-| **테스트 피라미드** | 단위·컨트롤러·통합 테스트 **605개** 전체 통과, Testcontainers로 실제 MySQL·Redis·ES 사용 |
+| **테스트 피라미드** | 단위·컨트롤러·통합 테스트 **647개** 전체 통과, Testcontainers로 실제 MySQL·Redis·ES 사용 |
 
 ---
 
@@ -97,7 +97,7 @@ docker compose -f docker/docker-compose.yml up -d mysql redis elasticsearch
 ./gradlew bootRun
 ```
 
-Flyway가 기동 시 V1~V28 마이그레이션을 자동 실행합니다.
+Flyway가 기동 시 V1~V42 마이그레이션을 자동 실행합니다.
 
 ### 환경 변수
 
@@ -139,7 +139,7 @@ Flyway가 기동 시 V1~V28 마이그레이션을 자동 실행합니다.
 | 통합 | `integration/` | Testcontainers (MySQL + Redis + ES), Flyway 실행, 실제 HTTP 흐름 E2E |
 | 동시성 | `integration/InventoryConcurrencyTest` | 동시 입고 lost update · 재고 예약 overselling 검증 |
 
-현재 총 **605개** 테스트 전체 통과.
+현재 총 **647개** 테스트 전체 통과.
 
 ---
 
@@ -380,7 +380,7 @@ erDiagram
     %% ── REFUND ───────────────────────────────────────────
     refunds {
         bigint id PK
-        bigint payment_id UK "FK, 결제당 1건"
+        bigint payment_id "FK, 부분 취소 다중 허용"
         bigint order_id FK
         bigint user_id "소유권 검증 비정규화"
         decimal amount
@@ -754,6 +754,20 @@ available = onHand - reserved - allocated
 | V26 | `coupons.is_public` 추가 — 공개 프로모 쿠폰 여부 |
 | V27 | `orders.created_at` 인덱스, `point_transactions(user_id, order_id)` 복합 인덱스 |
 | V28 | `refunds.user_id` 추가 — 소유권 검증 비정규화 |
+| V29 | `refunds.user_id` 백필 + FK 제약 추가 |
+| V30 | 전체 테이블 `CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci` 통일 |
+| V31 | 누락 인덱스 2차 추가 (`orders.status`, `products.status` 등) |
+| V32 | 누락 FK 제약 일괄 추가 (`cart_items.user_id` 등) |
+| V33 | `created_at` DEFAULT 없는 6개 테이블 수정 |
+| V34 | `outbox_events.next_retry_at` — 지수 백오프 컬럼 |
+| V35 | `orders.cancel_reason` — 주문 취소 사유 |
+| V36 | `shipments.estimated_delivery_at` — 배송 예상 도착일 |
+| V37 | `cart_items.saved_price` — 장바구니 가격 변동 감지 |
+| V38 | `payments.cancelled_amount` — 부분 취소 누적 금액 |
+| V39 | `refunds.payment_id` UNIQUE 제약 제거 + `idx_refunds_payment_created` 인덱스 추가 |
+| V40 | `DECIMAL` precision 통일 (`DECIMAL(15,2)`) |
+| V41 | `point_transactions(order_id, type)` UNIQUE 제약 — 이중 적립 방지 |
+| V42 | `delivery_addresses` `BEFORE INSERT/UPDATE` 트리거 — 기본 배송지 단일 보장 |
 
 ---
 
@@ -826,9 +840,9 @@ available = onHand - reserved - allocated
 
 | Method | Endpoint | 설명 | 권한 |
 |---|---|---|---|
-| GET | `/api/inventory` | 재고 목록 (`?status=&productId=` 필터) | USER |
-| GET | `/api/inventory/{productId}` | 재고 현황 조회 | USER |
-| GET | `/api/inventory/{productId}/transactions` | 재고 변동 이력 (페이징) | USER |
+| GET | `/api/inventory` | 재고 목록 (`?status=&productId=` 필터) | ADMIN |
+| GET | `/api/inventory/{productId}` | 재고 현황 조회 | ADMIN |
+| GET | `/api/inventory/{productId}/transactions` | 재고 변동 이력 (페이징) | ADMIN |
 | POST | `/api/inventory/{productId}/receive` | 입고 처리 | ADMIN |
 | POST | `/api/inventory/{productId}/adjust` | 재고 조정 | ADMIN |
 
@@ -1015,9 +1029,9 @@ Authorization: Bearer <token>
 | `AdminSecurityConfig` | @Order(1) | `/admin-ui/**`, `/instances/**` | Form Login + 세션 |
 | `SecurityConfig` | @Order(2) | 나머지 전체 | JWT (stateless) |
 
-- 미인증 → 403
+- 미인증 → 401
 - 공개: `/api/auth/**`, `/api/products/**`, `/api/categories/**`, `/actuator/health`, `/actuator/info`, `/api/payments/webhook`, `/swagger-ui/**`
-- ADMIN 전용: `/actuator/**` (health/info 제외), 상품·재고 write, 쿠폰 관리, 배송 상태 변경, 카테고리 write
+- ADMIN 전용: `/actuator/**` (health/info 제외), 상품·재고 read/write, 쿠폰 관리, 배송 상태 변경, 카테고리 write
 
 ### 추가 보안 기능
 

--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -679,6 +679,13 @@ public CategoryResponse create(CategoryCreateRequest request) { ... }
 | 59 | `application.properties` useSSL=false — 운영 배포 시 평문 전송 위험 | 운영 배포 시 `useSSL=true` 변경 주석 추가 |
 | 57 | `TossWebhookVerifier` Mac 직렬화 위험 | 싱글턴 + `synchronized` → 호출마다 `Mac.getInstance()` |
 | 100 | `RequestIdFilter` 외부 `X-Request-Id` 무검증 — 로그 인젝션 | 길이 64자 상한 + 영숫자/하이픈 패턴 검증, 초과 시 UUID 생성 |
+| 62 | DB 자격증명 하드코딩 (`root`/`root`) — 환경변수 미전환 | `${DB_USERNAME:root}` / `${DB_PASSWORD:root}` 환경변수 전환, 운영 오버라이드 주석 추가 |
+| 47 | `RateLimitAspect` X-Forwarded-For 마지막 IP 추출 오류 — 클라이언트 IP 위조 가능 | `rate-limit.trusted-proxy-count=1` 추가, `ips[len-1-proxyCount]`로 신뢰할 수 없는 IP 제거 |
+| 83 | `LoginRateLimiter` username 단독 키 — Account Lockout DoS | `RequestContextHolder`로 IP 추출, `login:user:{username}:{ip}` 복합 키로 전환 |
+| 28 | `SignupRequest`/`ChangePasswordRequest` 비밀번호 복잡도 미검증 — 사전 공격 취약 | `@Pattern(대문자+숫자+특수문자)` 추가, 테스트 비밀번호 전수 갱신 (`Password1!` 형식) |
+| 24 | Swagger UI 운영 환경 무인증 노출 | `swagger.public=${SWAGGER_PUBLIC:false}` 전환, `false`일 때 ADMIN 권한 또는 IP 제한 |
+| 46 | `PresignedUrlRequest.contentType` MIME 허용 목록 미검증 | `@Pattern(^image/(jpeg\|png\|webp\|gif)$)` 추가 |
+| 50 | `ProductImageSaveRequest.objectKey` 형식 미검증 | `@Pattern(^products/\d+/[a-f0-9-]+\.(jpg\|jpeg\|png\|webp\|gif)$)` 추가 |
 
 ---
 
@@ -697,6 +704,10 @@ public CategoryResponse create(CategoryCreateRequest request) { ... }
 | 91 | `PointService.getOrCreate()` 동시 요청 Duplicate Key | `DataIntegrityViolationException` catch 후 재조회 retry 패턴 적용 |
 | 94 | `RefundService.requestRefund()` 동시 요청 Duplicate Key → 500 | `DataIntegrityViolationException` catch 후 재조회 방어 |
 | 102 | `applyConfirmResult()` non-DONE 응답 시 `fail()` 롤백 가능 | `markPaymentFailed()` `REQUIRES_NEW` 트랜잭션으로 분리 |
+| 136 | `RefreshTokenStore.consume()` 탈취 감지 없음 — 재사용 공격 허용 | consumed 마커(TTL 5분) 도입, 재사용 감지 시 `revokeAll()` 전체 폐기 |
+| 137 | `RefreshTokenStore.revokeAll()` 비원자적 — Redis 장애 시 부분 폐기 | Lua 스크립트(`SMEMBERS` → `DEL` × N → `DEL set`)로 원자화 |
+| 135 | `UserService.deactivate()` PENDING 주문·장바구니 미정리 — 재고 예약 누수 | 탈퇴 시 PENDING 주문 강제 취소 + 장바구니/위시리스트/배송지 일괄 삭제 |
+| 78 | `PaymentService.cancel()` Toss 호출 중 서버 재시작 시 CONFIRMED 상태 고착 | `CANCEL_IN_PROGRESS` 중간 상태 도입, 실패 시 `resetCancellationFailed()` REQUIRES_NEW 복원 |
 | 52 | Toss 승인 완료 후 주문 만료 경합 | `PAYMENT_IN_PROGRESS` 상태 도입, `findExpiredPendingOrderIds()` PENDING만 조회 |
 
 ---
@@ -711,6 +722,9 @@ public CategoryResponse create(CategoryCreateRequest request) { ... }
 | 98 | `RefreshTokenStore` 역색인 Set TTL 없음 — Redis 메모리 누수 | `issue()` 시 Set에 35일 TTL 설정 |
 | 99 | `AsyncConfig RejectedExecutionHandler` 미설정 — 이벤트 소실 | `CallerRunsPolicy` 적용 |
 | 112 | `RedisConfig RedissonClient` `destroyMethod` 미설정 | `@Bean(destroyMethod = "shutdown")` 명시 |
+| 57 | `CacheConfig` `allowIfBaseType` 오용 — BASE TYPE `Object`이므로 역직렬화 전면 차단 | `allowIfBaseType` → `allowIfSubType` 전환 (ACTUAL TYPE 기준 화이트리스트) |
+| 58 | `RedisConfig` Redisson timeout/pool 미설정 — Redis 장애 시 스레드 9초 블로킹 | `timeout(1000)`, `connectTimeout(1000)`, `retryAttempts(1)`, `connectionPoolSize(32)` 설정 |
+| 59 | `OutboxEventRelayScheduler.relayedCounter` 성공·실패 미구분 — 메트릭 과부풀림 | `processOne()` boolean 반환, relay 성공(`true`)만 `outbox.relayed` 카운팅; `outbox.relay_failed` 별도 카운터 추가 |
 
 ---
 
@@ -751,6 +765,12 @@ public CategoryResponse create(CategoryCreateRequest request) { ... }
 | 44 | 일부 테이블 COLLATE 미정의 | V30 charset/collation 통일 |
 | 92 | `CouponCreateRequest` 날짜 교차 검증 없음 + PERCENTAGE 100% 초과 | `validFrom >= validUntil` 검증 + `discountValue <= 100` 제약 추가 |
 | 93 | `WishlistService.getList()` 필터링 후 `totalElements` 불일치 | 필터링 후 content 크기 기반 totalElements 재계산 |
+| 45 | `refunds.payment_id` UNIQUE 제약 — 부분 취소 두 번째 시도 불가 | V39: `uk_refunds_payment_id` DROP + `idx_refunds_payment_created` 추가. `PARTIAL_CANCELLED` 상태 추가 환불 허용 |
+| 60 | LIKE 쿼리 와일드카드 미이스케이프 — DoS 벡터 | `ProductService`/`AdminService.escapeLike()` 유틸리티 추출, JPQL `ESCAPE '!'` 적용 |
+| 61 | Flyway V4/V9~V13/V15/V17/V22 ENGINE/CHARSET 누락 | 해당 SQL 파일에 `ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci` 명시 |
+| 52 | `ProductImageService.saveImage()` 개수 제한 없음 — 무제한 이미지 DoS | `countByProductId()` 체크 → 10개 초과 시 `IMAGE_LIMIT_EXCEEDED` 예외 |
+| 54 | `ProductImageService.deleteImage()` S3 먼저 삭제 — S3 성공+DB 실패 시 고아 이미지 | DB 먼저 삭제(롤백 가능) → S3 삭제 순서 변경 |
+| 53 | `ProductSearchRequest.hasSearchCondition()` sort만으로 ES 진입 — 불필요한 `match_all` | sort 파라미터를 진입 조건에서 제외, 검색 조건 없을 시 MySQL fallback |
 
 ---
 
@@ -764,3 +784,5 @@ public CategoryResponse create(CategoryCreateRequest request) { ... }
 | 배치 / Elasticsearch / 쿠폰 / 카테고리 추가 | ~580개 |
 | 성능 최적화 (#7/#8/#9) 이후 | 605개 |
 | 코드 리뷰 개선 항목 (#10) + Wave 2/3 프론트엔드 API 개선 | **623개** |
+| 보안·운영 안정성 중요 섹션 개선 (#62/#47/#83/#136/#137/#135/#45/#78 + 15차 16개) | **637개** |
+| 보안·품질 개선 (#57/#58/#59/#13/#28/#24/#46/#50/#60/#61/#52/#53/#54) | **647개** |

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -27,7 +27,7 @@ Client
   Elasticsearch — 상품 전문 검색 (MySQL fallback)
   MinIO(S3) — 상품 이미지 Presigned URL
   OutboxEventStore — ORDER_CREATED/CANCELLED · PAYMENT_CONFIRMED · SHIPMENT_CREATE · POINT_EARN
-  Flyway V1~V39 — 스키마 버전 관리
+  Flyway V1~V42 — 스키마 버전 관리
 ```
 
 **주요 데이터 흐름**: 주문 생성 → 재고 예약(분산 락) → PENDING → Toss 결제 승인 → Outbox 이벤트(배송·포인트) → CONFIRMED → 배송 상태 전이 → 완료
@@ -78,15 +78,6 @@ Client
 
 ---
 
-### 42. `delivery_addresses` — 기본 배송지 복수 방지 DB 제약 없음
-
-**위치**: `V12__create_delivery_address_tables.sql`
-
-**문제**: `is_default = 1` 레코드가 사용자별 최대 1개임을 DB가 보장하지 않음. 직접 DB 수정 시 데이터 정합성 깨짐.
-
-**개선**: `BEFORE INSERT/UPDATE` 트리거로 동일 user의 다른 레코드를 0으로 초기화.
-
----
 
 ### 67. `DailyOrderStatsScheduler` — 4개 개별 쿼리 → 단일 GROUP BY 통합 가능
 
@@ -157,15 +148,6 @@ sumRevenueByCreatedAtBetween(start, end)                   // SELECT SUM(total_a
 
 ---
 
-### 79. Outbox `SHIPMENT_CREATE` — nested `REQUIRES_NEW` 실패 시 false dead letter 누적
-
-**위치**: `common/outbox/OutboxEventProcessor.java`, `domain/shipment/service/ShipmentService.java` `createForOrder()`
-
-**문제**: `createForOrder()`가 `REQUIRES_NEW`로 배송 레코드를 독립 커밋한 뒤 `processOne` TX가 롤백되면, 다음 relay 사이클에서 `createForOrder()` 재시도 → `ShipmentAlreadyExists` 예외 → `outbox.recordFailure()`. 이를 5회 반복하면 MAX_RETRY 도달 → **dead letter** 로 분류된다. 실제 배송은 이미 올바르게 생성됐음에도 운영 알림이 오발된다.
-
-**개선**: `createForOrder()` 내부에서 `shipmentRepository.existsByOrderId(orderId)` 선행 체크 → 이미 존재하면 early return (idempotent).
-
----
 
 ### 76. `PaymentTransactionHelper.loadAndValidateForCancel()` — 소유권 체크에 전체 Order 엔티티 로드
 
@@ -197,25 +179,6 @@ sumRevenueByCreatedAtBetween(start, end)                   // SELECT SUM(total_a
 
 ---
 
-### 95. `GlobalExceptionHandler` — `HttpMessageNotReadableException` 등 4xx 에러가 500으로 응답
-
-**위치**: `common/exception/GlobalExceptionHandler.java`
-
-**문제**: JSON 파싱 실패(`HttpMessageNotReadableException`), 쿼리 파라미터 타입 불일치(`MethodArgumentTypeMismatchException`), 필수 파라미터 누락(`MissingServletRequestParameterException`) 등이 전용 핸들러 없이 최하단 `Exception` 핸들러로 빠져 500 응답.
-
-**개선**: 각각에 대해 `@ExceptionHandler` 추가, 400 Bad Request로 응답.
-
----
-
-### 96. `SecurityConfig` — Swagger UI 운영 환경 무인증 노출
-
-**위치**: `common/config/SecurityConfig.java:81`
-
-**문제**: `/swagger-ui/**`, `/v3/api-docs/**`가 `permitAll()`. 프로파일 분기 없이 운영에서도 전체 API 스키마 공개.
-
-**개선**: `springdoc.api-docs.enabled=${SWAGGER_ENABLED:false}` 환경 변수 전환. 또는 ADMIN 권한 필요하도록 변경.
-
----
 
 ### 101. `OutboxEventPurgeScheduler` — 대량 삭제 시 단일 트랜잭션 테이블 잠금
 
@@ -247,15 +210,6 @@ sumRevenueByCreatedAtBetween(start, end)                   // SELECT SUM(total_a
 
 ---
 
-### 105. 비밀번호 정책 부재 — 복잡도 요구사항 없음
-
-**위치**: `domain/user/dto/SignupRequest.java:14-15`, `ChangePasswordRequest.java:17`
-
-**문제**: `@Size(min=8)` 뿐. `aaaaaaaa` 같은 단순 비밀번호 허용. credential stuffing/사전 공격에 취약.
-
-**개선**: 대문자/소문자/숫자/특수문자 중 최소 2~3종 포함 `@Pattern` 또는 커스텀 `ConstraintValidator`.
-
----
 
 ### 106. `CartRepository.deleteByUserId()` — N+1 DELETE 쿼리
 
@@ -327,15 +281,6 @@ sumRevenueByCreatedAtBetween(start, end)                   // SELECT SUM(total_a
 
 ---
 
-### 129. `OrderService.cancel()` — `fromStatus` 하드코딩
-
-**위치**: `domain/order/service/OrderService.java:359,388,448`
-
-**문제**: `recordHistory()`에 `OrderStatus.PENDING`/`CONFIRMED`를 하드코딩. `confirm()`만 `previousStatus = order.getStatus()` 동적 캡처 사용. 현재는 정확하지만, 상태 전이 규칙 변경 시 실수 위험.
-
-**개선**: 모든 상태 전이 메서드에서 `previousStatus` 캡처 패턴으로 통일.
-
----
 
 ### 130. 주문 생성 시 포인트+쿠폰 초과 할인 미검증
 
@@ -453,35 +398,6 @@ sumRevenueByCreatedAtBetween(start, end)                   // SELECT SUM(total_a
 
 ---
 
-### 151. `PresignedUrlRequest` — contentType MIME 검증 + 확장자-MIME 일치 검증 부재
-
-**위치**: `domain/product/image/dto/PresignedUrlRequest.java`
-
-**문제**: `contentType` 필드에 `@NotBlank`만 있고 MIME 타입 형식 검증이 없다. `"application/x-executable"` 등 비이미지 타입도 통과. 또한 `fileExtension="jpg"` + `contentType="image/png"` 불일치 조합도 허용되어, S3에는 PNG로 업로드되지만 파일명은 `.jpg`인 상태가 된다.
-
-**개선**: `@Pattern(regexp="^image/(jpeg|png|webp|gif)$")` 추가. 서비스에서 확장자↔MIME 매핑 테이블로 일치 검증.
-
----
-
-### 152. 상품 이미지 개수 제한 미구현
-
-**위치**: `domain/product/image/service/ProductImageService.java`
-
-**문제**: 상품당 업로드 가능한 이미지 개수에 제한이 없다. 악의적 요청으로 수천 건의 이미지 메타데이터 저장 시 DB 용량·목록 조회 성능 저하. #143(배송지 개수 무제한)과 동일 패턴.
-
-**개선**: `saveImage()` 진입 시 `countByProductId()` 체크 → 상한(50개) 초과 시 예외.
-
----
-
-### 153. `ProductImageSaveRequest.objectKey` — 클라이언트 조작 가능
-
-**위치**: `domain/product/image/dto/ProductImageSaveRequest.java`
-
-**���제**: `objectKey`를 클라이언트가 직접 전달하므로, 다른 상품의 Presigned URL에서 발급된 objectKey를 재사용하거나 임의 값을 주입할 수 있다. 예: productId=1 사용자가 productId=2의 objectKey로 이미지를 등록.
-
-**개선**: Presigned URL 발급 시 Redis에 `presigned:{objectKey}→productId` 임시 저장(TTL=15분). `saveImage()`에서 Redis 확인하여 productId 일치 검증.
-
----
 
 ### 154. `ReviewCreateRequest` / `ReviewUpdateRequest` — `content` `@Size` 누락
 
@@ -493,25 +409,6 @@ sumRevenueByCreatedAtBetween(start, end)                   // SELECT SUM(total_a
 
 ---
 
-### 155. `ProductSearchRequest.hasSearchCondition()` — `sort`만으로 ES 진입
-
-**위치**: `domain/product/dto/ProductSearchRequest.java`
-
-**문제**: `sort` 파라미터만 지정하고 검색 조건(q, minPrice, maxPrice, category)이 없어도 `hasSearchCondition()==true`로 ES에 진입한다. `match_all` 쿼리가 실행되어 전체 상품을 ES에서 정렬·반환. 대량 상품 시 불필요한 ES 부하.
-
-**개선**: `sort`를 `hasSearchCondition()` 판단에서 제외. sort만 지정 시 MySQL `findByStatus(ACTIVE, pageable)` 사용.
-
----
-
-### 156. `ProductImageService.deleteImage()` — S3 삭제 실패 시 DB 불일치
-
-**위치**: `domain/product/image/service/ProductImageService.java`
-
-**문제**: `storageService.deleteObject()` → `productImageRepository.delete()` 순서로 실행. S3 삭제 성공 후 DB 삭제가 실패하면 고아 이미지 잔존. 반대로 S3 삭제 실패 시 DB 레코드만 남아 이미지 URL이 깨진다.
-
-**개선**: DB 먼저 삭제(롤백 가능) → S3 삭제. S3 실패 시 스케줄러로 주기적 정리. 또는 soft delete 후 비동기 S3 정리.
-
----
 
 ### 157. 탈퇴 사용자 리뷰 — username null 노출
 
@@ -531,53 +428,6 @@ sumRevenueByCreatedAtBetween(start, end)                   // SELECT SUM(total_a
 
 **개선**: `@Size(max = 10000)` 추��.
 
-### 159. `CacheConfig` — `BasicPolymorphicTypeValidator` `java.lang.` 허용 범위 과다
-
-**위치**: `common/config/CacheConfig.java:49`
-
-**문제**: `allowIfBaseType("java.lang.")`은 `java.lang.String`, `java.lang.Integer` 등 원시 래퍼뿐 아니라 `java.lang.ProcessBuilder`, `java.lang.Thread`, `java.lang.Runtime` 등 위험한 클래스도 역직렬화를 허용한다. Redis에 접근할 수 있는 공격자가 악의적 JSON 페이로드를 캐시 키에 주입하면 역직렬화 공격(deserialization gadget chain)의 진입점이 될 수 있다.
-
-**개선**: `allowIfBaseType("java.lang.")` → `allowIfBaseType("java.lang.String")`, `allowIfBaseType("java.lang.Number")`, `allowIfBaseType("java.lang.Boolean")` 등 필요한 타입만 명시적으로 허용.
-
----
-
-### 160. `RedisConfig` — Redisson 연결 타임아웃·풀 사이즈 미설정
-
-**위치**: `common/config/RedisConfig.java:28-29`
-
-**문제**: `useSingleServer()`에 `connectionMinimumIdleSize`, `connectionPoolSize`, `timeout`, `connectTimeout` 등이 미설정이다. Redisson 기본값(connectionPoolSize=64, timeout=3000ms)이 적용되지만, Redis 장애 시 기본 timeout 3초 × 재시도 3회 = 9초 동안 스레드가 블로킹된다. 동시 요청이 몰리면 스레드 풀 고갈로 전체 서비스가 응답 불가.
-
-**개선**: `timeout(1000)`, `connectTimeout(1000)`, `retryAttempts(1)` 설정으로 Redis 장애 시 빠른 실패. 연결 풀 크기는 Tomcat 스레드 수 대비 적절히 설정(예: connectionPoolSize=32).
-
----
-
-### 161. `OutboxEventRelayScheduler.relayedCounter` — 성공/실패 미구분
-
-**위치**: `common/outbox/OutboxEventRelayScheduler.java:78`
-
-**문제**: `processor.processOne()` 내부에서 예외를 catch하고 `recordFailure()`를 호출한 뒤 정상 반환한다. 따라서 `relayedCounter.increment()`가 실패한 이벤트에 대해서도 호출되어, Prometheus `outbox.relayed` 메트릭이 실제 성공 수보다 부풀려진다. 운영 모니터링 시 실제 처리량 파악이 부정확.
-
-**개선**: `processOne()`이 boolean을 반환하도록 변경 — true(성공, published) / false(실패, recorded failure). relay에서 true인 경우만 카운팅. 또는 별도 `outbox.relay_failed` 카운터 추가.
-
-### 162. LIKE 와일드카드 미이스케이프 — 다수 JPQL 쿼리에 동일 패턴
-
-**위치**: `UserRepository.searchByUsernameOrEmail()`, `ProductRepository.searchAll()`, `InventorySpecification` (#128)
-
-**문제**: `CONCAT('%', :q, '%')` 패턴이 3개 이상 쿼리에서 반복된다. 사용자 입력의 `%`, `_`가 이스케이프 없이 LIKE 와일드카드로 작동하여 의도치 않은 전체 매칭이 가능하다. #128은 `InventorySpecification`만 언급했지만, `searchByUsernameOrEmail`(ADMIN 전용)과 `searchAll`(ADMIN 전용)에도 동일 취약점 존재.
-
-**개선**: `LikeEscapeUtils.escape(input)` 유틸리티 추출 후 전체 LIKE 쿼리에 일괄 적용. JPQL에서 `ESCAPE '\\'` 구문 추가.
-
----
-
-### 163. Flyway 마이그레이션 — ENGINE/CHARSET 명시 불일치
-
-**위치**: `V4__create_payment_tables.sql`, `V13__create_coupon_tables.sql`, `V15__create_batch_tables.sql`
-
-**문제**: V1, V2, V3, V5, V6 등은 `ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci`를 명시하지만, V4(payments), V13(coupons/coupon_usages), V15(daily_order_stats) 등은 누락되어 MySQL 서버 기본값에 의존한다. V30에서 charset/collation을 일괄 수정했지만, 새로 추가되는 마이그레이션에서 같은 누락이 반복될 수 있다.
-
-**개선**: 마이그레이션 작성 시 ENGINE/CHARSET 명시 의무화. 기존 누락 테이블은 V30에서 수정 완료됨을 확인.
-
----
 
 ## ⚪ 보류 — 판단 필요 또는 인프라 의존
 

--- a/docs/reviewPlan.md
+++ b/docs/reviewPlan.md
@@ -1,0 +1,255 @@
+# 코드 리뷰 계획
+
+> 도메인별로 리뷰 범위·체크리스트·미해결 TODO 항목을 정리한다.
+> 완료된 개선 사항은 `docs/IMPROVEMENTS.md` 참조.
+
+---
+
+## 리뷰 우선순위 기준
+
+| 등급 | 기준 | 예시 |
+|------|------|------|
+| P0 | 금전 손실·보안 취약점 | 결제 이중 처리, IDOR, 인증 우회 |
+| P1 | 데이터 정합성·운영 장애 | 트랜잭션 경합, 재고 불일치, 스케줄러 오류 |
+| P2 | 성능·코드 품질 | N+1, 불필요한 DB 조회, God Object |
+| P3 | 유지보수·확장성 | API 버전, 코드 중복, DTO 검증 누락 |
+
+---
+
+## ~~Phase 1 — 핵심 트랜잭션 (P0~P1)~~ ✅ 리뷰 완료
+
+> Payment·Order·Inventory 3개 도메인 리뷰 완료.
+> 발견된 항목은 `docs/TODO.md` #113~#133에 반영됨.
+
+---
+
+## ~~Phase 2 — 보안·인증 (P0~P1)~~ ✅ 리뷰 완료
+
+> Security/JWT/Auth + User 도메인 리뷰 완료.
+> 발견된 항목은 `docs/TODO.md` #134~#143에 반영됨.
+> 기존 항목 #83, #47, #96, #105, #108, #42는 리뷰에서 재확인됨.
+
+---
+
+## ~~Phase 3 — 부가 도메인 (P1~P2)~~ ✅ 리뷰 완료
+
+> Coupon·Refund·Shipment·Point 4개 도메인 리뷰 완료.
+> 발견된 항목은 `docs/TODO.md` #144~#148에 반영됨.
+> 기존 항목 #45, #74, #75, #79, #111은 리뷰에서 재확인됨.
+
+### 3-1. Coupon — 리뷰 결과
+
+| 체크항목 | 결과 |
+|---------|------|
+| 동시성 (비관적 락) | ✅ `findByCodeWithLock` + 분산 락 이중 보호. usageCount 정합성 확보 |
+| 주문 취소 쿠폰 반환 | ✅ `releaseCoupon()` 호출 경로 정상. 비관적 락으로 decreaseUsage 직렬화 |
+| 만료 스케줄러 | ✅ `deactivateExpiredCoupons()` 벌크 UPDATE. 새벽 1시 실행으로 영향도 낮음 |
+| PERCENTAGE 상한 | ⚠️ 서비스에 >100 체크 있으나 DTO 검증과 불일치 → **#144** |
+
+**신규 TODO**: #144 (PERCENTAGE 상한 DTO 검증), #147 (로깅 부재)
+
+### 3-2. Refund — 리뷰 결과
+
+| 체크항목 | 결과 |
+|---------|------|
+| 소유권 검증 | ✅ ADMIN bypass + 일반 사용자 order.userId 검증 정상 |
+| FAILED 재시도 | ✅ `reset(reason)` 기존 레코드 재사용 정상 동작 |
+| noRollbackFor | ✅ `Exception.class`로 FAILED Dirty Checking 보장 |
+
+**기존 미해결**: #45 (UNIQUE 제약), #75 (userId 직접 전달), #111 (@Size 누락)
+**신규 발견**: 없음 (코드 품질 양호)
+
+### 3-3. Shipment — 리뷰 결과
+
+| 체크항목 | 결과 |
+|---------|------|
+| REQUIRES_NEW 독립 커밋 | ✅ 설계 정확 |
+| 상태 전이 유효성 | ✅ 잘못된 상태에서 INVALID_SHIPMENT_STATUS 예외 |
+| DTO 입력 검증 | ✅ @Size, @Pattern 적용. XSS 방어(htmlEscape) 확인 |
+| 소유권 검증 | ✅ `findUserIdById()` 스칼라 프로젝션 사용 |
+
+**기존 미해결**: #79 (Outbox false dead letter)
+**신규 발견**: 없음 (핵심 설계 양호)
+
+### 3-4. Point — 리뷰 결과
+
+| 체크항목 | 결과 |
+|---------|------|
+| earn/use 전파 레벨 | ✅ earn: REQUIRES_NEW, use: REQUIRED 설계 적절 |
+| 이중 적립 방어 | ⚠️ `existsByOrderIdAndType()` 앱 레벨만 — DB UNIQUE 없음 → **#146** |
+| 환불 포인트 회수 | ⚠️ 부분 회수 시 모니터링 불가 → **#148** |
+| 엔티티 검증 | ⚠️ 뮤테이션 메서드 amount <= 0 가드 없음 → **#145** |
+
+**기존 미해결**: #74 (불필요한 SELECT FOR UPDATE)
+**신규 TODO**: #145 (엔티티 검증), #146 (UNIQUE 제약), #148 (부분 회수 모니터링)
+
+---
+
+## ~~Phase 4 — 상품·카탈로그 (P2~P3)~~ ✅ 리뷰 완료
+
+> Product·Category·ProductImage·Review·Wishlist 리뷰 완료.
+> 발견된 항목은 `docs/TODO.md` #149~#158에 반영됨.
+> 기존 항목 #53, #104는 리뷰에서 재확인됨.
+
+### 4-1. Product 핵심 — 리뷰 결과
+
+| 체크항목 | 결과 |
+|---------|------|
+| ES 검색 정확성 | ✅ multi_match, 가격 범위, 카테고리 필터 정상 |
+| MySQL fallback | ⚠️ ES/MySQL 응답 불일치 (#53 재확인) + sort만으로 ES 진입 → **#155** |
+| ES 동기화 타이밍 | ✅ `@TransactionalEventListener(AFTER_COMMIT)` 올바름 |
+| ES 검색 결과 응답 | ⚠️ 재고·리뷰 통계 null → MySQL 조회와 불일치 → **#149** |
+| DTO 검증 | ⚠️ description @Size 누락 → **#158** |
+
+### 4-2. Category — 리뷰 결과
+
+| 체크항목 | 결과 |
+|---------|------|
+| 카테고리 캐시 | ⚠️ `getById()` @Cacheable 누락 → **#150** |
+| 트리 조회 | ✅ in-memory 조립 O(n), parent LEFT JOIN FETCH N+1 방지 |
+| 삭제 제약 | ✅ CATEGORY_HAS_CHILDREN / PRODUCTS 검증 정상 |
+| 순환 참조 | ✅ 2단계 고정 구조이므로 직접 순환 방지만으로 충분 |
+
+### 4-3. ProductImage — 리뷰 결과
+
+| 체크항목 | 결과 |
+|---------|------|
+| MIME/확장자 검증 | ⚠️ contentType 형식 미검증 + 확장자-MIME 불일치 허용 → **#151** |
+| 이미지 개수 제한 | ⚠️ 상품당 무제한 → **#152** |
+| objectKey 보안 | ⚠️ 클라이언트 조작 가능 → **#153** |
+| S3 삭제 정합성 | ⚠️ 삭제 실패 시 DB 불일치 → **#156** |
+
+### 4-4. Review + Wishlist — 리뷰 결과
+
+| 체크항목 | 결과 |
+|---------|------|
+| 리뷰 구매 검증 | ✅ `orderRepository.existsConfirmedOrder()` 정상 |
+| 리뷰 중복 방지 | ✅ `existsByProductIdAndUserId()` 정상 |
+| content 검증 | ⚠️ @Size 누락 → **#154** |
+| 탈퇴 사용자 | ⚠️ username null 노출 → **#157** |
+| 위시리스트 N+1 | ✅ `findAllById()` + `findAllByProductIdIn()` 배치 조회 |
+
+**신규 TODO**: #149~#158 (10개)
+**기존 미해결**: #53 (ES fallback 불일치)
+
+---
+
+## ~~Phase 5 — 공통 인프라 (P1~P3)~~ ✅ 리뷰 완료
+
+> Outbox·예외처리·캐시/Redis·Rate Limit 4개 영역 리뷰 완료.
+> 발견된 항목은 `docs/TODO.md` #159~#161에 반영됨.
+> 기존 항목 #47, #83, #95, #101, #136, #137은 리뷰에서 재확인됨. #138은 완료 처리됨.
+
+### 5-1. Outbox 이벤트 — 리뷰 결과
+
+| 체크항목 | 결과 |
+|---------|------|
+| relay 분산 락 | ✅ `@DistributedLock(skipOnFailure=true)` 중복 relay 방지 정상 |
+| dead letter 알람 | ✅ Prometheus Gauge `outbox.dead_letters` 정상 노출 |
+| 지수 백오프 | ✅ `min(30 × 2^retryCount, 3600)` 연산 정확 |
+| Propagation.MANDATORY | ✅ 비즈니스 TX 바깥 호출 시 즉시 예외 |
+| processOne 멱등성 | ✅ `publishedAt != null` 체크로 이중 발행 방지 |
+| relayedCounter 정확성 | ⚠️ 실패 이벤트도 카운팅 → **#161** |
+
+**기존 미해결**: #101 (purge 대량 삭제 배치 전환)
+
+### 5-2. 예외 처리 / API 응답 — 리뷰 결과
+
+| 체크항목 | 결과 |
+|---------|------|
+| BusinessException | ✅ ErrorCode 기반 HTTP 상태 매핑 정확 |
+| MethodArgumentNotValid | ✅ 필드별 FieldErrorDetail 반환 |
+| IllegalArgumentException | ✅ 400 Bad Request |
+| DataIntegrityViolation | ✅ 409 Conflict, DB 구조 미노출 |
+| OptimisticLocking | ✅ 409 Conflict, 재시도 안내 |
+| NoResourceFound | ✅ 404 |
+| HttpMessageNotReadable | ✅ `@ExceptionHandler` 추가, 400 응답 (#95 해결) |
+| ErrorCode 체계 | ✅ 도메인별 그룹화, HTTP 상태 매핑 적절 |
+
+### 5-3. 캐시 / Redis — 리뷰 결과
+
+| 체크항목 | 결과 |
+|---------|------|
+| 직렬화 화이트리스트 | ✅ `allowIfBaseType` → `allowIfSubType` 전환 완료 (#57 해결) |
+| TTL 정책 | ✅ products 10분, inventory/orders 5분, categories 30분 적절 |
+| null 캐싱 | ✅ `disableCachingNullValues()` 적용 |
+| Redisson 연결 설정 | ✅ timeout(1000)/connectTimeout(1000)/retryAttempts(1)/poolSize(32) 완료 (#58 해결) |
+| RefreshTokenStore | ✅ revokeAll Lua 원자화 (#137 해결), consume() 탈취 감지 (#136 해결) |
+
+### 5-4. Rate Limit — 리뷰 결과
+
+| 체크항목 | 결과 |
+|---------|------|
+| Lua 원자성 | ✅ INCR + EXPIRE 원자적 처리 정상 |
+| trust-proxy 설정 | ✅ false 시 헤더 무시, true 시 X-Real-IP 우선 |
+| LoginRateLimiter | ✅ username+IP 복합 키로 Account Lockout DoS 방지 (#83 해결) |
+| X-Forwarded-For IP | ✅ `trusted-proxy-count=1` 적용, 클라이언트 IP 올바르게 추출 (#47 해결) |
+| /api/auth/refresh | ✅ Rate Limit 적용 완료 (#138 완료) |
+
+---
+
+## ~~Phase 6 — DB·인프라·코드 품질 (P2~P3)~~ ✅ 리뷰 완료
+
+> Flyway·Admin·크로스커팅 3개 영역 리뷰 완료.
+> 발견된 항목은 `docs/TODO.md` #162~#163에 반영됨.
+> 기존 항목 #41, #59, #62, #107, #43, #104, #25, #13, #103, #128은 리뷰에서 재확인됨.
+
+### 6-1. Flyway 마이그레이션 — 리뷰 결과
+
+| 체크항목 | 결과 |
+|---------|------|
+| DECIMAL precision | ✅ V40에서 `DECIMAL(15,2)` 통일 완료 (#41 해결) |
+| SSL/자격증명 | ✅ useSSL=false 주석 추가 (#59), DB 자격증명 환경변수 전환 (#62 해결) |
+| ENGINE/CHARSET 일관성 | ✅ V4/V9~V13/V15/V17/V22에 ENGINE/CHARSET 명시 완료 (#63 해결) |
+| 인덱스 전략 | ✅ V23/V25/V27/V31 복합 인덱스 적절. orders.created_at, point_transactions 커버링 인덱스 추가됨 |
+| FK 제약 | ✅ V32에서 누락 FK 일괄 추가 완료 |
+| 타임스탬프 기본값 | ✅ V33에서 일괄 수정 완료 |
+
+### 6-2. Admin 도메인 — 리뷰 결과
+
+| 체크항목 | 결과 |
+|---------|------|
+| 마지막 ADMIN 보호 | ❌ `updateRole()`에 ADMIN 수 체크 없음 (#107 재확인) |
+| 대시보드 성능 | ✅ `findOrderStats()` GROUP BY 단일 쿼리 + `userRepository.count()` — 현재 규모 적정 |
+| 주문 목록 사용자명 | ✅ `findAllById()` 배치 IN 쿼리 — 심각도 낮음 |
+| 검색 LIKE | ✅ `ProductService`/`AdminService.escapeLike()` 유틸리티 추출 완료 (#60 해결) |
+| RoleUpdateRequest | ✅ `@NotNull UserRole role` 검증 정상 |
+
+### 6-3. 크로스커팅 코드 품질 — 리뷰 결과
+
+| 체크항목 | 결과 |
+|---------|------|
+| resolveUserId | ⚠️ 10개+ 컨트롤러로 확산 (#104 재확인, 기존 6개→10개+) |
+| Pageable 기본값 | ✅ 전 컨트롤러 `size=20, sort=createdAt, DESC` 일관적 |
+| API 버전 관리 | ⚠️ `/api/v1/` 미도입 (#25 재확인) |
+| 페이지네이션 | ⚠️ 오프셋 기반 (#13), size 상한 미검증 (#103) 재확인 |
+
+**해결**: #60 (LIKE escape ProductService/AdminService), #61 (Flyway ENGINE/CHARSET), #62 (DB 자격증명), #41 (V40 DECIMAL 통일)
+**기존 미해결**: #107, #43, #104, #25, #13, #103, #128
+
+---
+
+## 리뷰 진행 요약
+
+| Phase | 범위 | 도메인 | 상태 |
+|-------|------|--------|------|
+| ~~**1**~~ | ~~핵심 트랜잭션~~ | ~~Payment, Order, Inventory~~ | ✅ 완료 → TODO #113~#133 |
+| ~~**2**~~ | ~~보안·인증~~ | ~~Security, User~~ | ✅ 완료 → TODO #134~#143 |
+| ~~**3**~~ | ~~부가 도메인~~ | ~~Coupon, Refund, Shipment, Point~~ | ✅ 완료 → TODO #144~#148 |
+| ~~**4**~~ | ~~상품·카탈로그~~ | ~~Product (+ category/image/review/wishlist)~~ | ✅ 완료 → TODO #149~#158 |
+| ~~**5**~~ | ~~공통 인프라~~ | ~~Outbox, Exception, Cache, RateLimit~~ | ✅ 완료 → TODO #159~#161 |
+| ~~**6**~~ | ~~DB·코드 품질~~ | ~~Flyway, Admin, 크로스커팅~~ | ✅ 완료 → TODO #162~#163 |
+
+---
+
+## 전체 리뷰 통계
+
+| 구분 | 수 |
+|------|---|
+| Phase 1~6 총 신규 발견 | **51개** (#113~#163) |
+| P0 (금전 손실·보안) | 5개 (#113, #115, #116, #117, #114) |
+| P1 (데이터 정합성·운영) | 22개 |
+| P2 (성능·코드 품질) | 16개 |
+| P3 (유지보수·확장성) | 8개 |
+| 보류 (판단 필요) | 6개 |
+| 조치 불필요 | 4개 |


### PR DESCRIPTION
## Summary

- **TODO.md**: 완료 항목 16개 제거(#42/#79/#95/#96/#105/#129/#151~#156/#159~#163), Flyway V1~V42 반영, 아키텍처 요약 갱신
- **IMPROVEMENTS.md**: 16·17차 개선 항목 추가(#28/#45/#46/#47/#50/#52~#54/#57~#62/#78/#83/#135~#137), 테스트 수 637→647개 반영
- **README.md**: 테스트 605→647개, Flyway V28→V42 마이그레이션 표 추가, 재고 API ADMIN 전용, 미인증 403→401, refunds UNIQUE 제거 ERD 반영
- **reviewPlan.md**: Phase 5–6 해결 항목 ✅ 표시(#47/#57~#62/#83/#95/#136/#137)

## Test plan
- [ ] 문서 내용이 코드 현황과 일치하는지 확인
- [ ] Flyway 마이그레이션 표(V1~V42) 순서 검토
- [ ] 테스트 수 647개 정확성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)