### PR TITLE
security: AdminSecurityConfig OR 조건 + prometheus ADMIN 전용 (#92 #94)

### DIFF
--- a/src/main/java/com/stockmanagement/common/config/AdminSecurityConfig.java
+++ b/src/main/java/com/stockmanagement/common/config/AdminSecurityConfig.java
@@ -47,9 +47,9 @@ public class AdminSecurityConfig {
      */
     @PostConstruct
     public void validateCredentials() {
-        if ("admin".equals(adminUsername) && "changeme".equals(adminPassword)) {
+        if ("admin".equals(adminUsername) || "changeme".equals(adminPassword)) {
             throw new IllegalStateException(
-                    "[SECURITY] ADMIN_USERNAME / ADMIN_PASSWORD가 기본값(admin/changeme)입니다. " +
+                    "[SECURITY] ADMIN_USERNAME 또는 ADMIN_PASSWORD가 기본값(admin/changeme)입니다. " +
                     "운영 환경에서는 환경변수를 반드시 설정하세요.");
         }
     }

--- a/src/main/java/com/stockmanagement/common/config/SecurityConfig.java
+++ b/src/main/java/com/stockmanagement/common/config/SecurityConfig.java
@@ -80,7 +80,8 @@ public class SecurityConfig {
                         .requestMatchers("/api/auth/**").permitAll()
                         .requestMatchers("/api/payments/webhook").permitAll()
                         // Actuator — health/info/prometheus는 공개 (내부망 전용), 나머지는 ADMIN 전용
-                        .requestMatchers("/actuator/health", "/actuator/info", "/actuator/prometheus").permitAll()
+                        .requestMatchers("/actuator/health", "/actuator/info").permitAll()
+                        .requestMatchers("/actuator/prometheus").hasRole("ADMIN")
                         .requestMatchers("/actuator/**").hasRole("ADMIN")
                         // Swagger UI — swagger.public=false(운영) 시 ADMIN 인증 필요
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html")

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -69,7 +69,7 @@ server.shutdown=graceful
 spring.lifecycle.timeout-per-shutdown-phase=30s
 
 # ===== Actuator =====
-# 공개 허용 최소 엔드포인트 — prometheus는 SecurityConfig에서 ADMIN 전용으로 제한
+# 공개 허용 최소 엔드포인트 — prometheus는 SecurityConfig에서 hasRole("ADMIN")으로 제한
 management.endpoints.web.exposure.include=health,info,prometheus,metrics
 management.endpoint.health.show-details=when-authorized
 management.endpoint.health.probes.enabled=true


### PR DESCRIPTION
## Summary
- `AdminSecurityConfig.validateCredentials()`: AND → OR 조건 전환 — username만 변경하고 password 기본값 유지 시에도 차단 (#92)
- `SecurityConfig`: `/actuator/prometheus` `permitAll()` → `hasRole("ADMIN")` — 시스템 메트릭 비인증 노출 차단 (#94)

## Test plan
- [x] 전체 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)