### PR TITLE
perf/fix: CategoryService 캐시 + CouponService 감사로그 + OrderService 스칼라 프로젝션 + RefundService userId 전환 (#51 #45 #18 #19)

### DIFF
--- a/src/main/java/com/stockmanagement/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/stockmanagement/domain/coupon/service/CouponService.java
@@ -18,6 +18,7 @@ import com.stockmanagement.domain.coupon.repository.CouponRepository;
 import com.stockmanagement.domain.coupon.repository.CouponUsageRepository;
 import com.stockmanagement.domain.coupon.repository.UserCouponRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -38,6 +39,7 @@ import java.util.stream.Collectors;
  * <p>applyCoupon() — 쓰기, 비관적 락으로 usageCount 동시성 제어.
  * <p>releaseCoupon() — 주문 취소 시 usageCount 복원.
  */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -192,6 +194,7 @@ public class CouponService {
             throw new BusinessException(ErrorCode.COUPON_ALREADY_ISSUED);
         }
 
+        log.info("[Coupon] 등록: userId={}, couponCode={}, couponId={}", userId, request.getCouponCode(), coupon.getId());
         int usedCount = couponUsageRepository.countByCoupon_IdAndUserId(coupon.getId(), userId);
         return MyCouponResponse.from(userCoupon, isUsable(coupon, usedCount, LocalDateTime.now()));
     }
@@ -243,6 +246,7 @@ public class CouponService {
                 .discountAmount(discountAmount)
                 .build());
 
+        log.info("[Coupon] 적용: userId={}, couponCode={}, orderId={}, discountAmount={}", userId, couponCode, orderId, discountAmount);
         return buildValidateResponse(coupon, orderAmount, discountAmount);
     }
 
@@ -263,6 +267,7 @@ public class CouponService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.COUPON_NOT_FOUND));
         coupon.decreaseUsage();
         couponUsageRepository.delete(usage);
+        log.info("[Coupon] 반환: orderId={}, couponId={}", orderId, coupon.getId());
     }
 
     // ===== 내부 검증 헬퍼 =====

--- a/src/main/java/com/stockmanagement/domain/order/service/OrderService.java
+++ b/src/main/java/com/stockmanagement/domain/order/service/OrderService.java
@@ -329,9 +329,11 @@ public class OrderService {
      * <p>ADMIN은 모든 주문 이력에 접근 가능하고, USER는 본인 주문 이력만 조회할 수 있다.
      */
     public List<OrderStatusHistoryResponse> getHistory(Long orderId, Long userId, boolean isAdmin) {
-        Order order = orderRepository.findById(orderId)
+        Long orderUserId = orderRepository.findUserIdById(orderId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
-        validateOrderOwnership(order, userId, isAdmin);
+        if (!isAdmin && !orderUserId.equals(userId)) {
+            throw new BusinessException(ErrorCode.ORDER_ACCESS_DENIED);
+        }
         return historyRepository.findByOrderIdOrderByCreatedAtAsc(orderId)
                 .stream().map(OrderStatusHistoryResponse::from).toList();
     }

--- a/src/main/java/com/stockmanagement/domain/product/category/service/CategoryService.java
+++ b/src/main/java/com/stockmanagement/domain/product/category/service/CategoryService.java
@@ -90,6 +90,7 @@ public class CategoryService {
     }
 
     /** 단건 조회 — children(하위 카테고리) 목록 포함 */
+    @Cacheable(cacheNames = "categories", key = "'id:' + #id")
     public CategoryResponse getById(Long id) {
         Category category = findByIdWithChildren(id);
         Set<Long> ids = category.getChildren().stream()

--- a/src/main/java/com/stockmanagement/domain/refund/controller/RefundController.java
+++ b/src/main/java/com/stockmanagement/domain/refund/controller/RefundController.java
@@ -33,8 +33,9 @@ public class RefundController {
     @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<RefundResponse> requestRefund(
             @Valid @RequestBody RefundRequest request,
-            @AuthenticationPrincipal String username) {
-        return ApiResponse.ok(refundService.requestRefund(request, username));
+            @AuthenticationPrincipal String username,
+            Authentication authentication) {
+        return ApiResponse.ok(refundService.requestRefund(request, resolveUserId(authentication, username)));
     }
 
     @Operation(summary = "내 환불 목록", description = "현재 로그인 사용자의 환불 내역을 최신순으로 페이징 조회한다.")
@@ -53,7 +54,7 @@ public class RefundController {
             @AuthenticationPrincipal String username,
             Authentication authentication) {
         boolean isAdmin = SecurityUtils.isAdmin(authentication);
-        return ApiResponse.ok(refundService.getById(refundId, username, isAdmin));
+        return ApiResponse.ok(refundService.getById(refundId, resolveUserId(authentication, username), isAdmin));
     }
 
     @Operation(summary = "결제 ID로 환불 조회", description = "ADMIN은 모든 환불 조회 가능. USER는 본인 주문의 환불만 가능.")
@@ -63,7 +64,7 @@ public class RefundController {
             @AuthenticationPrincipal String username,
             Authentication authentication) {
         boolean isAdmin = SecurityUtils.isAdmin(authentication);
-        return ApiResponse.ok(refundService.getByPaymentId(paymentId, username, isAdmin));
+        return ApiResponse.ok(refundService.getByPaymentId(paymentId, resolveUserId(authentication, username), isAdmin));
     }
 
     /**

--- a/src/main/java/com/stockmanagement/domain/refund/service/RefundService.java
+++ b/src/main/java/com/stockmanagement/domain/refund/service/RefundService.java
@@ -2,7 +2,6 @@ package com.stockmanagement.domain.refund.service;
 
 import com.stockmanagement.common.exception.BusinessException;
 import com.stockmanagement.common.exception.ErrorCode;
-import com.stockmanagement.domain.order.entity.Order;
 import com.stockmanagement.domain.order.repository.OrderRepository;
 import com.stockmanagement.domain.payment.dto.PaymentCancelRequest;
 import com.stockmanagement.domain.payment.entity.Payment;
@@ -15,8 +14,6 @@ import com.stockmanagement.domain.refund.dto.RefundResponse;
 import com.stockmanagement.domain.refund.entity.Refund;
 import com.stockmanagement.domain.refund.entity.RefundStatus;
 import com.stockmanagement.domain.refund.repository.RefundRepository;
-import com.stockmanagement.domain.user.entity.User;
-import com.stockmanagement.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -41,7 +38,6 @@ public class RefundService {
     private final PaymentRepository paymentRepository;
     private final OrderRepository orderRepository;
     private final PaymentService paymentService;
-    private final UserRepository userRepository;
 
     /**
      * 환불을 요청한다.
@@ -60,17 +56,14 @@ public class RefundService {
      * Error 계열(OOM 등)은 여기서 잡히지 않으므로 여전히 롤백된다.
      */
     @Transactional(noRollbackFor = Exception.class)
-    public RefundResponse requestRefund(RefundRequest request, String username) {
-        User user = userRepository.findByUsername(username)
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
-
+    public RefundResponse requestRefund(RefundRequest request, Long userId) {
         Payment payment = paymentRepository.findById(request.getPaymentId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.PAYMENT_NOT_FOUND));
 
-        // 요청자가 해당 주문의 소유자인지 검증
-        Order paymentOrder = orderRepository.findById(payment.getOrderId())
+        // 요청자가 해당 주문의 소유자인지 검증 — 스칼라 프로젝션으로 전체 엔티티 로드 불필요
+        Long orderUserId = orderRepository.findUserIdById(payment.getOrderId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
-        if (!paymentOrder.getUserId().equals(user.getId())) {
+        if (!orderUserId.equals(userId)) {
             throw new BusinessException(ErrorCode.REFUND_ACCESS_DENIED);
         }
 
@@ -101,7 +94,7 @@ public class RefundService {
                         Refund newRefund = refundRepository.save(Refund.builder()
                                 .paymentId(payment.getId())
                                 .orderId(payment.getOrderId())
-                                .userId(user.getId())
+                                .userId(userId)
                                 .amount(payment.getAmount())
                                 .reason(request.getReason())
                                 .build());
@@ -117,7 +110,7 @@ public class RefundService {
         try {
             // 소유권은 이미 위에서 검증했으므로 userId 전달 (isAdmin=false)
             paymentService.cancel(payment.getPaymentKey(),
-                    PaymentCancelRequest.of(request.getReason()), user.getId(), false);
+                    PaymentCancelRequest.of(request.getReason()), userId, false);
             refund.complete();
             log.info("[Refund] 환불 완료: refundId={}, paymentId={}", refund.getId(), payment.getId());
         } catch (Exception e) {
@@ -130,12 +123,10 @@ public class RefundService {
     }
 
     /** 환불 ID로 단건 조회한다. 본인 또는 ADMIN만 가능. */
-    public RefundResponse getById(Long refundId, String username, boolean isAdmin) {
-        User user = userRepository.findByUsername(username)
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+    public RefundResponse getById(Long refundId, Long userId, boolean isAdmin) {
         Refund refund = refundRepository.findById(refundId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.REFUND_NOT_FOUND));
-        validateOwnership(refund, user, isAdmin);
+        validateOwnership(refund, userId, isAdmin);
         return RefundResponse.from(refund);
     }
 
@@ -146,12 +137,10 @@ public class RefundService {
     }
 
     /** 결제 ID로 환불 정보를 조회한다. 본인 또는 ADMIN만 가능. */
-    public RefundResponse getByPaymentId(Long paymentId, String username, boolean isAdmin) {
-        User user = userRepository.findByUsername(username)
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+    public RefundResponse getByPaymentId(Long paymentId, Long userId, boolean isAdmin) {
         Refund refund = refundRepository.findByPaymentId(paymentId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.REFUND_NOT_FOUND));
-        validateOwnership(refund, user, isAdmin);
+        validateOwnership(refund, userId, isAdmin);
         return RefundResponse.from(refund);
     }
 
@@ -161,9 +150,9 @@ public class RefundService {
      *
      * <p>Refund.userId(비정규화)를 사용하여 orders 테이블 추가 조회를 제거한다.
      */
-    private void validateOwnership(Refund refund, User user, boolean isAdmin) {
+    private void validateOwnership(Refund refund, Long userId, boolean isAdmin) {
         if (isAdmin) return;
-        if (!refund.getUserId().equals(user.getId())) {
+        if (!refund.getUserId().equals(userId)) {
             throw new BusinessException(ErrorCode.REFUND_ACCESS_DENIED);
         }
     }

--- a/src/test/java/com/stockmanagement/domain/refund/controller/RefundControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/refund/controller/RefundControllerTest.java
@@ -25,7 +25,7 @@ import java.util.List;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
@@ -60,7 +60,7 @@ class RefundControllerTest {
         @Test
         @DisplayName("인증된 사용자 — 환불 요청 → 201")
         void requestsRefund() throws Exception {
-            given(refundService.requestRefund(any(), anyString())).willReturn(mock(RefundResponse.class));
+            given(refundService.requestRefund(any(), anyLong())).willReturn(mock(RefundResponse.class));
 
             mockMvc.perform(post("/api/refunds")
                             .with(authentication(USER_AUTH))
@@ -82,7 +82,7 @@ class RefundControllerTest {
         @Test
         @DisplayName("이미 환불된 결제 → 409")
         void duplicateRefund() throws Exception {
-            given(refundService.requestRefund(any(), anyString()))
+            given(refundService.requestRefund(any(), anyLong()))
                     .willThrow(new BusinessException(ErrorCode.REFUND_ALREADY_EXISTS));
 
             mockMvc.perform(post("/api/refunds")
@@ -103,7 +103,7 @@ class RefundControllerTest {
         @Test
         @DisplayName("인증된 사용자 — 환불 조회 → 200")
         void returnsRefund() throws Exception {
-            given(refundService.getById(1L, "user1", false)).willReturn(mock(RefundResponse.class));
+            given(refundService.getById(eq(1L), any(), eq(false))).willReturn(mock(RefundResponse.class));
 
             mockMvc.perform(get("/api/refunds/1").with(authentication(USER_AUTH)))
                     .andExpect(status().isOk())
@@ -120,7 +120,7 @@ class RefundControllerTest {
         @Test
         @DisplayName("존재하지 않는 환불 → 404")
         void notFound() throws Exception {
-            given(refundService.getById(999L, "user1", false))
+            given(refundService.getById(eq(999L), any(), eq(false)))
                     .willThrow(new BusinessException(ErrorCode.REFUND_NOT_FOUND));
 
             mockMvc.perform(get("/api/refunds/999").with(authentication(USER_AUTH)))
@@ -131,7 +131,7 @@ class RefundControllerTest {
         @Test
         @DisplayName("타인의 환불 조회 → 403")
         void accessDenied() throws Exception {
-            given(refundService.getById(1L, "user1", false))
+            given(refundService.getById(eq(1L), any(), eq(false)))
                     .willThrow(new BusinessException(ErrorCode.REFUND_ACCESS_DENIED));
 
             mockMvc.perform(get("/api/refunds/1").with(authentication(USER_AUTH)))
@@ -149,7 +149,7 @@ class RefundControllerTest {
         @Test
         @DisplayName("인증된 사용자 — 결제 ID로 환불 조회 → 200")
         void returnsRefundByPaymentId() throws Exception {
-            given(refundService.getByPaymentId(1L, "user1", false)).willReturn(mock(RefundResponse.class));
+            given(refundService.getByPaymentId(eq(1L), any(), eq(false))).willReturn(mock(RefundResponse.class));
 
             mockMvc.perform(get("/api/refunds/payments/1").with(authentication(USER_AUTH)))
                     .andExpect(status().isOk())

--- a/src/test/java/com/stockmanagement/domain/refund/service/RefundServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/refund/service/RefundServiceTest.java
@@ -2,8 +2,6 @@ package com.stockmanagement.domain.refund.service;
 
 import com.stockmanagement.common.exception.BusinessException;
 import com.stockmanagement.common.exception.ErrorCode;
-import com.stockmanagement.domain.order.entity.Order;
-import com.stockmanagement.domain.order.entity.OrderStatus;
 import com.stockmanagement.domain.order.repository.OrderRepository;
 import com.stockmanagement.domain.payment.entity.Payment;
 import com.stockmanagement.domain.payment.entity.PaymentStatus;
@@ -14,8 +12,6 @@ import com.stockmanagement.domain.refund.dto.RefundResponse;
 import com.stockmanagement.domain.refund.entity.Refund;
 import com.stockmanagement.domain.refund.entity.RefundStatus;
 import com.stockmanagement.domain.refund.repository.RefundRepository;
-import com.stockmanagement.domain.user.entity.User;
-import com.stockmanagement.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -42,15 +38,8 @@ class RefundServiceTest {
     @Mock private PaymentRepository paymentRepository;
     @Mock private OrderRepository orderRepository;
     @Mock private PaymentService paymentService;
-    @Mock private UserRepository userRepository;
 
     @InjectMocks private RefundService refundService;
-
-    private User mockUser(Long id) {
-        User u = User.builder().username("user1").password("pw").email("e@e.com").build();
-        ReflectionTestUtils.setField(u, "id", id);
-        return u;
-    }
 
     private Payment mockPayment(Long id, Long orderId) {
         Payment p = Payment.builder()
@@ -75,19 +64,12 @@ class RefundServiceTest {
     @DisplayName("requestRefund() — 환불 요청")
     class RequestRefund {
 
-        private Order mockOrder(Long orderId, Long userId) {
-            Order o = Order.builder().userId(userId).idempotencyKey("k").build();
-            ReflectionTestUtils.setField(o, "id", orderId);
-            return o;
-        }
-
         @Test
         @DisplayName("정상 환불 → COMPLETED 상태")
         void success() {
-            given(userRepository.findByUsername("user1")).willReturn(Optional.of(mockUser(1L)));
             Payment payment = mockPayment(10L, 100L);
             given(paymentRepository.findById(10L)).willReturn(Optional.of(payment));
-            given(orderRepository.findById(100L)).willReturn(Optional.of(mockOrder(100L, 1L)));
+            given(orderRepository.findUserIdById(100L)).willReturn(Optional.of(1L));
             given(refundRepository.findFirstByPaymentIdOrderByCreatedAtDesc(10L)).willReturn(Optional.empty());
 
             Refund saved = Refund.builder()
@@ -97,7 +79,7 @@ class RefundServiceTest {
             ReflectionTestUtils.setField(saved, "id", 5L);
             given(refundRepository.save(any())).willReturn(saved);
 
-            RefundResponse response = refundService.requestRefund(mockRequest(10L), "user1");
+            RefundResponse response = refundService.requestRefund(mockRequest(10L), 1L);
 
             assertThat(response.getPaymentId()).isEqualTo(10L);
             verify(paymentService).cancel(eq("pk_test_abc123"), any(), eq(1L), eq(false));
@@ -107,10 +89,8 @@ class RefundServiceTest {
         @Test
         @DisplayName("중복 환불 요청 (COMPLETED) → REFUND_ALREADY_EXISTS")
         void duplicate() {
-            given(userRepository.findByUsername("user1")).willReturn(Optional.of(mockUser(1L)));
             given(paymentRepository.findById(10L)).willReturn(Optional.of(mockPayment(10L, 100L)));
-            given(orderRepository.findById(100L)).willReturn(Optional.of(mockOrder(100L, 1L)));
-            // 이미 COMPLETED 상태의 환불이 존재 → 재시도 불가
+            given(orderRepository.findUserIdById(100L)).willReturn(Optional.of(1L));
             Refund completed = Refund.builder()
                     .paymentId(10L).orderId(100L)
                     .amount(BigDecimal.valueOf(50000)).reason("변심")
@@ -118,7 +98,7 @@ class RefundServiceTest {
             completed.complete();
             given(refundRepository.findFirstByPaymentIdOrderByCreatedAtDesc(10L)).willReturn(Optional.of(completed));
 
-            assertThatThrownBy(() -> refundService.requestRefund(mockRequest(10L), "user1"))
+            assertThatThrownBy(() -> refundService.requestRefund(mockRequest(10L), 1L))
                     .isInstanceOf(BusinessException.class)
                     .hasFieldOrPropertyWithValue("errorCode", ErrorCode.REFUND_ALREADY_EXISTS);
         }
@@ -126,12 +106,10 @@ class RefundServiceTest {
         @Test
         @DisplayName("이전 환불이 FAILED → 재시도 허용, COMPLETED 상태로 전이")
         void retryAfterFailed() {
-            given(userRepository.findByUsername("user1")).willReturn(Optional.of(mockUser(1L)));
             Payment payment = mockPayment(10L, 100L);
             given(paymentRepository.findById(10L)).willReturn(Optional.of(payment));
-            given(orderRepository.findById(100L)).willReturn(Optional.of(mockOrder(100L, 1L)));
+            given(orderRepository.findUserIdById(100L)).willReturn(Optional.of(1L));
 
-            // 기존 FAILED 환불 레코드 (paymentId UNIQUE로 새 레코드 생성 불가)
             Refund failedRefund = Refund.builder()
                     .paymentId(10L).orderId(100L)
                     .amount(BigDecimal.valueOf(50000)).reason("이전 사유")
@@ -140,7 +118,7 @@ class RefundServiceTest {
             ReflectionTestUtils.setField(failedRefund, "id", 5L);
             given(refundRepository.findFirstByPaymentIdOrderByCreatedAtDesc(10L)).willReturn(Optional.of(failedRefund));
 
-            refundService.requestRefund(mockRequest(10L), "user1");
+            refundService.requestRefund(mockRequest(10L), 1L);
 
             verify(paymentService).cancel(eq("pk_test_abc123"), any(), eq(1L), eq(false));
             assertThat(failedRefund.getStatus()).isEqualTo(RefundStatus.COMPLETED);
@@ -149,10 +127,9 @@ class RefundServiceTest {
         @Test
         @DisplayName("PaymentService.cancel() 실패 → FAILED 상태, 예외 전파")
         void failsWhenPaymentCancelThrows() {
-            given(userRepository.findByUsername("user1")).willReturn(Optional.of(mockUser(1L)));
             Payment payment = mockPayment(10L, 100L);
             given(paymentRepository.findById(10L)).willReturn(Optional.of(payment));
-            given(orderRepository.findById(100L)).willReturn(Optional.of(mockOrder(100L, 1L)));
+            given(orderRepository.findUserIdById(100L)).willReturn(Optional.of(1L));
             given(refundRepository.findFirstByPaymentIdOrderByCreatedAtDesc(10L)).willReturn(Optional.empty());
 
             Refund saved = Refund.builder()
@@ -163,7 +140,7 @@ class RefundServiceTest {
             doThrow(new BusinessException(ErrorCode.TOSS_PAYMENTS_ERROR))
                     .when(paymentService).cancel(any(), any(), any(), anyBoolean());
 
-            assertThatThrownBy(() -> refundService.requestRefund(mockRequest(10L), "user1"))
+            assertThatThrownBy(() -> refundService.requestRefund(mockRequest(10L), 1L))
                     .isInstanceOf(BusinessException.class);
             assertThat(saved.getStatus()).isEqualTo(RefundStatus.FAILED);
         }
@@ -176,17 +153,14 @@ class RefundServiceTest {
         @Test
         @DisplayName("존재하면 반환")
         void found() {
-            User user = mockUser(1L);
-            // Refund.userId(비정규화)로 소유권 검증 — orderRepository 조회 없음
             Refund refund = Refund.builder()
                     .paymentId(10L).orderId(100L).userId(1L)
                     .amount(BigDecimal.valueOf(50000)).reason("변심")
                     .build();
             ReflectionTestUtils.setField(refund, "id", 5L);
-            given(userRepository.findByUsername("user1")).willReturn(Optional.of(user));
             given(refundRepository.findByPaymentId(10L)).willReturn(Optional.of(refund));
 
-            RefundResponse response = refundService.getByPaymentId(10L, "user1", false);
+            RefundResponse response = refundService.getByPaymentId(10L, 1L, false);
 
             assertThat(response.getId()).isEqualTo(5L);
             verify(orderRepository, never()).findById(any());
@@ -195,11 +169,9 @@ class RefundServiceTest {
         @Test
         @DisplayName("없으면 REFUND_NOT_FOUND")
         void notFound() {
-            User user = mockUser(1L);
-            given(userRepository.findByUsername("user1")).willReturn(Optional.of(user));
             given(refundRepository.findByPaymentId(10L)).willReturn(Optional.empty());
 
-            assertThatThrownBy(() -> refundService.getByPaymentId(10L, "user1", false))
+            assertThatThrownBy(() -> refundService.getByPaymentId(10L, 1L, false))
                     .isInstanceOf(BusinessException.class)
                     .hasFieldOrPropertyWithValue("errorCode", ErrorCode.REFUND_NOT_FOUND);
         }
@@ -207,19 +179,16 @@ class RefundServiceTest {
         @Test
         @DisplayName("ADMIN은 타인 환불도 조회 가능")
         void adminCanAccessAnyRefund() {
-            User admin = mockUser(99L);
             Refund refund = Refund.builder()
                     .paymentId(10L).orderId(100L).userId(1L)
                     .amount(BigDecimal.valueOf(50000)).reason("변심")
                     .build();
             ReflectionTestUtils.setField(refund, "id", 5L);
-            given(userRepository.findByUsername("admin")).willReturn(Optional.of(admin));
             given(refundRepository.findByPaymentId(10L)).willReturn(Optional.of(refund));
 
-            RefundResponse response = refundService.getByPaymentId(10L, "admin", true);
+            RefundResponse response = refundService.getByPaymentId(10L, 99L, true);
 
             assertThat(response.getId()).isEqualTo(5L);
-            // isAdmin=true 이므로 orderRepository 조회 없음
             verify(orderRepository, never()).findById(any());
         }
     }


### PR DESCRIPTION
## Summary

- **#51** `CategoryService.getById()` — `@Cacheable(cacheNames="categories", key="'id:'+#id")` 추가 (기존 `allEntries=true` CacheEvict로 자동 무효화)
- **#45** `CouponService` — `@Slf4j` 추가 + `claim`/`applyCoupon`/`releaseCoupon` 감사 로그 출력
- **#18** `OrderService.getHistory()` — `findById(Order)` 전체 엔티티 로드 → `findUserIdById()` 스칼라 프로젝션 전환 (소유권 검증 DB round-trip 절감)
- **#19** `RefundService` — `String username` + `UserRepository` 제거 → `Long userId` 직접 수신
  - `requestRefund`: `orderRepository.findUserIdById()`로 소유권 검증
  - `getById` / `getByPaymentId`: userId 직접 수신
  - `RefundController`: `resolveUserId(authentication, username)` 헬퍼로 JWT claim 또는 DB fallback

## Test plan

- [x] `RefundServiceTest` — requestRefund / getByPaymentId 케이스 userId로 재작성
- [x] `RefundControllerTest` — 스텁을 `anyLong()` / `eq(N)` 매처로 갱신
- [x] 전체 테스트 통과 (BUILD SUCCESSFUL)