### PR TITLE
perf: InventorySnapshot Slice 전환 + DailyOrderStats 단일 GROUP BY 쿼리 (#17 #16)

### DIFF
--- a/src/main/java/com/stockmanagement/domain/inventory/repository/InventoryRepository.java
+++ b/src/main/java/com/stockmanagement/domain/inventory/repository/InventoryRepository.java
@@ -4,6 +4,7 @@ import com.stockmanagement.domain.inventory.entity.Inventory;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -57,4 +58,13 @@ public interface InventoryRepository extends JpaRepository<Inventory, Long>, Jpa
     @EntityGraph(attributePaths = {"product"})
     @Override
     Page<Inventory> findAll(Specification<Inventory> spec, Pageable pageable);
+
+    /**
+     * 스냅샷 배치용 전체 재고 Slice 조회 — COUNT 쿼리 없이 LIMIT만 실행한다.
+     *
+     * <p>{@code Page}의 매 페이지마다 발생하는 {@code SELECT COUNT(*)} 오버헤드를 제거한다.
+     * 다음 페이지 존재 여부({@code hasNext})만 확인하면 되므로 Slice로 충분하다.
+     */
+    @Query("SELECT i FROM Inventory i")
+    Slice<Inventory> findAllAsSlice(Pageable pageable);
 }

--- a/src/main/java/com/stockmanagement/domain/inventory/scheduler/InventorySnapshotScheduler.java
+++ b/src/main/java/com/stockmanagement/domain/inventory/scheduler/InventorySnapshotScheduler.java
@@ -7,8 +7,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -44,19 +44,16 @@ public class InventorySnapshotScheduler {
 
         int pageNum = 0;
         int totalSaved = 0;
-        long totalElements = 0;
+
+        log.info("[InventorySnapshotScheduler] 재고 스냅샷 시작 — 기준일: {}", today);
 
         while (true) {
-            Page<Inventory> inventoryPage = inventoryRepository.findAll(PageRequest.of(pageNum, PAGE_SIZE));
-            if (inventoryPage.isEmpty()) break;
-
-            if (pageNum == 0) {
-                totalElements = inventoryPage.getTotalElements();
-                log.info("[InventorySnapshotScheduler] 재고 스냅샷 시작 — 전체: {}건, 기준일: {}", totalElements, today);
-            }
+            // Slice: COUNT 쿼리 없이 LIMIT만 실행하여 매 페이지 SELECT COUNT(*) 오버헤드 제거
+            Slice<Inventory> inventorySlice = inventoryRepository.findAllAsSlice(PageRequest.of(pageNum, PAGE_SIZE));
+            if (inventorySlice.isEmpty()) break;
 
             try {
-                totalSaved += snapshotProcessor.processBatch(inventoryPage.getContent(), alreadySnapped, today);
+                totalSaved += snapshotProcessor.processBatch(inventorySlice.getContent(), alreadySnapped, today);
             } catch (DataIntegrityViolationException e) {
                 // 레이스 컨디션: alreadySnapped 조회 후 INSERT 사이에 다른 인스턴스가 먼저 저장한 경우
                 log.debug("[InventorySnapshotScheduler] 중복 스냅샷 감지 (동시 실행 경합) — date={}, page={}", today, pageNum);
@@ -65,11 +62,10 @@ public class InventorySnapshotScheduler {
                 throw new RuntimeException("재고 스냅샷 저장 실패: " + today, e);
             }
 
-            if (inventoryPage.isLast()) break;
+            if (!inventorySlice.hasNext()) break;
             pageNum++;
         }
 
-        log.info("[InventorySnapshotScheduler] 완료 — 저장: {}건 / 스킵: {}건",
-                totalSaved, totalElements - totalSaved);
+        log.info("[InventorySnapshotScheduler] 완료 — 저장: {}건", totalSaved);
     }
 }

--- a/src/main/java/com/stockmanagement/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/stockmanagement/domain/order/repository/OrderRepository.java
@@ -173,4 +173,19 @@ public interface OrderRepository extends JpaRepository<Order, Long>, JpaSpecific
            "AND o.createdAt >= :start AND o.createdAt < :end")
     BigDecimal sumRevenueByCreatedAtBetween(@Param("start") LocalDateTime start,
                                             @Param("end") LocalDateTime end);
+
+    /**
+     * 기간 내 주문을 상태별로 GROUP BY하여 건수·금액을 단일 쿼리로 집계한다 (일별 통계 최적화).
+     *
+     * <p>기존 4개 개별 쿼리(count×3 + sum×1)를 1개로 대체한다.
+     * 결과를 status 키로 매핑하면 CONFIRMED/CANCELLED 건수와 매출액을 한 번에 얻을 수 있다.
+     */
+    @Query("SELECT o.status AS status, COUNT(o) AS orderCount, " +
+           "COALESCE(SUM(CASE WHEN o.status = com.stockmanagement.domain.order.entity.OrderStatus.CONFIRMED " +
+           "THEN o.totalAmount - o.discountAmount - o.usedPoints ELSE 0 END), 0) AS totalAmount " +
+           "FROM Order o " +
+           "WHERE o.createdAt >= :start AND o.createdAt < :end " +
+           "GROUP BY o.status")
+    List<OrderStatsProjection> findOrderStatsBetween(@Param("start") LocalDateTime start,
+                                                     @Param("end") LocalDateTime end);
 }

--- a/src/main/java/com/stockmanagement/domain/order/scheduler/DailyOrderStatsScheduler.java
+++ b/src/main/java/com/stockmanagement/domain/order/scheduler/DailyOrderStatsScheduler.java
@@ -4,6 +4,7 @@ import com.stockmanagement.domain.order.entity.DailyOrderStats;
 import com.stockmanagement.domain.order.entity.OrderStatus;
 import com.stockmanagement.domain.order.repository.DailyOrderStatsRepository;
 import com.stockmanagement.domain.order.repository.OrderRepository;
+import com.stockmanagement.domain.order.repository.OrderStatsProjection;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -14,12 +15,17 @@ import org.springframework.transaction.annotation.Transactional;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * 일별 주문·매출 통계 스케줄러.
  *
  * <p>매일 자정 1분에 전일 주문을 집계하여 {@code daily_order_stats}에 저장한다.
  * 동일 날짜 레코드가 이미 존재하면 update하여 멱등성을 보장한다.
+ *
+ * <p>기존 4개 개별 쿼리(count×3 + sum×1) → {@code findOrderStatsBetween()} 단일 GROUP BY 쿼리로 대체.
  */
 @Slf4j
 @Component
@@ -40,12 +46,18 @@ public class DailyOrderStatsScheduler {
         log.info("[DailyOrderStatsScheduler] 일별 통계 집계 시작 — 기준일: {}", yesterday);
 
         try {
-            int totalOrders     = (int) orderRepository.countByCreatedAtBetween(start, end);
-            int confirmedOrders = (int) orderRepository.countByStatusAndCreatedAtBetween(
-                    OrderStatus.CONFIRMED, start, end);
-            int cancelledOrders = (int) orderRepository.countByStatusAndCreatedAtBetween(
-                    OrderStatus.CANCELLED, start, end);
-            BigDecimal totalRevenue = orderRepository.sumRevenueByCreatedAtBetween(start, end);
+            // 단일 GROUP BY 쿼리로 상태별 건수·매출액을 한 번에 조회 (기존 4개 쿼리 대체)
+            List<OrderStatsProjection> statsList = orderRepository.findOrderStatsBetween(start, end);
+            Map<OrderStatus, OrderStatsProjection> statsMap = statsList.stream()
+                    .collect(Collectors.toMap(OrderStatsProjection::getStatus, s -> s));
+
+            int totalOrders     = statsList.stream().mapToInt(s -> (int) s.getOrderCount()).sum();
+            int confirmedOrders = statsMap.containsKey(OrderStatus.CONFIRMED)
+                    ? (int) statsMap.get(OrderStatus.CONFIRMED).getOrderCount() : 0;
+            int cancelledOrders = statsMap.containsKey(OrderStatus.CANCELLED)
+                    ? (int) statsMap.get(OrderStatus.CANCELLED).getOrderCount() : 0;
+            BigDecimal totalRevenue = statsMap.containsKey(OrderStatus.CONFIRMED)
+                    ? statsMap.get(OrderStatus.CONFIRMED).getTotalAmount() : BigDecimal.ZERO;
 
             statsRepository.findByStatDate(yesterday)
                     .ifPresentOrElse(

--- a/src/test/java/com/stockmanagement/domain/inventory/scheduler/InventorySnapshotSchedulerTest.java
+++ b/src/test/java/com/stockmanagement/domain/inventory/scheduler/InventorySnapshotSchedulerTest.java
@@ -9,9 +9,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
@@ -35,8 +35,8 @@ class InventorySnapshotSchedulerTest {
     @DisplayName("스냅샷 미존재 시 processBatch() 호출")
     void savesSnapshotWhenNotExists() {
         Inventory inv = buildInventory(1L, 100, 10, 5);
-        Page<Inventory> page = new PageImpl<>(List.of(inv));
-        given(inventoryRepository.findAll(any(Pageable.class))).willReturn(page);
+        Slice<Inventory> slice = new SliceImpl<>(List.of(inv));
+        given(inventoryRepository.findAllAsSlice(any(Pageable.class))).willReturn(slice);
         given(snapshotRepository.findInventoryIdsBySnapshotDate(any(LocalDate.class)))
                 .willReturn(Set.of());
         given(snapshotProcessor.processBatch(anyList(), anySet(), any(LocalDate.class)))
@@ -51,8 +51,8 @@ class InventorySnapshotSchedulerTest {
     @DisplayName("스냅샷 이미 존재 시 alreadySnapped에 inventoryId 포함하여 processor에 전달")
     void passesAlreadySnappedToProcessor() {
         Inventory inv = buildInventory(1L, 100, 10, 5);
-        Page<Inventory> page = new PageImpl<>(List.of(inv));
-        given(inventoryRepository.findAll(any(Pageable.class))).willReturn(page);
+        Slice<Inventory> slice = new SliceImpl<>(List.of(inv));
+        given(inventoryRepository.findAllAsSlice(any(Pageable.class))).willReturn(slice);
         given(snapshotRepository.findInventoryIdsBySnapshotDate(any(LocalDate.class)))
                 .willReturn(Set.of(1L));
         given(snapshotProcessor.processBatch(anyList(), anySet(), any(LocalDate.class)))

--- a/src/test/java/com/stockmanagement/domain/order/scheduler/DailyOrderStatsSchedulerTest.java
+++ b/src/test/java/com/stockmanagement/domain/order/scheduler/DailyOrderStatsSchedulerTest.java
@@ -4,6 +4,7 @@ import com.stockmanagement.domain.order.entity.DailyOrderStats;
 import com.stockmanagement.domain.order.entity.OrderStatus;
 import com.stockmanagement.domain.order.repository.DailyOrderStatsRepository;
 import com.stockmanagement.domain.order.repository.OrderRepository;
+import com.stockmanagement.domain.order.repository.OrderStatsProjection;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,6 +16,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -33,7 +35,7 @@ class DailyOrderStatsSchedulerTest {
     @Test
     @DisplayName("전일 집계 후 레코드 미존재 시 신규 저장")
     void savesNewStatsWhenNotExists() {
-        stubOrderCounts(10, 6, 2, BigDecimal.valueOf(50000));
+        stubOrderStats(10, 6, 2, BigDecimal.valueOf(50000));
         given(statsRepository.findByStatDate(any(LocalDate.class))).willReturn(Optional.empty());
         given(statsRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
 
@@ -51,7 +53,7 @@ class DailyOrderStatsSchedulerTest {
     @Test
     @DisplayName("전일 집계 후 레코드 이미 존재 시 update")
     void updatesExistingStats() {
-        stubOrderCounts(5, 3, 1, BigDecimal.valueOf(30000));
+        stubOrderStats(5, 3, 1, BigDecimal.valueOf(30000));
         DailyOrderStats existing = buildStats(LocalDate.now().minusDays(1), 0, 0, 0, BigDecimal.ZERO);
         given(statsRepository.findByStatDate(any(LocalDate.class))).willReturn(Optional.of(existing));
 
@@ -65,13 +67,24 @@ class DailyOrderStatsSchedulerTest {
 
     // ===== 헬퍼 =====
 
-    private void stubOrderCounts(long total, long confirmed, long cancelled, BigDecimal revenue) {
-        given(orderRepository.countByCreatedAtBetween(any(), any())).willReturn(total);
-        given(orderRepository.countByStatusAndCreatedAtBetween(eq(OrderStatus.CONFIRMED), any(), any()))
-                .willReturn(confirmed);
-        given(orderRepository.countByStatusAndCreatedAtBetween(eq(OrderStatus.CANCELLED), any(), any()))
-                .willReturn(cancelled);
-        given(orderRepository.sumRevenueByCreatedAtBetween(any(), any())).willReturn(revenue);
+    /** findOrderStatsBetween() 단일 GROUP BY 쿼리 결과를 스텁한다. */
+    private void stubOrderStats(long total, long confirmed, long cancelled, BigDecimal revenue) {
+        // PENDING = total - confirmed - cancelled
+        long pending = total - confirmed - cancelled;
+        List<OrderStatsProjection> projections = List.of(
+                buildProjection(OrderStatus.PENDING, pending, BigDecimal.ZERO),
+                buildProjection(OrderStatus.CONFIRMED, confirmed, revenue),
+                buildProjection(OrderStatus.CANCELLED, cancelled, BigDecimal.ZERO)
+        );
+        given(orderRepository.findOrderStatsBetween(any(), any())).willReturn(projections);
+    }
+
+    private OrderStatsProjection buildProjection(OrderStatus status, long count, BigDecimal amount) {
+        return new OrderStatsProjection() {
+            @Override public OrderStatus getStatus() { return status; }
+            @Override public long getOrderCount() { return count; }
+            @Override public BigDecimal getTotalAmount() { return amount; }
+        };
     }
 
     private DailyOrderStats buildStats(LocalDate date, int total, int confirmed, int cancelled,


### PR DESCRIPTION
## Summary

- **#17** `InventorySnapshotScheduler` — `Page<Inventory>` → `Slice<Inventory>` 전환
  - COUNT 쿼리 제거로 페이지당 쿼리 1개 절감
  - `InventoryRepository.findAllAsSlice(Pageable)` 추가
- **#16** `DailyOrderStatsScheduler` — 4개 개별 쿼리 → 단일 `GROUP BY` 쿼리 통합
  - `OrderRepository.findOrderStatsBetween()` + `OrderStatsProjection` 인터페이스 추가
  - `Map<OrderStatus, OrderStatsProjection>`으로 상태별 통계 조회

## Test plan

- [x] `InventorySnapshotSchedulerTest` — `SliceImpl` 기반 페이지 루프 검증
- [x] `DailyOrderStatsSchedulerTest` — `OrderStatsProjection` stub으로 단일 쿼리 동작 검증
- [x] 전체 테스트 통과 (BUILD SUCCESSFUL)