### PR TITLE
fix: name @Size + PERCENTAGE DTO 검증 + max-page-size + 감사 로그 (#95 #98 #100 #101)

### DIFF
--- a/src/main/java/com/stockmanagement/domain/coupon/dto/CouponCreateRequest.java
+++ b/src/main/java/com/stockmanagement/domain/coupon/dto/CouponCreateRequest.java
@@ -40,6 +40,15 @@ public class CouponCreateRequest {
     @DecimalMax("999999999")
     private BigDecimal discountValue;
 
+    @AssertTrue(message = "PERCENTAGE 할인율은 100을 초과할 수 없습니다.")
+    private boolean isDiscountValueValid() {
+        if (discountType == null || discountValue == null) return true;
+        if (discountType == DiscountType.PERCENTAGE) {
+            return discountValue.compareTo(BigDecimal.valueOf(100)) <= 0;
+        }
+        return true;
+    }
+
     /** null 허용 — 최소 주문 금액 제한 없음. */
     @DecimalMin("0")
     private BigDecimal minimumOrderAmount;

--- a/src/main/java/com/stockmanagement/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/stockmanagement/domain/coupon/service/CouponService.java
@@ -76,7 +76,9 @@ public class CouponService {
                 .validUntil(request.getValidUntil())
                 .isPublic(request.isPublic())
                 .build();
-        return CouponResponse.from(couponRepository.save(coupon));
+        Coupon saved = couponRepository.save(coupon);
+        log.info("[ADMIN] 쿠폰 생성 — code={}, type={}, value={}", saved.getCode(), saved.getDiscountType(), saved.getDiscountValue());
+        return CouponResponse.from(saved);
     }
 
     public Page<CouponResponse> getList(Pageable pageable) {
@@ -91,6 +93,7 @@ public class CouponService {
     public CouponResponse deactivate(Long id) {
         Coupon coupon = findById(id);
         coupon.deactivate();
+        log.info("[ADMIN] 쿠폰 비활성화 — id={}, code={}", coupon.getId(), coupon.getCode());
         return CouponResponse.from(coupon);
     }
 
@@ -110,6 +113,7 @@ public class CouponService {
                     .coupon(coupon)
                     .build());
             userCouponRepository.flush();
+            log.info("[ADMIN] 쿠폰 발급 — couponId={}, userId={}, code={}", couponId, userId, coupon.getCode());
         } catch (DataIntegrityViolationException e) {
             throw new BusinessException(ErrorCode.COUPON_ALREADY_ISSUED);
         }

--- a/src/main/java/com/stockmanagement/domain/product/dto/ProductCreateRequest.java
+++ b/src/main/java/com/stockmanagement/domain/product/dto/ProductCreateRequest.java
@@ -17,6 +17,7 @@ import java.math.BigDecimal;
 public class ProductCreateRequest {
 
     @NotBlank(message = "상품명은 필수입니다.")
+    @Size(max = 255, message = "상품명은 255자를 초과할 수 없습니다.")
     private String name;
 
     /** 선택 입력 — null 허용 */

--- a/src/main/java/com/stockmanagement/domain/product/dto/ProductUpdateRequest.java
+++ b/src/main/java/com/stockmanagement/domain/product/dto/ProductUpdateRequest.java
@@ -20,6 +20,7 @@ import java.math.BigDecimal;
 public class ProductUpdateRequest {
 
     @NotBlank(message = "상품명은 필수입니다.")
+    @Size(max = 255, message = "상품명은 255자를 초과할 수 없습니다.")
     private String name;
 
     /** 선택 입력 — null 전달 시 기존 설명이 null로 갱신됨 */

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -30,6 +30,9 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 spring.jpa.properties.hibernate.default_batch_fetch_size=50
 spring.jpa.open-in-view=false
 
+# ===== Pageable =====
+spring.data.web.pageable.max-page-size=100
+
 # ===== Flyway =====
 spring.flyway.enabled=true
 spring.flyway.baseline-on-migrate=true


### PR DESCRIPTION
## Summary
- `ProductCreateRequest`/`ProductUpdateRequest`: `name` 필드 `@Size(max=255)` 추가 — 256자+ 입력 시 500 대신 400 반환 (#95)
- `CouponCreateRequest`: `@AssertTrue` 메서드로 PERCENTAGE 타입 100% 초과 DTO 레벨 차단 (#100)
- `application.properties`: `spring.data.web.pageable.max-page-size=100` 추가 — 기본값 2000 방지 (#98)
- `CouponService`: create/deactivate/issueToUser ADMIN 연산 감사 로그 추가 (#101)
- #96은 이미 수정 완료 확인 (SAME_PASSWORD ErrorCode 존재)

## Test plan
- [x] 전체 테스트 통과 (647개)

🤖 Generated with [Claude Code](https://claude.com/claude-code)