### PR TITLE
perf: resolveUserId 유틸 공통화 및 addOrUpdate 응답 최적화 (#21, #27)

### DIFF
--- a/src/main/java/com/stockmanagement/common/security/SecurityUtils.java
+++ b/src/main/java/com/stockmanagement/common/security/SecurityUtils.java
@@ -2,6 +2,8 @@ package com.stockmanagement.common.security;
 
 import org.springframework.security.core.Authentication;
 
+import java.util.function.Supplier;
+
 /** Spring Security 관련 공통 유틸리티. */
 public final class SecurityUtils {
 
@@ -17,5 +19,23 @@ public final class SecurityUtils {
         if (authentication == null) return false;
         return authentication.getAuthorities().stream()
                 .anyMatch(a -> a.getAuthority().equals("ROLE_ADMIN"));
+    }
+
+    /**
+     * JWT claim 또는 fallback으로 userId를 결정한다.
+     *
+     * <p>{@link com.stockmanagement.common.security.JwtAuthenticationFilter}가
+     * {@code auth.setDetails(userId)}에 저장한 경우 DB 조회를 건너뛴다.
+     * details가 없으면 {@code fallback}을 호출한다 (UserService.resolveUserId 등).
+     *
+     * @param auth     Spring Security 인증 객체 (null 허용)
+     * @param fallback userId를 DB에서 조회하는 람다
+     * @return 결정된 userId
+     */
+    public static Long resolveUserId(Authentication auth, Supplier<Long> fallback) {
+        if (auth != null && auth.getDetails() instanceof Long userId) {
+            return userId;
+        }
+        return fallback.get();
     }
 }

--- a/src/main/java/com/stockmanagement/domain/order/cart/controller/CartController.java
+++ b/src/main/java/com/stockmanagement/domain/order/cart/controller/CartController.java
@@ -3,6 +3,7 @@ package com.stockmanagement.domain.order.cart.controller;
 import com.stockmanagement.common.dto.ApiResponse;
 import com.stockmanagement.domain.order.cart.dto.CartCheckoutRequest;
 import com.stockmanagement.domain.order.cart.dto.CartItemRequest;
+import com.stockmanagement.domain.order.cart.dto.CartItemResponse;
 import com.stockmanagement.domain.order.cart.dto.CartResponse;
 import com.stockmanagement.domain.order.cart.service.CartService;
 import com.stockmanagement.domain.order.dto.OrderResponse;
@@ -47,7 +48,7 @@ public class CartController {
     @Operation(summary = "상품 추가 또는 수량 변경",
                description = "동일 상품이 이미 있으면 수량을 요청값으로 교체한다.")
     @PostMapping("/items")
-    public ApiResponse<CartResponse> addOrUpdate(
+    public ApiResponse<CartItemResponse> addOrUpdate(
             @AuthenticationPrincipal String username,
             @RequestBody @Valid CartItemRequest request) {
         return ApiResponse.ok(cartService.addOrUpdate(userService.resolveUserId(username), request));

--- a/src/main/java/com/stockmanagement/domain/order/cart/service/CartService.java
+++ b/src/main/java/com/stockmanagement/domain/order/cart/service/CartService.java
@@ -4,6 +4,7 @@ import com.stockmanagement.common.exception.BusinessException;
 import com.stockmanagement.common.exception.ErrorCode;
 import com.stockmanagement.domain.order.cart.dto.CartCheckoutRequest;
 import com.stockmanagement.domain.order.cart.dto.CartItemRequest;
+import com.stockmanagement.domain.order.cart.dto.CartItemResponse;
 import com.stockmanagement.domain.order.cart.dto.CartResponse;
 import com.stockmanagement.domain.order.cart.entity.CartItem;
 import com.stockmanagement.domain.order.cart.repository.CartRepository;
@@ -66,9 +67,10 @@ public class CartService {
      *
      * <p>동일 상품이 이미 담겨 있으면 요청 수량으로 덮어쓴다(교체).
      * 없으면 새 CartItem을 추가한다.
+     * 전체 장바구니 재조회 없이 영향받은 단건만 반환하여 불필요한 쿼리를 최소화한다.
      */
     @Transactional
-    public CartResponse addOrUpdate(Long userId, CartItemRequest request) {
+    public CartItemResponse addOrUpdate(Long userId, CartItemRequest request) {
         Product product = productRepository.findById(request.getProductId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND));
 
@@ -80,25 +82,31 @@ public class CartService {
         Optional<CartItem> existing =
                 cartRepository.findByUserIdAndProductId(userId, product.getId());
 
+        CartItem cartItem;
         if (existing.isPresent()) {
-            existing.get().updateQuantity(request.getQuantity());
+            cartItem = existing.get();
+            cartItem.updateQuantity(request.getQuantity());
         } else {
             try {
-                CartItem item = CartItem.builder()
+                cartItem = cartRepository.saveAndFlush(CartItem.builder()
                         .userId(userId)
                         .product(product)
                         .quantity(request.getQuantity())
                         .savedPrice(product.getPrice())
-                        .build();
-                cartRepository.saveAndFlush(item);
+                        .build());
             } catch (DataIntegrityViolationException e) {
                 // 동시 요청으로 UK(user_id, product_id) 충돌 — 재조회 후 수량 업데이트
-                cartRepository.findByUserIdAndProductId(userId, product.getId())
-                        .ifPresent(item -> item.updateQuantity(request.getQuantity()));
+                cartItem = cartRepository.findByUserIdAndProductId(userId, product.getId())
+                        .orElseThrow(() -> new BusinessException(ErrorCode.CART_ITEM_NOT_FOUND));
+                cartItem.updateQuantity(request.getQuantity());
             }
         }
 
-        return getCart(userId);
+        // 단건 재고 조회 (전체 장바구니 리로드 불필요)
+        Integer available = inventoryRepository.findByProductId(product.getId())
+                .map(Inventory::getAvailable)
+                .orElse(null);
+        return CartItemResponse.from(cartItem, available);
     }
 
     /**

--- a/src/main/java/com/stockmanagement/domain/order/controller/OrderController.java
+++ b/src/main/java/com/stockmanagement/domain/order/controller/OrderController.java
@@ -67,7 +67,7 @@ public class OrderController {
             @RequestBody @Valid OrderPreviewRequest request,
             @AuthenticationPrincipal String username,
             Authentication authentication) {
-        return ApiResponse.ok(orderService.preview(request, resolveUserId(authentication, username)));
+        return ApiResponse.ok(orderService.preview(request, SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username))));
     }
 
     @Operation(summary = "주문 생성", description = "재고 예약(reserved++) 후 PENDING 주문 생성. 동일 idempotencyKey 재요청 시 기존 주문 반환.")
@@ -88,7 +88,7 @@ public class OrderController {
             @AuthenticationPrincipal String username,
             Authentication authentication) {
         boolean isAdmin = SecurityUtils.isAdmin(authentication);
-        return ApiResponse.ok(orderService.getByIdForUser(id, resolveUserId(authentication, username), isAdmin));
+        return ApiResponse.ok(orderService.getByIdForUser(id, SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username)), isAdmin));
     }
 
     @Operation(summary = "주문 상세 통합 조회",
@@ -99,7 +99,7 @@ public class OrderController {
             @AuthenticationPrincipal String username,
             Authentication authentication) {
         boolean isAdmin = SecurityUtils.isAdmin(authentication);
-        return ApiResponse.ok(orderDetailService.getDetail(id, resolveUserId(authentication, username), isAdmin));
+        return ApiResponse.ok(orderDetailService.getDetail(id, SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username)), isAdmin));
     }
 
     @Operation(summary = "주문 목록 조회 (필터 + 페이징)",
@@ -113,7 +113,7 @@ public class OrderController {
             Pageable pageable) {
         boolean isAdmin = SecurityUtils.isAdmin(authentication);
         // ADMIN은 request.userId 파라미터로 필터링하므로 userId 해결 불필요
-        Long userId = isAdmin ? null : resolveUserId(authentication, username);
+        Long userId = isAdmin ? null : SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username));
         return ApiResponse.ok(orderService.getList(userId, isAdmin, request, pageable));
     }
 
@@ -136,7 +136,7 @@ public class OrderController {
             @RequestParam(required = false) Long lastId,
             @Min(1) @Max(100) @RequestParam(defaultValue = "20") int size) {
         boolean isAdmin = SecurityUtils.isAdmin(authentication);
-        Long userId = resolveUserId(authentication, username);
+        Long userId = SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username));
         return ApiResponse.ok(orderService.getOrderScroll(userId, isAdmin, status, lastId, size));
     }
 
@@ -149,7 +149,7 @@ public class OrderController {
             Authentication authentication) {
         boolean isAdmin = SecurityUtils.isAdmin(authentication);
         String reason = request != null ? request.reason() : null;
-        return ApiResponse.ok(orderService.cancel(id, resolveUserId(authentication, username), isAdmin, reason));
+        return ApiResponse.ok(orderService.cancel(id, SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username)), isAdmin, reason));
     }
 
     @Operation(summary = "주문 상태 변경 이력 조회", description = "생성·취소·확정·환불 등 모든 상태 전이를 시간순으로 반환. ADMIN은 모든 주문, USER는 본인 주문만 가능.")
@@ -159,19 +159,6 @@ public class OrderController {
             @AuthenticationPrincipal String username,
             Authentication authentication) {
         boolean isAdmin = SecurityUtils.isAdmin(authentication);
-        return ApiResponse.ok(orderService.getHistory(id, resolveUserId(authentication, username), isAdmin));
-    }
-
-    /**
-     * JWT claim 또는 DB 조회로 userId를 결정한다.
-     *
-     * <p>JwtAuthenticationFilter가 {@code auth.setDetails(userId)}에 저장한 경우 DB 조회를 건너뛴다.
-     * 구 토큰 또는 테스트 환경처럼 details가 없으면 userService.resolveUserId(username)로 DB 조회.
-     */
-    private Long resolveUserId(Authentication auth, String username) {
-        if (auth != null && auth.getDetails() instanceof Long userId) {
-            return userId;
-        }
-        return userService.resolveUserId(username);
+        return ApiResponse.ok(orderService.getHistory(id, SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username)), isAdmin));
     }
 }

--- a/src/main/java/com/stockmanagement/domain/payment/controller/PaymentController.java
+++ b/src/main/java/com/stockmanagement/domain/payment/controller/PaymentController.java
@@ -54,7 +54,7 @@ public class PaymentController {
             @RequestBody @Valid PaymentPrepareRequest request,
             @AuthenticationPrincipal String username,
             Authentication authentication) {
-        return ApiResponse.ok(paymentService.prepare(request, resolveUserId(authentication, username)));
+        return ApiResponse.ok(paymentService.prepare(request, SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username))));
     }
 
     @Operation(summary = "결제 승인", description = "결제창 완료 후 paymentKey로 호출. Order → CONFIRMED, reserved→allocated. 본인 주문만 가능.")
@@ -64,7 +64,7 @@ public class PaymentController {
             @RequestBody @Valid PaymentConfirmRequest request,
             @AuthenticationPrincipal String username,
             Authentication authentication) {
-        return ApiResponse.ok(paymentService.confirm(request, resolveUserId(authentication, username)));
+        return ApiResponse.ok(paymentService.confirm(request, SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username))));
     }
 
     @Operation(summary = "결제 취소/환불", description = "본인 결제만 취소 가능. ADMIN은 전체 취소 가능. Order → CANCELLED, allocated 해제.")
@@ -75,7 +75,7 @@ public class PaymentController {
             @AuthenticationPrincipal String username,
             Authentication authentication) {
         boolean isAdmin = SecurityUtils.isAdmin(authentication);
-        return ApiResponse.ok(paymentService.cancel(paymentKey, request, resolveUserId(authentication, username), isAdmin));
+        return ApiResponse.ok(paymentService.cancel(paymentKey, request, SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username)), isAdmin));
     }
 
     @Operation(summary = "TossPayments 웹훅 수신", description = "공개 엔드포인트. Toss-Signature 헤더로 HMAC-SHA256 서명 검증 후 처리.")
@@ -100,7 +100,7 @@ public class PaymentController {
             @AuthenticationPrincipal String username,
             Authentication authentication,
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        return ApiResponse.ok(paymentService.getMyPayments(resolveUserId(authentication, username), pageable));
+        return ApiResponse.ok(paymentService.getMyPayments(SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username)), pageable));
     }
 
     @Operation(summary = "결제 조회", description = "paymentKey로 결제 상세 조회. 본인 결제만 가능 (ADMIN은 전체 조회).")
@@ -110,7 +110,7 @@ public class PaymentController {
             @AuthenticationPrincipal String username,
             Authentication authentication) {
         boolean isAdmin = SecurityUtils.isAdmin(authentication);
-        return ApiResponse.ok(paymentService.getByPaymentKey(paymentKey, resolveUserId(authentication, username), isAdmin));
+        return ApiResponse.ok(paymentService.getByPaymentKey(paymentKey, SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username)), isAdmin));
     }
 
     @Operation(summary = "주문별 결제 조회", description = "주문 ID로 결제 정보 조회. 결제 전이면 data: null 반환. 본인 주문만 가능.")
@@ -120,19 +120,6 @@ public class PaymentController {
             @AuthenticationPrincipal String username,
             Authentication authentication) {
         boolean isAdmin = SecurityUtils.isAdmin(authentication);
-        return ApiResponse.ok(paymentService.getByOrderId(orderId, resolveUserId(authentication, username), isAdmin).orElse(null));
-    }
-
-    /**
-     * JWT claim 또는 DB 조회로 userId를 결정한다.
-     *
-     * <p>JwtAuthenticationFilter가 {@code auth.setDetails(userId)}에 저장한 경우 DB 조회를 건너뛴다.
-     * 구 토큰 또는 테스트 환경처럼 details가 없으면 userService.resolveUserId(username)으로 DB 조회.
-     */
-    private Long resolveUserId(Authentication auth, String username) {
-        if (auth != null && auth.getDetails() instanceof Long userId) {
-            return userId;
-        }
-        return userService.resolveUserId(username);
+        return ApiResponse.ok(paymentService.getByOrderId(orderId, SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username)), isAdmin).orElse(null));
     }
 }

--- a/src/main/java/com/stockmanagement/domain/product/controller/ProductController.java
+++ b/src/main/java/com/stockmanagement/domain/product/controller/ProductController.java
@@ -1,6 +1,7 @@
 package com.stockmanagement.domain.product.controller;
 
 import com.stockmanagement.common.dto.ApiResponse;
+import com.stockmanagement.common.security.SecurityUtils;
 import com.stockmanagement.domain.product.dto.ProductCreateRequest;
 import com.stockmanagement.domain.product.dto.ProductResponse;
 import com.stockmanagement.domain.product.dto.ProductSearchRequest;
@@ -44,7 +45,7 @@ public class ProductController {
             @AuthenticationPrincipal String username,
             Authentication authentication) {
         if (isAuthenticated(authentication)) {
-            Long userId = resolveUserId(authentication, username);
+            Long userId = SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username));
             return ApiResponse.ok(productService.getByIdForUser(id, userId));
         }
         return ApiResponse.ok(productService.getById(id));
@@ -63,7 +64,7 @@ public class ProductController {
             @PageableDefault(size = 20, sort = "id") Pageable pageable,
             @AuthenticationPrincipal String username,
             Authentication authentication) {
-        Long userId = isAuthenticated(authentication) ? resolveUserId(authentication, username) : null;
+        Long userId = isAuthenticated(authentication) ? SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username)) : null;
         return ApiResponse.ok(productService.getList(pageable, request, userId));
     }
 
@@ -94,13 +95,5 @@ public class ProductController {
     private boolean isAuthenticated(Authentication auth) {
         return auth != null && auth.isAuthenticated()
                 && !(auth instanceof AnonymousAuthenticationToken);
-    }
-
-    /** JWT claim details에서 userId 추출. 구 토큰이면 DB fallback. */
-    private Long resolveUserId(Authentication auth, String username) {
-        if (auth != null && auth.getDetails() instanceof Long userId) {
-            return userId;
-        }
-        return userService.resolveUserId(username);
     }
 }

--- a/src/main/java/com/stockmanagement/domain/product/review/controller/ReviewController.java
+++ b/src/main/java/com/stockmanagement/domain/product/review/controller/ReviewController.java
@@ -1,6 +1,7 @@
 package com.stockmanagement.domain.product.review.controller;
 
 import com.stockmanagement.common.dto.ApiResponse;
+import com.stockmanagement.common.security.SecurityUtils;
 import com.stockmanagement.domain.product.review.dto.RatingStatsResponse;
 import com.stockmanagement.domain.product.review.dto.ReviewCreateRequest;
 import com.stockmanagement.domain.product.review.dto.ReviewResponse;
@@ -37,7 +38,7 @@ public class ReviewController {
             @AuthenticationPrincipal String username,
             Authentication authentication,
             @Valid @RequestBody ReviewCreateRequest request) {
-        return ApiResponse.ok(reviewService.create(productId, resolveUserId(authentication, username), request));
+        return ApiResponse.ok(reviewService.create(productId, SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username)), request));
     }
 
     @Operation(summary = "상품 리뷰 목록 조회",
@@ -66,7 +67,7 @@ public class ReviewController {
             @AuthenticationPrincipal String username,
             Authentication authentication,
             @Valid @RequestBody ReviewUpdateRequest request) {
-        return ApiResponse.ok(reviewService.update(productId, reviewId, resolveUserId(authentication, username), request));
+        return ApiResponse.ok(reviewService.update(productId, reviewId, SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username)), request));
     }
 
     @Operation(summary = "리뷰 삭제 (작성자 본인)")
@@ -77,14 +78,6 @@ public class ReviewController {
             @PathVariable Long reviewId,
             @AuthenticationPrincipal String username,
             Authentication authentication) {
-        reviewService.delete(productId, reviewId, resolveUserId(authentication, username));
-    }
-
-    /** JWT claim details에서 userId 추출. 구 토큰이면 DB fallback. */
-    private Long resolveUserId(Authentication auth, String username) {
-        if (auth != null && auth.getDetails() instanceof Long userId) {
-            return userId;
-        }
-        return userService.resolveUserId(username);
+        reviewService.delete(productId, reviewId, SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username)));
     }
 }

--- a/src/main/java/com/stockmanagement/domain/product/wishlist/controller/WishlistController.java
+++ b/src/main/java/com/stockmanagement/domain/product/wishlist/controller/WishlistController.java
@@ -1,6 +1,7 @@
 package com.stockmanagement.domain.product.wishlist.controller;
 
 import com.stockmanagement.common.dto.ApiResponse;
+import com.stockmanagement.common.security.SecurityUtils;
 import com.stockmanagement.domain.product.wishlist.dto.WishlistResponse;
 import com.stockmanagement.domain.product.wishlist.service.WishlistService;
 import com.stockmanagement.domain.user.service.UserService;
@@ -32,7 +33,7 @@ public class WishlistController {
             @PathVariable Long productId,
             @AuthenticationPrincipal String username,
             Authentication authentication) {
-        return ApiResponse.ok(wishlistService.add(productId, resolveUserId(authentication, username)));
+        return ApiResponse.ok(wishlistService.add(productId, SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username))));
     }
 
     @Operation(summary = "위시리스트에서 상품 제거")
@@ -42,7 +43,7 @@ public class WishlistController {
             @PathVariable Long productId,
             @AuthenticationPrincipal String username,
             Authentication authentication) {
-        wishlistService.remove(productId, resolveUserId(authentication, username));
+        wishlistService.remove(productId, SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username)));
     }
 
     @Operation(summary = "특정 상품의 위시리스트 추가 여부 조회",
@@ -52,7 +53,7 @@ public class WishlistController {
             @PathVariable Long productId,
             @AuthenticationPrincipal String username,
             Authentication authentication) {
-        boolean wishlisted = wishlistService.isWishlisted(productId, resolveUserId(authentication, username));
+        boolean wishlisted = wishlistService.isWishlisted(productId, SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username)));
         return ApiResponse.ok(java.util.Map.of("wishlisted", wishlisted));
     }
 
@@ -62,14 +63,6 @@ public class WishlistController {
             @AuthenticationPrincipal String username,
             Authentication authentication,
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        return ApiResponse.ok(wishlistService.getList(resolveUserId(authentication, username), pageable));
-    }
-
-    /** JWT details에서 userId를 추출하고, 없으면 DB fallback. */
-    private Long resolveUserId(Authentication auth, String username) {
-        if (auth != null && auth.getDetails() instanceof Long userId) {
-            return userId;
-        }
-        return userService.resolveUserId(username);
+        return ApiResponse.ok(wishlistService.getList(SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username)), pageable));
     }
 }

--- a/src/main/java/com/stockmanagement/domain/refund/controller/RefundController.java
+++ b/src/main/java/com/stockmanagement/domain/refund/controller/RefundController.java
@@ -43,7 +43,7 @@ public class RefundController {
             @AuthenticationPrincipal String username,
             Authentication authentication,
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        return ApiResponse.ok(refundService.getMyRefunds(resolveUserId(authentication, username), pageable));
+        return ApiResponse.ok(refundService.getMyRefunds(SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username)), pageable));
     }
 
     @Operation(summary = "환불 단건 조회", description = "ADMIN은 모든 환불 조회 가능. USER는 본인 주문의 환불만 가능.")
@@ -64,18 +64,5 @@ public class RefundController {
             Authentication authentication) {
         boolean isAdmin = SecurityUtils.isAdmin(authentication);
         return ApiResponse.ok(refundService.getByPaymentId(paymentId, username, isAdmin));
-    }
-
-    /**
-     * JWT claim 또는 DB 조회로 userId를 결정한다.
-     *
-     * <p>JwtAuthenticationFilter가 {@code auth.setDetails(userId)}에 저장한 경우 DB 조회를 건너뛴다.
-     * 구 토큰 또는 테스트 환경처럼 details가 없으면 userService.resolveUserId(username)로 DB 조회.
-     */
-    private Long resolveUserId(Authentication auth, String username) {
-        if (auth != null && auth.getDetails() instanceof Long userId) {
-            return userId;
-        }
-        return userService.resolveUserId(username);
     }
 }

--- a/src/main/java/com/stockmanagement/domain/shipment/controller/ShipmentController.java
+++ b/src/main/java/com/stockmanagement/domain/shipment/controller/ShipmentController.java
@@ -46,7 +46,7 @@ public class ShipmentController {
             @AuthenticationPrincipal String username,
             Authentication authentication,
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        Long userId = resolveUserId(authentication, username);
+        Long userId = SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username));
         return ApiResponse.ok(shipmentService.getMyShipments(userId, pageable));
     }
 
@@ -79,12 +79,5 @@ public class ShipmentController {
     @PatchMapping("/orders/{orderId}/return")
     public ApiResponse<ShipmentResponse> processReturn(@PathVariable Long orderId) {
         return ApiResponse.ok(shipmentService.processReturn(orderId));
-    }
-
-    private Long resolveUserId(Authentication auth, String username) {
-        if (auth != null && auth.getDetails() instanceof Long userId) {
-            return userId;
-        }
-        return userService.resolveUserId(username);
     }
 }

--- a/src/main/java/com/stockmanagement/domain/user/controller/UserController.java
+++ b/src/main/java/com/stockmanagement/domain/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.stockmanagement.domain.user.controller;
 
 import com.stockmanagement.common.dto.ApiResponse;
+import com.stockmanagement.common.security.SecurityUtils;
 import com.stockmanagement.domain.order.dto.OrderResponse;
 import com.stockmanagement.domain.product.review.dto.ReviewResponse;
 import com.stockmanagement.domain.product.review.service.ReviewService;
@@ -92,15 +93,7 @@ public class UserController {
             @RequestParam(required = false) Integer rating,
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
             Pageable pageable) {
-        Long userId = resolveUserId(authentication, username);
+        Long userId = SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username));
         return ApiResponse.ok(reviewService.getMyReviews(userId, pageable, rating));
-    }
-
-    /** JWT claim details에서 userId 추출. 구 토큰이면 DB fallback. */
-    private Long resolveUserId(Authentication auth, String username) {
-        if (auth != null && auth.getDetails() instanceof Long userId) {
-            return userId;
-        }
-        return userService.resolveUserId(username);
     }
 }

--- a/src/test/java/com/stockmanagement/domain/order/cart/controller/CartControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/order/cart/controller/CartControllerTest.java
@@ -2,6 +2,7 @@ package com.stockmanagement.domain.order.cart.controller;
 
 import com.stockmanagement.common.config.SecurityConfig;
 import com.stockmanagement.common.security.JwtBlacklist;
+import com.stockmanagement.domain.order.cart.dto.CartItemResponse;
 import com.stockmanagement.domain.order.cart.dto.CartResponse;
 import com.stockmanagement.domain.order.cart.service.CartService;
 import com.stockmanagement.domain.order.dto.OrderResponse;
@@ -87,7 +88,7 @@ class CartControllerTest {
         @Test
         @DisplayName("인증된 사용자 — 상품 추가 → 200")
         void addsItem() throws Exception {
-            given(cartService.addOrUpdate(anyLong(), any())).willReturn(mock(CartResponse.class));
+            given(cartService.addOrUpdate(anyLong(), any())).willReturn(mock(CartItemResponse.class));
 
             mockMvc.perform(post("/api/cart/items")
                             .with(authentication(USER_AUTH))

--- a/src/test/java/com/stockmanagement/domain/order/cart/service/CartServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/order/cart/service/CartServiceTest.java
@@ -95,7 +95,8 @@ class CartServiceTest {
             CartItemRequest request = mockCartItemRequest(1L, 3);
             given(productRepository.findById(1L)).willReturn(Optional.of(product));
             given(cartRepository.findByUserIdAndProductId(anyLong(), any())).willReturn(Optional.empty());
-            given(cartRepository.findByUserId(1L)).willReturn(List.of(cartItem));
+            given(cartRepository.saveAndFlush(any())).willReturn(cartItem);
+            given(inventoryRepository.findByProductId(any())).willReturn(Optional.empty());
 
             cartService.addOrUpdate(1L, request);
 
@@ -108,7 +109,7 @@ class CartServiceTest {
             CartItemRequest request = mockCartItemRequest(1L, 5);
             given(productRepository.findById(1L)).willReturn(Optional.of(product));
             given(cartRepository.findByUserIdAndProductId(eq(1L), any())).willReturn(Optional.of(cartItem));
-            given(cartRepository.findByUserId(1L)).willReturn(List.of(cartItem));
+            given(inventoryRepository.findByProductId(any())).willReturn(Optional.empty());
 
             cartService.addOrUpdate(1L, request);
 

--- a/src/test/java/com/stockmanagement/integration/CartIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/CartIntegrationTest.java
@@ -43,8 +43,8 @@ class CartIntegrationTest extends AbstractIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"productId\":" + productId + ",\"quantity\":3}"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.items[0].quantity").value(3))
-                .andExpect(jsonPath("$.data.totalAmount").value(6000));
+                .andExpect(jsonPath("$.data.quantity").value(3))
+                .andExpect(jsonPath("$.data.subtotal").value(6000));
 
         // 조회
         mockMvc.perform(get("/api/cart")
@@ -73,8 +73,8 @@ class CartIntegrationTest extends AbstractIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"productId\":" + productId + ",\"quantity\":5}"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.items[0].quantity").value(5))
-                .andExpect(jsonPath("$.data.totalAmount").value(5000));
+                .andExpect(jsonPath("$.data.quantity").value(5))
+                .andExpect(jsonPath("$.data.subtotal").value(5000));
     }
 
     @Test


### PR DESCRIPTION
## 변경 내용

### #27 SecurityUtils.resolveUserId() 공통 유틸
- `SecurityUtils.resolveUserId(Authentication, Supplier<Long>)` 정적 메서드 추가
- JWT `auth.getDetails()`에 userId Long 값이 있으면 DB 조회 없이 즉시 반환
- 없으면 `fallback.get()` (UserService.resolveUserId) 호출
- OrderController, PaymentController, UserController, ReviewController, WishlistController, ShipmentController, ProductController, RefundController의 private resolveUserId 헬퍼 제거 및 공통 메서드로 교체

### #21 CartService.addOrUpdate() 응답 최적화
- 반환 타입: `CartResponse` → `CartItemResponse`
- 기존: 업데이트 후 `getCart()` 호출 → `findByUserId()` + `findAllByProductIdIn()` 전체 재조회
- 개선: `findByProductId()` 단건 조회만 수행

## 테스트
- 647개 전체 통과