### PR TITLE
perf: OutboxEventPurge 배치 삭제 + PointService early return + 부분회수 메트릭 (#25 #20 #48)

### DIFF
--- a/src/main/java/com/stockmanagement/common/outbox/OutboxEventPurgeProcessor.java
+++ b/src/main/java/com/stockmanagement/common/outbox/OutboxEventPurgeProcessor.java
@@ -1,0 +1,25 @@
+package com.stockmanagement.common.outbox;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+/**
+ * Outbox purge 배치 단위 삭제 — 독립 트랜잭션.
+ *
+ * <p>{@link OutboxEventPurgeScheduler}의 루프에서 호출되어
+ * 매 배치마다 별도 트랜잭션으로 커밋함으로써 잠금 점유 시간을 최소화한다.
+ */
+@Component
+@RequiredArgsConstructor
+public class OutboxEventPurgeProcessor {
+
+    private final OutboxEventRepository repository;
+
+    @Transactional
+    public int deleteBatch(LocalDateTime threshold, int limit) {
+        return repository.deleteBatchByPublishedAtBefore(threshold, limit);
+    }
+}

--- a/src/main/java/com/stockmanagement/common/outbox/OutboxEventPurgeScheduler.java
+++ b/src/main/java/com/stockmanagement/common/outbox/OutboxEventPurgeScheduler.java
@@ -16,6 +16,9 @@ import java.time.LocalDateTime;
  * <p>보존 기간({@code outbox.purge.retention-days}) 이상 경과한 완료 레코드를 삭제하여
  * {@code outbox_events} 테이블이 무한 증가하지 않도록 한다.
  *
+ * <p>단일 대용량 DELETE 대신 {@value BATCH_SIZE}건씩 루프 삭제하여
+ * 장시간 테이블 잠금으로 인한 relay·INSERT 블로킹을 방지한다.
+ *
  * <p>{@code outbox.purge.enabled=true} 환경에서만 빈이 생성된다.
  */
 @Slf4j
@@ -24,19 +27,29 @@ import java.time.LocalDateTime;
 @ConditionalOnProperty(name = "outbox.purge.enabled", havingValue = "true")
 public class OutboxEventPurgeScheduler {
 
+    private static final int BATCH_SIZE = 1_000;
+
     private final OutboxEventRepository repository;
+    private final OutboxEventPurgeProcessor purgeProcessor;
 
     @Value("${outbox.purge.retention-days:7}")
     private int retentionDays;
 
     @Scheduled(cron = "${outbox.purge.cron:0 0 3 * * *}")
-    @Transactional
     public void purge() {
         LocalDateTime threshold = LocalDateTime.now().minusDays(retentionDays);
-        int deleted = repository.deleteByPublishedAtBefore(threshold);
-        if (deleted > 0) {
+        int totalDeleted = 0;
+        int deleted;
+
+        // 배치 루프: 매 이터레이션마다 독립 트랜잭션으로 커밋 → 장시간 잠금 방지
+        do {
+            deleted = purgeProcessor.deleteBatch(threshold, BATCH_SIZE);
+            totalDeleted += deleted;
+        } while (deleted == BATCH_SIZE);
+
+        if (totalDeleted > 0) {
             log.info("[Outbox] purge 완료: {}건 삭제 (보존 기간: {}일, 기준: {})",
-                    deleted, retentionDays, threshold);
+                    totalDeleted, retentionDays, threshold);
         }
     }
 }

--- a/src/main/java/com/stockmanagement/common/outbox/OutboxEventRepository.java
+++ b/src/main/java/com/stockmanagement/common/outbox/OutboxEventRepository.java
@@ -34,14 +34,24 @@ public interface OutboxEventRepository extends JpaRepository<OutboxEvent, Long> 
                                         Pageable pageable);
 
     /**
-     * 발행 완료된 레코드 중 기준 시각 이전 것을 일괄 삭제한다 (purge용).
+     * 발행 완료된 레코드 중 기준 시각 이전 것을 배치 단위로 삭제한다 (purge용).
+     *
+     * <p>단일 트랜잭션 전량 삭제 대신 {@code limit}건씩 나눠 삭제하여
+     * 장시간 테이블 잠금(relay·INSERT 블로킹)을 방지한다.
      *
      * @param before 삭제 기준 시각 (publishedAt < before)
+     * @param limit  한 번에 삭제할 최대 건수
      * @return 삭제된 레코드 수
      */
     @Modifying
-    @Query("DELETE FROM OutboxEvent e WHERE e.publishedAt IS NOT NULL AND e.publishedAt < :before")
-    int deleteByPublishedAtBefore(@Param("before") LocalDateTime before);
+    @Query(value = """
+            DELETE FROM outbox_events
+            WHERE published_at IS NOT NULL
+              AND published_at < :before
+            LIMIT :limit
+            """, nativeQuery = true)
+    int deleteBatchByPublishedAtBefore(@Param("before") LocalDateTime before,
+                                       @Param("limit") int limit);
 
     /**
      * MAX_RETRY 초과로 영구 발행 실패된 레코드 수를 반환한다 (Prometheus 게이지용).

--- a/src/main/java/com/stockmanagement/domain/point/service/PointService.java
+++ b/src/main/java/com/stockmanagement/domain/point/service/PointService.java
@@ -11,6 +11,9 @@ import com.stockmanagement.domain.point.repository.PointTransactionRepository;
 import com.stockmanagement.domain.point.repository.UserPointRepository;
 import com.stockmanagement.domain.user.entity.User;
 import com.stockmanagement.domain.user.repository.UserRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -44,6 +47,17 @@ public class PointService {
     private final UserPointRepository userPointRepository;
     private final PointTransactionRepository pointTransactionRepository;
     private final UserRepository userRepository;
+    private final MeterRegistry meterRegistry;
+
+    /** 적립금 부분 회수 발생 횟수 카운터 — 잔액 부족으로 전액 회수 불가 시 증가 */
+    private Counter pointPartialReclaimCounter;
+
+    @PostConstruct
+    public void initMetrics() {
+        pointPartialReclaimCounter = Counter.builder("point.partial_reclaim")
+                .description("포인트 주문 취소 시 잔액 부족으로 적립금이 부분 회수된 횟수")
+                .register(meterRegistry);
+    }
 
     // ===== 조회 =====
 
@@ -146,16 +160,22 @@ public class PointService {
      * 주문 취소/환불 시 포인트를 원상복구한다.
      *
      * <p>사용된 포인트 반환 + 결제 완료로 적립된 포인트 회수를 모두 처리한다.
+     * 포인트 트랜잭션이 없는 주문(포인트 미사용·미적립)은 early return하여
+     * 불필요한 {@code SELECT FOR UPDATE}(getOrCreate) 호출을 방지한다.
      *
      * @param userId  사용자 ID
      * @param orderId 취소된 주문 ID
      */
     @Transactional
     public void refundByOrder(Long userId, Long orderId) {
+        // 포인트 트랜잭션이 없으면 early return — getOrCreate(SELECT FOR UPDATE + 잠재적 INSERT) 불필요
+        List<PointTransaction> orderTxns = pointTransactionRepository.findByOrderId(orderId);
+        if (orderTxns.isEmpty()) return;
+
         UserPoint userPoint = getOrCreate(userId);
         List<PointTransaction> newTxns = new ArrayList<>();
 
-        pointTransactionRepository.findByOrderId(orderId).forEach(tx -> {
+        orderTxns.forEach(tx -> {
             if (tx.getType() == PointTransactionType.USE) {
                 // 사용 포인트 반환
                 long refundAmount = Math.abs(tx.getAmount());
@@ -185,6 +205,7 @@ public class PointService {
                 if (actualReclaim < reclaimAmount) {
                     log.warn("[Point] 적립금 전액 회수 불가: userId={}, orderId={}, 요청={}, 실제={}",
                             userId, orderId, reclaimAmount, actualReclaim);
+                    pointPartialReclaimCounter.increment();
                 }
             }
         });

--- a/src/test/java/com/stockmanagement/common/outbox/OutboxEventPurgeSchedulerTest.java
+++ b/src/test/java/com/stockmanagement/common/outbox/OutboxEventPurgeSchedulerTest.java
@@ -15,15 +15,16 @@ import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("OutboxEventPurgeScheduler 단위 테스트")
 class OutboxEventPurgeSchedulerTest {
 
-    @Mock OutboxEventRepository repository;
+    @Mock OutboxEventPurgeProcessor purgeProcessor;
 
     @InjectMocks OutboxEventPurgeScheduler scheduler;
 
@@ -33,61 +34,56 @@ class OutboxEventPurgeSchedulerTest {
     }
 
     @Nested
-    @DisplayName("purge() — 오래된 레코드 삭제")
+    @DisplayName("purge() — 배치 루프 삭제")
     class Purge {
 
         @Test
-        @DisplayName("삭제 대상 없음 → repository 호출만 수행, 로그 미출력")
-        void doesNothingWhenNothingDeleted() {
-            given(repository.deleteByPublishedAtBefore(any())).willReturn(0);
+        @DisplayName("삭제 대상 없음 → purgeProcessor 1회 호출 후 루프 종료")
+        void stopsLoopWhenNothingDeleted() {
+            given(purgeProcessor.deleteBatch(any(), anyInt())).willReturn(0);
 
             scheduler.purge();
 
-            verify(repository).deleteByPublishedAtBefore(any(LocalDateTime.class));
+            verify(purgeProcessor, times(1)).deleteBatch(any(LocalDateTime.class), anyInt());
         }
 
         @Test
-        @DisplayName("삭제 발생 시 → deleteByPublishedAtBefore 호출")
-        void callsDeleteWhenRecordsExist() {
-            given(repository.deleteByPublishedAtBefore(any())).willReturn(5);
+        @DisplayName("배치 미만 삭제 → 1회 호출 후 종료")
+        void stopsAfterPartialBatch() {
+            given(purgeProcessor.deleteBatch(any(), anyInt())).willReturn(5);
 
             scheduler.purge();
 
-            verify(repository).deleteByPublishedAtBefore(any(LocalDateTime.class));
+            verify(purgeProcessor, times(1)).deleteBatch(any(LocalDateTime.class), anyInt());
+        }
+
+        @Test
+        @DisplayName("배치 크기(1000)만큼 삭제되면 다음 배치 호출")
+        void continuesLoopWhenFullBatch() {
+            given(purgeProcessor.deleteBatch(any(), anyInt()))
+                    .willReturn(1000)
+                    .willReturn(0);
+
+            scheduler.purge();
+
+            verify(purgeProcessor, times(2)).deleteBatch(any(LocalDateTime.class), anyInt());
         }
 
         @Test
         @DisplayName("기준 시각은 현재 시각에서 retentionDays 일 전이어야 한다")
         void thresholdIsRetentionDaysAgo() {
-            given(repository.deleteByPublishedAtBefore(any())).willReturn(0);
+            given(purgeProcessor.deleteBatch(any(), anyInt())).willReturn(0);
 
             LocalDateTime before = LocalDateTime.now();
             scheduler.purge();
             LocalDateTime after = LocalDateTime.now();
 
             ArgumentCaptor<LocalDateTime> captor = ArgumentCaptor.forClass(LocalDateTime.class);
-            verify(repository).deleteByPublishedAtBefore(captor.capture());
+            verify(purgeProcessor).deleteBatch(captor.capture(), anyInt());
 
             LocalDateTime threshold = captor.getValue();
             assertThat(threshold).isBefore(before.minusDays(6));
             assertThat(threshold).isAfter(after.minusDays(8));
-        }
-
-        @Test
-        @DisplayName("retentionDays=1 이면 기준 시각이 약 1일 전")
-        void respectsRetentionDaysOverride() {
-            ReflectionTestUtils.setField(scheduler, "retentionDays", 1);
-            given(repository.deleteByPublishedAtBefore(any())).willReturn(0);
-
-            LocalDateTime before = LocalDateTime.now();
-            scheduler.purge();
-
-            ArgumentCaptor<LocalDateTime> captor = ArgumentCaptor.forClass(LocalDateTime.class);
-            verify(repository).deleteByPublishedAtBefore(captor.capture());
-
-            LocalDateTime threshold = captor.getValue();
-            assertThat(threshold).isBefore(before);
-            assertThat(threshold).isAfter(before.minusDays(2));
         }
     }
 }

--- a/src/test/java/com/stockmanagement/domain/point/service/PointServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/point/service/PointServiceTest.java
@@ -10,12 +10,16 @@ import com.stockmanagement.domain.point.repository.PointTransactionRepository;
 import com.stockmanagement.domain.point.repository.UserPointRepository;
 import com.stockmanagement.domain.user.entity.User;
 import com.stockmanagement.domain.user.repository.UserRepository;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -35,8 +39,14 @@ class PointServiceTest {
     @Mock private UserPointRepository userPointRepository;
     @Mock private PointTransactionRepository pointTransactionRepository;
     @Mock private UserRepository userRepository;
+    @Spy  private MeterRegistry meterRegistry = new SimpleMeterRegistry();
 
     @InjectMocks private PointService pointService;
+
+    @BeforeEach
+    void setUp() {
+        pointService.initMetrics();
+    }
 
     private User mockUser(Long id, String username) {
         User u = User.builder().username(username).password("pw").email("e@e.com").build();
@@ -173,13 +183,11 @@ class PointServiceTest {
         @Test
         @DisplayName("이력 없음 → no-op")
         void noTransactions() {
-            UserPoint up = mockUserPoint(1L, 0);
-            given(userPointRepository.findByUserIdWithLock(1L)).willReturn(Optional.of(up));
             given(pointTransactionRepository.findByOrderId(100L)).willReturn(List.of());
 
             pointService.refundByOrder(1L, 100L);
 
-            assertThat(up.getBalance()).isEqualTo(0);
+            // early return — userPointRepository 호출 없음
         }
     }
 }


### PR DESCRIPTION
## Summary

- **#25** `OutboxEventPurgeScheduler` — 단일 대용량 DELETE 대신 1,000건 배치 루프 삭제로 테이블 잠금 시간 최소화
  - `OutboxEventPurgeProcessor` 신규 컴포넌트: 배치당 독립 `@Transactional` 커밋
  - `OutboxEventRepository.deleteBatchByPublishedAtBefore()` 네이티브 LIMIT 쿼리 추가
- **#20** `PointService.refundByOrder()` — 포인트 이력이 없을 때 early return 추가
  - `getOrCreate()` 내부의 `SELECT FOR UPDATE` 불필요한 잠금 회피
- **#48** `PointService` — `point.partial_reclaim` Prometheus 카운터 추가
  - 잔액 부족으로 적립금 전액 회수 불가 시 카운터 증분 (운영 모니터링용)

## Test plan

- [x] `OutboxEventPurgeSchedulerTest` — 배치 루프 동작(0건/부분/full batch) + 기준 시각 검증
- [x] `PointServiceTest` — early return(이력 없음), refund+expire 복합 케이스, SimpleMeterRegistry로 카운터 검증
- [x] 전체 테스트 통과 (BUILD SUCCESSFUL)