### PR TITLE
perf: getByOrderId 스칼라 프로젝션 + resolveUserId JWT 활용 (#97 #99)

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,7 +1,6 @@
 # TODO — 기술적 개선 항목
 
-> 보안 취약점, 프로덕션 버그, 성능 결함, 코드 품질 문제를 우선순위별로 정리한다.
-> 완료된 항목은 `docs/IMPROVEMENTS.md` 참조.
+> 모든 항목은 GitHub Issues로 관리. 완료된 항목은 `docs/IMPROVEMENTS.md` 참조.
 
 ---
 
@@ -13,8 +12,8 @@ Client
   ├─ AuthController (JWT 발급)
   ├─ ProductController / CategoryController / ProductImageController
   ├─ InventoryController
-  ├─ OrderController → OrderService(God Object) → InventoryService · CouponService · PointService
-  ├─ PaymentController → PaymentService → PaymentTransactionHelper → OrderService (역방향 의존)
+  ├─ OrderController → OrderService → InventoryService · CouponService · PointService
+  ├─ PaymentController → PaymentService → PaymentTransactionHelper → OrderService
   │                                                                 └─ OutboxEventStore
   ├─ ShipmentController → ShipmentService
   ├─ RefundController → RefundService → PaymentService
@@ -36,456 +35,46 @@ Client
 
 ---
 
-## 🔴 긴급 — 금전 손실·데이터 정합성 (즉시 수정)
-
----
-
-## 🟠 중요 — 보안·운영 안정성 (운영 전 권장)
-
----
-
-## 🟡 중장기 개선
-
----
-
-### 51. `OrderService` God Object — 단일 서비스에 책임 과다
-
-**위치**: `domain/order/service/OrderService.java` (430줄)
-
-**문제**: 주문 생성·조회·취소·상태 이력·페이지네이션·쿠폰·포인트·재고·배송지 검증을 단일 클래스가 담당. 테스트 시 Mock이 10개 이상 필요.
-
-**개선 방향**: `OrderQueryService`(조회), `OrderCommandService`(생성·취소), `OrderValidationService`(검증) 분리.
-
----
-
-### 13. 오프셋 페이지네이션 성능 한계
-
-**위치**: 주문 목록, 재고 이력, 리뷰 등 `Pageable` 엔드포인트
-
-**문제**: `LIMIT ? OFFSET ?`는 페이지 번호가 클수록 앞 레코드를 모두 스캔 후 버림. 대량 이력 보유 사용자의 마지막 페이지 조회 시 풀스캔.
-
-**개선**: `WHERE id < :lastId LIMIT ?` 커서 기반 페이지네이션 전환.
-
----
-
-### 41. `DECIMAL` precision 불일치 — `DECIMAL(19,2)` vs `DECIMAL(12,2)`
-
-**위치**: `V13`, `V21`, `V15` 마이그레이션
-
-**문제**: 같은 금액 컬럼이 두 precision으로 혼재. `orders.total_amount(12,2)`와 `coupons.discount_value(19,2)` 비교 시 묵시적 캐스팅 발생.
-
-**개선**: `DECIMAL(15,2)`로 통일 (최대 999억원 지원).
-
----
-
-
-### 67. `DailyOrderStatsScheduler` — 4개 개별 쿼리 → 단일 GROUP BY 통합 가능
-
-**위치**: `domain/order/scheduler/DailyOrderStatsScheduler.java:44-49`
-
-**문제**: 전일 통계를 4개 별도 쿼리로 집계한다.
-
-```java
-countByCreatedAtBetween(start, end)                        // SELECT COUNT(*)
-countByStatusAndCreatedAtBetween(CONFIRMED, start, end)    // SELECT COUNT(*)
-countByStatusAndCreatedAtBetween(CANCELLED, start, end)    // SELECT COUNT(*)
-sumRevenueByCreatedAtBetween(start, end)                   // SELECT SUM(total_amount)
-```
-
-`OrderRepository`에 이미 `findOrderStats()` GROUP BY 메서드가 있지만 날짜 범위 파라미터가 없어 미사용.
-
-**개선**: `findOrderStats(start, end)` — `WHERE created_at BETWEEN :start AND :end GROUP BY status` 단일 쿼리로 count·revenue를 한 번에 조회.
-
----
-
-### 68. `InventorySnapshotScheduler` — `Page<T>` COUNT 중복 쿼리 → `Slice<T>` 전환
-
-**위치**: `domain/inventory/scheduler/InventorySnapshotScheduler.java:50`
-
-**문제**: `inventoryRepository.findAll(PageRequest.of(pageNum, PAGE_SIZE))`는 매 페이지마다 `SELECT COUNT(*) FROM inventory` 쿼리를 추가로 실행한다. `totalElements`는 첫 번째 페이지에서만 사용하므로 나머지 페이지의 COUNT 쿼리는 불필요한 오버헤드다.
-
-**개선**: `Page<T>` → `Slice<T>` 전환. 또는 `id > :lastId LIMIT n` 커서 쿼리로 교체.
-
----
-
-### 69. `PaymentService.getByOrderId()` — 소유권 체크에 전체 Order 엔티티 로드
-
-**위치**: `domain/payment/service/PaymentService.java:308`
-
-**문제**: USER 소유권 검증 시 `orderRepository.findById(orderId)`로 Order 전체 엔티티를 로드한다. 목적은 `order.getUserId()` 스칼라 값 추출뿐. `ShipmentService.getByOrderId()`는 이미 `findUserIdById()` 프로젝션으로 해결했으나 미적용.
-
-**개선**: `orderRepository.findUserIdById(orderId)` 스칼라 쿼리로 교체.
-
----
-
-### 70. `CartService.addOrUpdate()` — 응답 구성용 전체 장바구니 재조회
-
-**위치**: `domain/order/cart/service/CartService.java:92`
-
-**문제**: 항목 추가·수량 변경 후 `return getCart(userId)`를 호출한다. `getCart()`는 내부에서 `findByUserId()` + `findAllByProductIdIn()` 2개 쿼리를 추가로 실행한다.
-
-**개선**: 변경된 CartItem 상태를 in-memory로 응답에 반영하거나, 클라이언트가 별도 GET으로 최신 장바구니를 조회하게 분리.
-
----
-
-### 74. `PointService.refundByOrder()` — 포인트 미사용 주문도 항상 `SELECT FOR UPDATE`
-
-**위치**: `domain/point/service/PointService.java:147-148`
-
-**문제**: `getOrCreate(userId)`가 메서드 진입 직후 호출되어, 주문에 `USE`/`EARN` 트랜잭션이 없어도 항상 `SELECT ... FOR UPDATE`를 실행한다. 포인트 계정이 없으면 빈 `UserPoint` 레코드(ghost record)를 새로 INSERT한다.
-
-**개선**: `pointTransactionRepository.findByOrderId(orderId)`를 먼저 실행하고, 결과가 비어 있으면 early return.
-
----
-
-### 75. `RefundService` — `userRepository.findByUsername()` DB round-trip
-
-**위치**: `domain/refund/service/RefundService.java:60`, `:114`, `:124`
-
-**문제**: `requestRefund()`, `getById()`, `getByPaymentId()` 세 메서드 모두 `userRepository.findByUsername(username)`으로 User 엔티티 전체를 로드한다. 목적은 `user.getId()`(Long) 하나뿐이며, JWT 클레임에서 추출한 userId를 파라미터로 받으면 DB 조회 없이 처리 가능하다.
-
-**개선**: 시그니처를 `(String username)` → `(Long userId)`로 변경. 컨트롤러에서 `resolveUserId()` 헬퍼로 JWT claim 추출.
-
----
-
-
-### 76. `PaymentTransactionHelper.loadAndValidateForCancel()` — 소유권 체크에 전체 Order 엔티티 로드
-
-**위치**: `domain/payment/service/PaymentTransactionHelper.java:273`
-
-**문제**: USER 소유권 검증 시 `orderRepository.findById(payment.getOrderId())`로 Order 엔티티 전체를 로드한다. `order.getUserId()` 스칼라 값만 필요하며, `findUserIdById()` 스칼라 프로젝션이 이미 존재한다.
-
-**개선**: `orderRepository.findUserIdById(payment.getOrderId())` 스칼라 쿼리로 교체.
-
----
-
-### 71. `OrderService.getHistory()` — 소유권 체크에 전체 Order 엔티티 로드
-
-**위치**: `domain/order/service/OrderService.java:291`
-
-**문제**: `historyRepository.findByOrderIdOrderByCreatedAtAsc(orderId)` 호출 전 소유권 검증을 위해 `orderRepository.findById(orderId)`로 전체 Order 엔티티를 로드한다. items 컬렉션은 이 흐름에서 사용하지 않는다.
-
-**개선**: `findUserIdById()` 스칼라 프로젝션으로 교체 (#49, #69와 동일 패턴).
-
----
-
-### 25. API 버전 관리 부재
-
-**위치**: 모든 컨트롤러 (`/api/products`, `/api/orders` 등)
-
-**문제**: 버전 prefix 없이 `/api/` 직접 사용. 응답 스키마 변경 시 하위 호환성 관리 불가.
-
-**개선**: `/api/v1/` prefix 도입.
-
----
-
-
-### 101. `OutboxEventPurgeScheduler` — 대량 삭제 시 단일 트랜잭션 테이블 잠금
-
-**위치**: `common/outbox/OutboxEventPurgeScheduler.java:33-36`
-
-**문제**: `@Transactional` + `DELETE WHERE publishedAt < :before`가 단일 트랜잭션. 7일간 수만~수십만 건이면 장시간 잠금으로 relay/INSERT 블로킹.
-
-**개선**: 1,000건 단위 배치 삭제 루프 전환.
-
----
-
-### 103. 커서 스크롤 `size` 파라미터 상한 미검증
-
-**위치**: `domain/order/controller/OrderController.java:133`, `domain/inventory/controller/InventoryController.java:82`
-
-**문제**: `@RequestParam(defaultValue = "20") int size`에 `@Max` 제약 없음. `size=1000000` 전달 시 메모리 과다 사용 및 DB 부하.
-
-**개선**: `@Min(1) @Max(100)` 범위 제약 추가.
-
----
-
-### 104. `resolveUserId()` 헬퍼 6개 컨트롤러에 동일 코드 복붙
-
-**위치**: `ProductController`, `ReviewController`, `WishlistController`, `ShipmentController`, `RefundController`, `CartController`
-
-**문제**: JWT details에서 userId 추출하는 동일한 4줄 메서드가 6곳에 copy-paste.
-
-**개선**: `SecurityUtils`에 유틸리티 메서드 추출. 또는 `HandlerMethodArgumentResolver`로 `@CurrentUserId Long userId` 어노테이션 자동 주입.
-
----
-
-
-### 106. `CartRepository.deleteByUserId()` — N+1 DELETE 쿼리
-
-**위치**: `domain/order/cart/repository/CartRepository.java:25,28`
-
-**문제**: Spring Data JPA 파생 삭제 메서드는 SELECT 후 건별 DELETE. 장바구니 10개 상품 → 11개 쿼리.
-
-**개선**: `@Modifying @Query("DELETE FROM CartItem c WHERE c.userId = :userId")` 벌크 DELETE.
-
----
-
-### 107. `AdminController.updateRole()` — 마지막 ADMIN 자기 해제 시 ADMIN 0명
-
-**위치**: `domain/admin/controller/AdminController.java:68-72`
-
-**문제**: 유일한 ADMIN이 자기를 USER로 변경하면 시스템에 ADMIN이 0명. DB 직접 조작 외 복구 불가.
-
-**개선**: 현재 ADMIN 수 체크하여 마지막 ADMIN 권한 해제 차단.
-
----
-
-### 108. `ChangePasswordRequest` — 현재/신규 비밀번호 동일 허용
-
-**위치**: `domain/user/service/UserService.java:167-176`
-
-**문제**: 같은 비밀번호로 변경 시 Refresh Token 전체 폐기(`revokeAll`) 부작용만 발생하고 보안 개선 없음.
-
-**개선**: `currentPassword.equals(newPassword)` 동일 비밀번호 변경 차단.
-
----
-
-### 109. `Inventory` 엔티티/서비스 간 방어 로직 불일치
-
-**위치**: `domain/inventory/entity/Inventory.java:133-135` vs `domain/inventory/service/InventoryService.java:209-215`
-
-**문제**: 서비스에서 `reserved < quantity` 시 예외를 던지지만, 엔티티의 `releaseReservation()`은 `Math.max(0, reserved - quantity)`로 음수를 조용히 0으로 클램핑. 다른 호출 경로 추가 시 데이터 불일치를 조용히 삼킬 수 있다. `confirmAllocation()`도 동일 (#117 참조).
-
-**개선**: 엔티티 메서드가 자체적으로 `quantity > reserved` 시 예외를 던지도록 통일. `Math.max(0, ...)` 클램핑 제거.
-
----
-
-### 126. `Inventory` 엔티티 — `reserve/release/confirm`에 `quantity <= 0` 검증 없음
-
-**위치**: `domain/inventory/entity/Inventory.java:121-156`
-
-**문제**: `receive()`는 `quantity <= 0` 검증이 있지만, `reserve()`, `releaseReservation()`, `confirmAllocation()`, `releaseAllocation()`에는 없다. `reserve(productId, -5)` 호출 시 reserved가 감소하여 가용 재고가 허위로 증가. 현재는 DTO `@Min(1)` 검증이 간접 방어하지만, Entity 자체 방어 없음.
-
-**개선**: 모든 뮤테이션 메서드에 `if (quantity <= 0) throw IllegalArgumentException` 가드 추가.
-
----
-
-### 127. `InventoryReceiveRequest` / `InventoryAdjustRequest` — `note` `@Size` 누락
-
-**위치**: `domain/inventory/dto/InventoryReceiveRequest.java:22`, `InventoryAdjustRequest.java:20`
-
-**문제**: `note` 필드에 `@Size(max=255)` 없음. `InventoryTransaction.note`는 `@Column(length=255)`. 초과 시 DB 에러.
-
-**개선**: `@Size(max = 255)` 추가.
-
----
-
-### 128. `InventorySpecification` — LIKE 와일드카드 미이스케이프
-
-**위치**: `domain/inventory/repository/InventorySpecification.java:58-60,68-70`
-
-**문제**: 사용자 입력을 `"%" + input + "%"` 로 직접 LIKE 패턴에 결합. `%`, `_` 특수문자를 이스케이프하지 않아 `productName=%%%` 입력 시 전체 테이블 매칭. SQL injection은 아니지만 DoS 벡터.
-
-**개선**: `%`와 `_`를 `\\%`, `\\_`로 이스케이프하는 유틸리티 적용.
-
----
-
-
-### 130. 주문 생성 시 포인트+쿠폰 초과 할인 미검증
-
-**위치**: `domain/order/service/OrderService.java:172-212`
-
-**문제**: 쿠폰 할인 + 포인트가 totalAmount를 초과해도 `getPayableAmount()`가 `max(0, ...)`으로 0 클램핑만 한다. 10,000원 상품에 5,000원 쿠폰 + 8,000포인트 적용 시 실제 필요한 포인트는 5,000인데 8,000이 차감된다. 취소 시 8,000 포인트가 환불되므로 결과적으로는 정상이지만, "결제 금액 0원" 주문이 생성되어 Toss 결제 없이 자동 확정되는 로직이 없으면 만료 취소된다.
-
-**개선**: `usePoints`가 `totalAmount - couponDiscount`를 초과하면 에러 반환 또는 초과분 자동 잘라내기.
-
----
-
-### 131. `CartService.addOrUpdate()` — 동시 호출 시 중복 CartItem 생성
-
-**위치**: `domain/order/cart/service/CartService.java:79-92`
-
-**문제**: `findByUserIdAndProductId()` 조회 후 `save()` 사이에 갭이 있어 같은 사용자가 같은 상품으로 동시 요청 시 UNIQUE 제약 위반 예외. 500 에러 반환.
-
-**개선**: `DataIntegrityViolationException` catch 후 update fallback. 또는 비관적 락.
-
----
-
-### 132. `OrderRepository` 통계 쿼리 범위 불일치
-
-**위치**: `domain/order/repository/OrderRepository.java:145,148-151`
-
-**문제**: `countByCreatedAtBetween`은 Spring Data BETWEEN (end inclusive), `countByStatusAndCreatedAtBetween`은 `@Query`로 `< :end` (end exclusive). `end = yesterday.atTime(LocalTime.MAX)`이므로 실질 차이는 미미하지만 의도가 불일치.
-
-**개선**: 두 쿼리를 `>= start AND < end`로 통일, end를 `today.atStartOfDay()`로 전달.
-
----
-
-### 133. `PaymentService.handleWebhook()` — JSON 파싱 실패 시 500 반환
-
-**위치**: `domain/payment/controller/PaymentController.java:86`
-
-**문제**: `objectMapper.readValue()` 실패 시 500 반환. Toss는 비-2xx 응답에 재시도하므로, malformed payload에 대해 최대 7회 불필요한 재시도를 받는다.
-
-**개선**: `JsonProcessingException` catch 후 로그 남기고 200 반환.
-
----
-
-### 111. `RefundRequest.reason` 길이 검증 없음
-
-**위치**: `domain/refund/dto/RefundRequest.java:15`
-
-**문제**: `@NotBlank`만 있고 `@Size(max=300)` 없음. `Refund.reason` 컬럼은 `length=300`이므로 초과 입력 시 DB truncation 에러.
-
-**개선**: `@Size(max = 300)` 추가.
-
-### 144. `CouponCreateRequest` — PERCENTAGE 타입 `discountValue` 상한 미검증
-
-**위치**: `domain/coupon/dto/CouponCreateRequest.java`
-
-**문제**: `@DecimalMin("0.01")` + `@DecimalMax("999999999")`로 FIXED_AMOUNT와 PERCENTAGE를 동일하게 검증한다. PERCENTAGE 쿠폰에 `discountValue=500`을 설정하면 500% 할인이 저장된다. 서비스 레벨에서 `discountValue > 100` 체크가 있지만, DTO 검증과 이중 검증이 불일치.
-
-**개선**: `CouponService.create()`에서 PERCENTAGE 시 `0 < discountValue <= 100` 검증 강화. 또는 커스텀 `@Valid` 그룹으로 타입별 DTO 분리.
-
----
-
-### 145. `UserPoint` 엔티티 — `earn()/use()/refund()` 메서드에 `amount <= 0` 검증 없음
-
-**위치**: `domain/point/entity/UserPoint.java:46-61`
-
-**문제**: `earn()`, `use()`, `refund()` 모든 뮤테이션 메서드에 `amount <= 0` 가드가 없다. `Inventory` 엔티티의 `receive()`에는 검증이 있지만(#126과 동일 패턴) `UserPoint`에는 없다. `use(-100)` 호출 시 `balance -= (-100)` → 잔액 증가.
-
-**개선**: 모든 뮤테이션 메서드에 `if (amount <= 0) throw new IllegalArgumentException` 가드 추가.
-
----
-
-### 146. `PointTransaction` — `(order_id, type)` 복합 UNIQUE 제약 부재
-
-**위치**: `domain/point/repository/PointTransactionRepository.java`, Flyway 마이그레이션
-
-**문제**: `PointService.earn()`이 `existsByOrderIdAndType(orderId, EARN)`으로 멱등성을 체크하지만, DB 레벨 UNIQUE 제약이 없다. Outbox relay 재시도 등으로 두 스레드가 동시에 `exists()==false`를 받으면 둘 다 INSERT 성공 → 이중 적립. #114(주문 멱등성)과 동일 패턴.
-
-**개선**: Flyway 마이그레이션에서 `ALTER TABLE point_transactions ADD UNIQUE INDEX uk_order_type (order_id, type)` 추가. `DataIntegrityViolationException` catch 후 early return.
-
----
-
-### 147. `CouponService` — 쿠폰 적용·반환 로깅 부재
-
-**위치**: `domain/coupon/service/CouponService.java`
-
-**문제**: `applyCoupon()`, `releaseCoupon()`, `claim()` 등 주요 비즈니스 메서드에 로그가 없다. 쿠폰 남용·이상 사용 패턴 감지 및 감사(audit) 추적이 불가능.
-
-**개선**: 주요 메서드에 `log.info()` 추가 — userId, couponCode, orderId, discountAmount 포함.
-
----
-
-### 148. `PointService.refundByOrder()` — 부분 회수 시 모니터링 불가
-
-**위치**: `domain/point/service/PointService.java:168-186`
-
-**문제**: `actualReclaim = Math.min(reclaimAmount, balance)`로 잔액 부족 시 부분 회수만 하고 WARN 로그만 남긴다. 환불은 성공으로 처리되지만 사용자에게 포인트가 전액 복구되지 않는다. 로그만으로는 운영 모니터링·대시보드 집계가 어렵다.
-
-**개선**: 부분 회수 발생 시 별도 메트릭(`point.partial_reclaim`) 발행. 또는 Prometheus 카운터로 누적.
-
-### 149. `ProductDocument.toProductResponse()` — ES 검색 결과에 재고·리뷰 통계 누락
-
-**위치**: `domain/product/document/ProductDocument.java:79-90`
-
-**문제**: ES 검색 결과에서 `availableQuantity`, `avgRating`, `reviewCount`가 null로 반환된다. MySQL `getById()` 응답에는 이 필드가 채워져 있어, 동일 API(`GET /api/products`)가 ES/MySQL 중 어디서 조회되느냐에 따라 응답 구조가 달라진다. 프론트엔드가 null 방어 처리를 해야 한다.
-
-**개선**: ProductDocument에 해당 필드 추가 후 색인 시 DB에서 채우기. 또는 ES 검색 결과에 대해 DB 보강 쿼리 추가(배치 조회).
-
----
-
-### 150. `CategoryService.getById()` — `@Cacheable` 누락
-
-**위치**: `domain/product/category/service/CategoryService.java`
-
-**문제**: `getList()`와 `getTree()`에는 `@Cacheable`이 있지만 `getById()`에는 없다. 단건 조회 시마다 DB에서 children 로드 + `countActiveProductsByCategoryIds()` 배치 쿼리 2회 실행. 상품 상세 페이지에서 카테고리 정보를 반복 조회할 때 불필요한 DB 히트.
-
-**개선**: `@Cacheable(cacheNames="categories", key="'id_'+#id")` 추가. `update()`/`delete()`의 `@CacheEvict`에 해당 키도 무효화.
-
----
-
-
-### 154. `ReviewCreateRequest` / `ReviewUpdateRequest` — `content` `@Size` 누락
-
-**위치**: `domain/product/review/dto/ReviewCreateRequest.java`, `ReviewUpdateRequest.java`
-
-**문제**: `content` 필드에 `@NotBlank`만 있고 `@Size(max)` 없음. `Review.content`는 `@Column(columnDefinition="TEXT")`로 DB 레벨 제약이 느슨하다. 수십 MB 문자열 전송 시 메모리 과다 사용.
-
-**개선**: `@Size(max = 5000)` 추가.
-
----
-
-
-### 157. 탈퇴 사용자 리뷰 — username null 노출
-
-**위치**: `domain/product/review/service/ReviewService.java`
-
-**문제**: 사용자 탈퇴(soft delete) 시 `userRepository.findAllById()`가 `@SQLRestriction`으로 필터링하여 해당 사용자를 반환하지 않는다. `usernameMap.get(userId)`가 null → `maskUsername(null)` → null 반환. 클라이언트에 `"username": null` 노출.
-
-**개선**: `usernameMap`에서 userId를 찾을 수 없으면 `"[탈퇴사용자]"` 기본값으로 대체.
-
----
-
-### 158. `ProductCreateRequest` / `ProductUpdateRequest` — `description` `@Size` 누락
-
-**위치**: `domain/product/dto/ProductCreateRequest.java`, `ProductUpdateRequest.java`
-
-**문제**: `description` 필드에 `@Size(max)` 없음. `Product.description`은 `@Column(columnDefinition="TEXT")`로 무제한. 수십 MB 설명 전송 시 메모리·DB 오���헤드.
-
-**개선**: `@Size(max = 10000)` 추��.
-
-
-## ⚪ 보류 — 판단 필요 또는 인프라 의존
-
----
-
-### 43. 대시보�� GROUP BY — `daily_order_stats` 미활용
-
-**위치**: `OrderRepository.findOrderStats()`, `AdminService.getDashboard()`
-
-**문제**: `SELECT status, COUNT(*), SUM(totalAmount) FROM orders GROUP BY status` — 이미 `daily_order_stats` 집계 테이블이 있는데 미사용. 주문 누적 시 응답 지연.
-
-**개선**: 대시보드 통계를 `daily_order_stats` + 당일 live 집계 조합으로 전환. 또는 Redis 캐시(5분 TTL).
-
-> **보류 이유**: 어드민 전용 기능이고 현재 데이터 규모에서 성능 문제 없음. 운영 후 모니터링으로 판단.
-
----
-
-### 53. `ProductService` ES Fallback — MySQL LIKE 검색으로 결과 불일치
-
-**위치**: `domain/product/service/ProductService.java` `getList()`
-
-**문제**: ES 장애 시 MySQL `LIKE '%keyword%'` fallback이 ES 형태소 분석 결과와 전혀 다른 결과를 반환. UX 불일치.
-
-**보류 이유**: 빈 결과 반환 vs LIKE fallback 유지 중 어느 쪽이 나은지는 제품 결정 사항.
-
----
-
-### 20. 리드 레플리카 라우팅 미적용
-
-**위치**: 전체 `@Transactional(readOnly = true)` 쿼리
-
-**보류 이유**: Replica 인프라 없이 코드만으로 완결 불가. Aurora Reader Endpoint 또는 `AbstractRoutingDataSource` 도입 시 재검토.
-
----
-
-### 16. `OrderExpiryScheduler` 순차 취소 → 배치 처리
-
-**위치**: `domain/order/scheduler/OrderExpiryScheduler.java`
-
-**보류 이유**: 만료 주문 건수가 적은 초기 운영 단계에서는 현행 유지. 100건 초과 시 벌크 UPDATE 전환 검토.
-
----
-
-### 15. `AdminService.getOrders()` 사용자명 조회
-
-**위치**: `domain/admin/service/AdminService.java`
-
-**보류 이유**: 이미 `findAllById()` 단일 IN 쿼리. 현재 규모에서 심각도 낮음.
-
----
-
-## ~~조치 불필요~~
-
----
-
-| # | 항목 | 판단 근거 |
-|---|------|-----------|
-| ~~60~~ | Toss Webhook Replay Attack | 일반 결제 웹훅에 타임스탬프 헤더 없음. `PaymentIdempotencyManager` + 상태 전이 검증으로 충분. |
-| ~~61~~ | CSP `unsafe-inline` | REST API 서버 — HTML 직접 렌더링 없음. `/admin-ui`(SBA)가 인라인 스크립트 의존하여 제거 불가. |
-| ~~65~~ | `GlobalExceptionHandler` 예외 메시지 노출 | 폴백 핸들러가 `ErrorCode.INTERNAL_SERVER_ERROR.getMessage()` 고정 메시지만 반환. 이미 올바르게 구현됨. |
-| ~~90~~ | `EmailService.buildItemsTable()` LazyInitializationException | `OrderRepository.findByIdWithItems()`에 `JOIN FETCH i.product` 이미 포함 — 발생 불가. |
+## Open Issues
+
+### 🔴 긴급 — 금전 손실·데이터 정합성
+
+| Issue | 항목 |
+|-------|------|
+| [#89](https://github.com/nameless0422/stock-management-api/issues/89) | RefundService.getByPaymentId() 부분 취소 다건 환불 시 500 에러 |
+| [#90](https://github.com/nameless0422/stock-management-api/issues/90) | cancelPendingOrdersByUser() 탈퇴 시 주문 취소 실패로 전체 롤백 |
+| [#91](https://github.com/nameless0422/stock-management-api/issues/91) | PointService.refundByOrder() uk_point_txn_order_type 충돌 미처리 |
+
+### 🟠 중요 — 보안·운영 안정성
+
+| Issue | 항목 |
+|-------|------|
+| [#92](https://github.com/nameless0422/stock-management-api/issues/92) | AdminSecurityConfig 기본값 검증 AND 조건 취약 |
+| [#93](https://github.com/nameless0422/stock-management-api/issues/93) | swagger.public 기본값 true — 운영 시 API 명세 공개 |
+| [#94](https://github.com/nameless0422/stock-management-api/issues/94) | /actuator/prometheus 인증 없이 공개 |
+| [#95](https://github.com/nameless0422/stock-management-api/issues/95) | ProductCreateRequest/ProductUpdateRequest name @Size 누락 |
+| [#96](https://github.com/nameless0422/stock-management-api/issues/96) | ChangePasswordRequest 현재/신규 비밀번호 동일 허용 |
+
+### 🟡 중장기 개선
+
+| Issue | 항목 |
+|-------|------|
+| [#14](https://github.com/nameless0422/stock-management-api/issues/14) | OrderService God Object 분리 |
+| [#97](https://github.com/nameless0422/stock-management-api/issues/97) | PaymentService.getByOrderId() 스칼라 프로젝션 미전환 |
+| [#98](https://github.com/nameless0422/stock-management-api/issues/98) | Pageable max-page-size 전역 설정 부재 |
+| [#99](https://github.com/nameless0422/stock-management-api/issues/99) | resolveUserId() 4개 컨트롤러 JWT details 미활용 |
+| [#100](https://github.com/nameless0422/stock-management-api/issues/100) | CouponCreateRequest PERCENTAGE DTO 레벨 검증 부재 |
+| [#101](https://github.com/nameless0422/stock-management-api/issues/101) | CouponService ADMIN 연산 감사 로깅 부재 |
+| [#47](https://github.com/nameless0422/stock-management-api/issues/47) | ES 검색 결과에 재고·리뷰 통계 누락 |
+| [#15](https://github.com/nameless0422/stock-management-api/issues/15) | 오프셋 페이지네이션 → 커서 기반 전환 |
+| [#22](https://github.com/nameless0422/stock-management-api/issues/22) | API 버전 관리 부재 — /api/v1/ prefix 도입 |
+
+### ⚪ 보류
+
+| Issue | 항목 | 보류 이유 |
+|-------|------|-----------|
+| [#62](https://github.com/nameless0422/stock-management-api/issues/62) | 대시보드 daily_order_stats 미활용 | 현 규모 성능 문제 없음 |
+| [#63](https://github.com/nameless0422/stock-management-api/issues/63) | ES Fallback MySQL LIKE 불일치 | 제품 결정 사항 |
+| [#64](https://github.com/nameless0422/stock-management-api/issues/64) | 리드 레플리카 라우팅 | 인프라 의존 |
+| [#65](https://github.com/nameless0422/stock-management-api/issues/65) | OrderExpiryScheduler 배치 전환 | 초기 운영 현행 유지 |
+| [#66](https://github.com/nameless0422/stock-management-api/issues/66) | AdminService.getOrders() 사용자명 | 심각도 낮음 |

--- a/docs/reviewPlan.md
+++ b/docs/reviewPlan.md
@@ -1,7 +1,8 @@
-# 코드 리뷰 계획
+# 코드 리뷰 계획 (최종)
 
 > 도메인별로 리뷰 범위·체크리스트·미해결 TODO 항목을 정리한다.
 > 완료된 개선 사항은 `docs/IMPROVEMENTS.md` 참조.
+> Phase 1~6 리뷰 완료. Phase 7 리뷰 완료 — 22개 해결 확인, 7개 신규 발견.
 
 ---
 
@@ -16,229 +17,119 @@
 
 ---
 
-## ~~Phase 1 — 핵심 트랜잭션 (P0~P1)~~ ✅ 리뷰 완료
+## 이전 리뷰 요약 (Phase 1~6 완료)
 
-> Payment·Order·Inventory 3개 도메인 리뷰 완료.
-> 발견된 항목은 `docs/TODO.md` #113~#133에 반영됨.
+| Phase | 범위 | 상태 |
+|-------|------|------|
+| ~~1~~ | 핵심 트랜잭션 (Payment, Order, Inventory) | ✅ 완료 → TODO #113~#133 |
+| ~~2~~ | 보안·인증 (Security, User) | ✅ 완료 → TODO #134~#143 |
+| ~~3~~ | 부가 도메인 (Coupon, Refund, Shipment, Point) | ✅ 완료 → TODO #144~#148 |
+| ~~4~~ | 상품·카탈로그 (Product, Category, Image, Review, Wishlist) | ✅ 완료 → TODO #149~#158 |
+| ~~5~~ | 공통 인프라 (Outbox, Exception, Cache, RateLimit) | ✅ 완료 → TODO #159~#161 |
+| ~~6~~ | DB·코드 품질 (Flyway, Admin, 크로스커팅) | ✅ 완료 → TODO #162~#163 |
 
----
-
-## ~~Phase 2 — 보안·인증 (P0~P1)~~ ✅ 리뷰 완료
-
-> Security/JWT/Auth + User 도메인 리뷰 완료.
-> 발견된 항목은 `docs/TODO.md` #134~#143에 반영됨.
-> 기존 항목 #83, #47, #96, #105, #108, #42는 리뷰에서 재확인됨.
-
----
-
-## ~~Phase 3 — 부가 도메인 (P1~P2)~~ ✅ 리뷰 완료
-
-> Coupon·Refund·Shipment·Point 4개 도메인 리뷰 완료.
-> 발견된 항목은 `docs/TODO.md` #144~#148에 반영됨.
-> 기존 항목 #45, #74, #75, #79, #111은 리뷰에서 재확인됨.
-
-### 3-1. Coupon — 리뷰 결과
-
-| 체크항목 | 결과 |
-|---------|------|
-| 동시성 (비관적 락) | ✅ `findByCodeWithLock` + 분산 락 이중 보호. usageCount 정합성 확보 |
-| 주문 취소 쿠폰 반환 | ✅ `releaseCoupon()` 호출 경로 정상. 비관적 락으로 decreaseUsage 직렬화 |
-| 만료 스케줄러 | ✅ `deactivateExpiredCoupons()` 벌크 UPDATE. 새벽 1시 실행으로 영향도 낮음 |
-| PERCENTAGE 상한 | ⚠️ 서비스에 >100 체크 있으나 DTO 검증과 불일치 → **#144** |
-
-**신규 TODO**: #144 (PERCENTAGE 상한 DTO 검증), #147 (로깅 부재)
-
-### 3-2. Refund — 리뷰 결과
-
-| 체크항목 | 결과 |
-|---------|------|
-| 소유권 검증 | ✅ ADMIN bypass + 일반 사용자 order.userId 검증 정상 |
-| FAILED 재시도 | ✅ `reset(reason)` 기존 레코드 재사용 정상 동작 |
-| noRollbackFor | ✅ `Exception.class`로 FAILED Dirty Checking 보장 |
-
-**기존 미해결**: #45 (UNIQUE 제약), #75 (userId 직접 전달), #111 (@Size 누락)
-**신규 발견**: 없음 (코드 품질 양호)
-
-### 3-3. Shipment — 리뷰 결과
-
-| 체크항목 | 결과 |
-|---------|------|
-| REQUIRES_NEW 독립 커밋 | ✅ 설계 정확 |
-| 상태 전이 유효성 | ✅ 잘못된 상태에서 INVALID_SHIPMENT_STATUS 예외 |
-| DTO 입력 검증 | ✅ @Size, @Pattern 적용. XSS 방어(htmlEscape) 확인 |
-| 소유권 검증 | ✅ `findUserIdById()` 스칼라 프로젝션 사용 |
-
-**기존 미해결**: #79 (Outbox false dead letter)
-**신규 발견**: 없음 (핵심 설계 양호)
-
-### 3-4. Point — 리뷰 결과
-
-| 체크항목 | 결과 |
-|---------|------|
-| earn/use 전파 레벨 | ✅ earn: REQUIRES_NEW, use: REQUIRED 설계 적절 |
-| 이중 적립 방어 | ⚠️ `existsByOrderIdAndType()` 앱 레벨만 — DB UNIQUE 없음 → **#146** |
-| 환불 포인트 회수 | ⚠️ 부분 회수 시 모니터링 불가 → **#148** |
-| 엔티티 검증 | ⚠️ 뮤테이션 메서드 amount <= 0 가드 없음 → **#145** |
-
-**기존 미해결**: #74 (불필요한 SELECT FOR UPDATE)
-**신규 TODO**: #145 (엔티티 검증), #146 (UNIQUE 제약), #148 (부분 회수 모니터링)
+**전체 통계**: Phase 1~6에서 51개 항목 발견 (#113~#163), 647개 테스트 전체 통과.
 
 ---
 
-## ~~Phase 4 — 상품·카탈로그 (P2~P3)~~ ✅ 리뷰 완료
+## ~~Phase 7 — 미해결 TODO 정리 + 신규 발견~~ ✅ 리뷰 완료
 
-> Product·Category·ProductImage·Review·Wishlist 리뷰 완료.
-> 발견된 항목은 `docs/TODO.md` #149~#158에 반영됨.
-> 기존 항목 #53, #104는 리뷰에서 재확인됨.
-
-### 4-1. Product 핵심 — 리뷰 결과
-
-| 체크항목 | 결과 |
-|---------|------|
-| ES 검색 정확성 | ✅ multi_match, 가격 범위, 카테고리 필터 정상 |
-| MySQL fallback | ⚠️ ES/MySQL 응답 불일치 (#53 재확인) + sort만으로 ES 진입 → **#155** |
-| ES 동기화 타이밍 | ✅ `@TransactionalEventListener(AFTER_COMMIT)` 올바름 |
-| ES 검색 결과 응답 | ⚠️ 재고·리뷰 통계 null → MySQL 조회와 불일치 → **#149** |
-| DTO 검증 | ⚠️ description @Size 누락 → **#158** |
-
-### 4-2. Category — 리뷰 결과
-
-| 체크항목 | 결과 |
-|---------|------|
-| 카테고리 캐시 | ⚠️ `getById()` @Cacheable 누락 → **#150** |
-| 트리 조회 | ✅ in-memory 조립 O(n), parent LEFT JOIN FETCH N+1 방지 |
-| 삭제 제약 | ✅ CATEGORY_HAS_CHILDREN / PRODUCTS 검증 정상 |
-| 순환 참조 | ✅ 2단계 고정 구조이므로 직접 순환 방지만으로 충분 |
-
-### 4-3. ProductImage — 리뷰 결과
-
-| 체크항목 | 결과 |
-|---------|------|
-| MIME/확장자 검증 | ⚠️ contentType 형식 미검증 + 확장자-MIME 불일치 허용 → **#151** |
-| 이미지 개수 제한 | ⚠️ 상품당 무제한 → **#152** |
-| objectKey 보안 | ⚠️ 클라이언트 조작 가능 → **#153** |
-| S3 삭제 정합성 | ⚠️ 삭제 실패 시 DB 불일치 → **#156** |
-
-### 4-4. Review + Wishlist — 리뷰 결과
-
-| 체크항목 | 결과 |
-|---------|------|
-| 리뷰 구매 검증 | ✅ `orderRepository.existsConfirmedOrder()` 정상 |
-| 리뷰 중복 방지 | ✅ `existsByProductIdAndUserId()` 정상 |
-| content 검증 | ⚠️ @Size 누락 → **#154** |
-| 탈퇴 사용자 | ⚠️ username null 노출 → **#157** |
-| 위시리스트 N+1 | ✅ `findAllById()` + `findAllByProductIdIn()` 배치 조회 |
-
-**신규 TODO**: #149~#158 (10개)
-**기존 미해결**: #53 (ES fallback 불일치)
+> 기존 TODO.md 잔여 38개 항목 + 최신 코드 탐색.
+> **22개 해결 확인**, **11개 미해결 잔존**, **7개 신규 발견** → TODO #164~#170.
 
 ---
 
-## ~~Phase 5 — 공통 인프라 (P1~P3)~~ ✅ 리뷰 완료
+### 7-1. 데이터 정합성·트랜잭션 — 리뷰 결과
 
-> Outbox·예외처리·캐시/Redis·Rate Limit 4개 영역 리뷰 완료.
-> 발견된 항목은 `docs/TODO.md` #159~#161에 반영됨.
-> 기존 항목 #47, #83, #95, #101, #136, #137은 리뷰에서 재확인됨. #138은 완료 처리됨.
-
-### 5-1. Outbox 이벤트 — 리뷰 결과
-
-| 체크항목 | 결과 |
-|---------|------|
-| relay 분산 락 | ✅ `@DistributedLock(skipOnFailure=true)` 중복 relay 방지 정상 |
-| dead letter 알람 | ✅ Prometheus Gauge `outbox.dead_letters` 정상 노출 |
-| 지수 백오프 | ✅ `min(30 × 2^retryCount, 3600)` 연산 정확 |
-| Propagation.MANDATORY | ✅ 비즈니스 TX 바깥 호출 시 즉시 예외 |
-| processOne 멱등성 | ✅ `publishedAt != null` 체크로 이중 발행 방지 |
-| relayedCounter 정확성 | ⚠️ 실패 이벤트도 카운팅 → **#161** |
-
-**기존 미해결**: #101 (purge 대량 삭제 배치 전환)
-
-### 5-2. 예외 처리 / API 응답 — 리뷰 결과
-
-| 체크항목 | 결과 |
-|---------|------|
-| BusinessException | ✅ ErrorCode 기반 HTTP 상태 매핑 정확 |
-| MethodArgumentNotValid | ✅ 필드별 FieldErrorDetail 반환 |
-| IllegalArgumentException | ✅ 400 Bad Request |
-| DataIntegrityViolation | ✅ 409 Conflict, DB 구조 미노출 |
-| OptimisticLocking | ✅ 409 Conflict, 재시도 안내 |
-| NoResourceFound | ✅ 404 |
-| HttpMessageNotReadable | ✅ `@ExceptionHandler` 추가, 400 응답 (#95 해결) |
-| ErrorCode 체계 | ✅ 도메인별 그룹화, HTTP 상태 매핑 적절 |
-
-### 5-3. 캐시 / Redis — 리뷰 결과
-
-| 체크항목 | 결과 |
-|---------|------|
-| 직렬화 화이트리스트 | ✅ `allowIfBaseType` → `allowIfSubType` 전환 완료 (#57 해결) |
-| TTL 정책 | ✅ products 10분, inventory/orders 5분, categories 30분 적절 |
-| null 캐싱 | ✅ `disableCachingNullValues()` 적용 |
-| Redisson 연결 설정 | ✅ timeout(1000)/connectTimeout(1000)/retryAttempts(1)/poolSize(32) 완료 (#58 해결) |
-| RefreshTokenStore | ✅ revokeAll Lua 원자화 (#137 해결), consume() 탈취 감지 (#136 해결) |
-
-### 5-4. Rate Limit — 리뷰 결과
-
-| 체크항목 | 결과 |
-|---------|------|
-| Lua 원자성 | ✅ INCR + EXPIRE 원자적 처리 정상 |
-| trust-proxy 설정 | ✅ false 시 헤더 무시, true 시 X-Real-IP 우선 |
-| LoginRateLimiter | ✅ username+IP 복합 키로 Account Lockout DoS 방지 (#83 해결) |
-| X-Forwarded-For IP | ✅ `trusted-proxy-count=1` 적용, 클라이언트 IP 올바르게 추출 (#47 해결) |
-| /api/auth/refresh | ✅ Rate Limit 적용 완료 (#138 완료) |
+| # | 항목 | 결과 |
+|---|------|------|
+| ~~130~~ | 포인트+쿠폰 초과 할인 미검증 | ✅ **해결** — 명시적 예외로 차단 |
+| ~~146~~ | PointTransaction UNIQUE 제약 부재 | ✅ **해결** — V41 마이그레이션 적용 |
+| ~~131~~ | CartService.addOrUpdate() 동시 500 | ✅ **해결** — DataIntegrityViolationException catch |
+| ~~109~~ | Inventory releaseReservation 음수 클램핑 | ✅ **해결** — 상태 불일치 예외로 강화 |
+| ~~126~~ | Inventory amount ≤ 0 미검증 | ✅ **해결** — 5개 메서드 모두 가드 추가 |
+| ~~145~~ | UserPoint amount ≤ 0 미검증 | ✅ **해결** — 3개 메서드 가드 추가 |
+| **164** | RefundService.getByPaymentId() 다건 환불 500 | ❌ **신규** — `findByPaymentId()` 단건 → 부분 취소 2회+ 시 500 |
+| **165** | cancelPendingOrdersByUser() 전체 롤백 | ❌ **신규** — deactivate 트랜잭션 전파로 N번째 실패 시 전체 롤백 |
+| **166** | PointService.refundByOrder() UK 충돌 미처리 | ❌ **신규** — V41 UNIQUE 추가 후 멱등성 체크 누락 |
 
 ---
 
-## ~~Phase 6 — DB·인프라·코드 품질 (P2~P3)~~ ✅ 리뷰 완료
+### 7-2. 보안 — 리뷰 결과
 
-> Flyway·Admin·크로스커팅 3개 영역 리뷰 완료.
-> 발견된 항목은 `docs/TODO.md` #162~#163에 반영됨.
-> 기존 항목 #41, #59, #62, #107, #43, #104, #25, #13, #103, #128은 리뷰에서 재확인됨.
+| # | 항목 | 결과 |
+|---|------|------|
+| ~~107~~ | 마지막 ADMIN 강등 방지 | ✅ **해결** — `countByRole` 체크 + LAST_ADMIN ErrorCode |
+| 108 | 현재/신규 비밀번호 동일 허용 | ❌ **미수정** — DTO·서비스 모두 검증 없음 |
+| **167** | AdminSecurityConfig AND 조건 취약 | ❌ **신규** — username만 기본값이면 password 약해도 통과 |
+| **168** | swagger.public 기본값 true | ❌ **신규** — properties 미설정 → 항상 공개 |
+| **169** | /actuator/prometheus 인증 없이 공개 | ❌ **신규** — 주석과 코드 불일치, permitAll() |
 
-### 6-1. Flyway 마이그레이션 — 리뷰 결과
+---
 
-| 체크항목 | 결과 |
-|---------|------|
-| DECIMAL precision | ✅ V40에서 `DECIMAL(15,2)` 통일 완료 (#41 해결) |
-| SSL/자격증명 | ✅ useSSL=false 주석 추가 (#59), DB 자격증명 환경변수 전환 (#62 해결) |
-| ENGINE/CHARSET 일관성 | ✅ V4/V9~V13/V15/V17/V22에 ENGINE/CHARSET 명시 완료 (#63 해결) |
-| 인덱스 전략 | ✅ V23/V25/V27/V31 복합 인덱스 적절. orders.created_at, point_transactions 커버링 인덱스 추가됨 |
-| FK 제약 | ✅ V32에서 누락 FK 일괄 추가 완료 |
-| 타임스탬프 기본값 | ✅ V33에서 일괄 수정 완료 |
+### 7-3. DTO 입력 검증 — 리뷰 결과
 
-### 6-2. Admin 도메인 — 리뷰 결과
+| # | 항목 | 결과 |
+|---|------|------|
+| ~~111~~ | RefundRequest.reason @Size | ✅ **해결** |
+| ~~127~~ | InventoryReceiveRequest/AdjustRequest note @Size | ✅ **해결** |
+| ~~154~~ | ReviewCreateRequest/UpdateRequest content @Size | ✅ **해결** |
+| ~~158~~ | ProductCreateRequest/UpdateRequest description @Size | ✅ **해결** |
+| ~~128~~ | InventorySpecification LIKE 이스케이프 | ✅ **해결** |
+| 144 | CouponCreateRequest PERCENTAGE DTO 검증 | ⚠️ **부분** — 서비스 검증 있음, DTO 구멍 잔존 |
+| 103 | Pageable size 상한 | ⚠️ **부분** — 커서 해결, Pageable 11개 미해결 |
+| **170** | ProductCreateRequest/UpdateRequest name @Size 누락 | ❌ **신규** — 255자 초과 시 500 에러 |
 
-| 체크항목 | 결과 |
-|---------|------|
-| 마지막 ADMIN 보호 | ❌ `updateRole()`에 ADMIN 수 체크 없음 (#107 재확인) |
-| 대시보드 성능 | ✅ `findOrderStats()` GROUP BY 단일 쿼리 + `userRepository.count()` — 현재 규모 적정 |
-| 주문 목록 사용자명 | ✅ `findAllById()` 배치 IN 쿼리 — 심각도 낮음 |
-| 검색 LIKE | ✅ `ProductService`/`AdminService.escapeLike()` 유틸리티 추출 완료 (#60 해결) |
-| RoleUpdateRequest | ✅ `@NotNull UserRole role` 검증 정상 |
+---
 
-### 6-3. 크로스커팅 코드 품질 — 리뷰 결과
+### 7-4. 성능 최적화 — 리뷰 결과
 
-| 체크항목 | 결과 |
-|---------|------|
-| resolveUserId | ⚠️ 10개+ 컨트롤러로 확산 (#104 재확인, 기존 6개→10개+) |
-| Pageable 기본값 | ✅ 전 컨트롤러 `size=20, sort=createdAt, DESC` 일관적 |
-| API 버전 관리 | ⚠️ `/api/v1/` 미도입 (#25 재확인) |
-| 페이지네이션 | ⚠️ 오프셋 기반 (#13), size 상한 미검증 (#103) 재확인 |
+| # | 항목 | 결과 |
+|---|------|------|
+| 69 | PaymentService.getByOrderId() 전체 Order 로드 | ❌ **미수정** — 주석과 구현 불일치 |
+| ~~71~~ | OrderService.getHistory() 전체 Order 로드 | ✅ **해결** — findUserIdById() 프로젝션 |
+| 76 | PaymentTransactionHelper.loadAndValidateForCancel() | ⏸️ **보류** — 상태 변경 겸용으로 전체 로드 불가피 |
+| ~~74~~ | PointService.refundByOrder() SELECT FOR UPDATE | ✅ **해결** — early return |
+| ~~75~~ | RefundService username→userId | ✅ **해결** — Long userId 전환 |
+| ~~106~~ | CartRepository N+1 DELETE | ✅ **해결** — 벌크 DELETE |
+| ~~70~~ | CartService.addOrUpdate() 장바구니 재조회 | ✅ **해결** — 단건 응답 |
 
-**해결**: #60 (LIKE escape ProductService/AdminService), #61 (Flyway ENGINE/CHARSET), #62 (DB 자격증명), #41 (V40 DECIMAL 통일)
-**기존 미해결**: #107, #43, #104, #25, #13, #103, #128
+---
+
+### 7-5. 코드 품질 — 리뷰 결과
+
+| # | 항목 | 결과 |
+|---|------|------|
+| 51 | OrderService God Object | ⚠️ **부분** — OrderDetailService 분리, 본체 600+ 줄 잔존 |
+| 104 | resolveUserId() 복붙 | ⚠️ **부분** — SecurityUtils 도입, 4개 컨트롤러 미적용 |
+| 147 | CouponService 로깅 부재 | ⚠️ **부분** — 비즈니스 메서드 완료, ADMIN 연산 미흡 |
+| ~~148~~ | PointService 부분 회수 메트릭 | ✅ **해결** — Prometheus Counter |
+| ~~157~~ | 탈퇴 사용자 리뷰 null | ✅ **해결** — `[탈퇴사용자]` 기본값 |
+| ~~132~~ | OrderRepository 통계 쿼리 범위 | ✅ **해결** — 반열린 구간 통일 |
+| ~~133~~ | Webhook JSON 파싱 500 | ✅ **해결** — catch → 200 |
+
+---
+
+### 7-6. 카탈로그 — 리뷰 결과
+
+| # | 항목 | 결과 |
+|---|------|------|
+| 149 | ES 검색 응답 재고·리뷰 null | ❌ **미수정** — toProductResponse()에 필드 없음 |
+| ~~150~~ | CategoryService.getById() @Cacheable | ✅ **해결** |
 
 ---
 
 ## 리뷰 진행 요약
 
-| Phase | 범위 | 도메인 | 상태 |
-|-------|------|--------|------|
-| ~~**1**~~ | ~~핵심 트랜잭션~~ | ~~Payment, Order, Inventory~~ | ✅ 완료 → TODO #113~#133 |
-| ~~**2**~~ | ~~보안·인증~~ | ~~Security, User~~ | ✅ 완료 → TODO #134~#143 |
-| ~~**3**~~ | ~~부가 도메인~~ | ~~Coupon, Refund, Shipment, Point~~ | ✅ 완료 → TODO #144~#148 |
-| ~~**4**~~ | ~~상품·카탈로그~~ | ~~Product (+ category/image/review/wishlist)~~ | ✅ 완료 → TODO #149~#158 |
-| ~~**5**~~ | ~~공통 인프라~~ | ~~Outbox, Exception, Cache, RateLimit~~ | ✅ 완료 → TODO #159~#161 |
-| ~~**6**~~ | ~~DB·코드 품질~~ | ~~Flyway, Admin, 크로스커팅~~ | ✅ 완료 → TODO #162~#163 |
+| Phase | 범위 | 상태 |
+|-------|------|------|
+| ~~**1**~~ | 핵심 트랜잭션 | ✅ 완료 → TODO #113~#133 |
+| ~~**2**~~ | 보안·인증 | ✅ 완료 → TODO #134~#143 |
+| ~~**3**~~ | 부가 도메인 | ✅ 완료 → TODO #144~#148 |
+| ~~**4**~~ | 상품·카탈로그 | ✅ 완료 → TODO #149~#158 |
+| ~~**5**~~ | 공통 인프라 | ✅ 완료 → TODO #159~#161 |
+| ~~**6**~~ | DB·코드 품질 | ✅ 완료 → TODO #162~#163 |
+| ~~**7**~~ | 미해결 정리 + 신규 | ✅ 완료 → TODO #164~#170, 22개 해결 확인 |
 
 ---
 
@@ -246,10 +137,28 @@
 
 | 구분 | 수 |
 |------|---|
-| Phase 1~6 총 신규 발견 | **51개** (#113~#163) |
-| P0 (금전 손실·보안) | 5개 (#113, #115, #116, #117, #114) |
-| P1 (데이터 정합성·운영) | 22개 |
-| P2 (성능·코드 품질) | 16개 |
-| P3 (유지보수·확장성) | 8개 |
-| 보류 (판단 필요) | 6개 |
-| 조치 불필요 | 4개 |
+| Phase 1~6 총 발견 | 51개 (#113~#163) |
+| Phase 7 신규 발견 | 7개 (#164~#170) |
+| Phase 7에서 해결 확인 | 22개 |
+| **현재 미해결 잔여** | **15개** |
+| 보류 | 7개 |
+
+### 미해결 항목 요약 (우선순위순)
+
+| 등급 | 항목 | 핵심 |
+|------|------|------|
+| 🔴 P0 | #164 | RefundService.getByPaymentId() 다건 500 |
+| 🔴 P0 | #165 | cancelPendingOrdersByUser() 전체 롤백 |
+| 🔴 P0 | #166 | PointService.refundByOrder() UK 충돌 |
+| 🟠 P1 | #108 | 비밀번호 동일 변경 허용 |
+| 🟠 P1 | #167 | AdminSecurityConfig AND 조건 취약 |
+| 🟠 P1 | #168 | swagger.public 기본값 true |
+| 🟠 P1 | #169 | /actuator/prometheus 공개 |
+| 🟠 P1 | #170 | ProductRequest name @Size 누락 |
+| 🟡 P2 | #69 | PaymentService 전체 Order 로드 |
+| 🟡 P2 | #103 | Pageable max-page-size 미설정 |
+| 🟡 P2 | #104 | resolveUserId 4개 컨트롤러 미적용 |
+| 🟡 P2 | #144 | CouponCreateRequest PERCENTAGE DTO |
+| 🟡 P2 | #147 | CouponService ADMIN 로깅 |
+| 🟡 P2 | #149 | ES 검색 응답 null |
+| 🟡 P3 | #51 | OrderService God Object |

--- a/src/main/java/com/stockmanagement/domain/coupon/controller/CouponController.java
+++ b/src/main/java/com/stockmanagement/domain/coupon/controller/CouponController.java
@@ -1,6 +1,7 @@
 package com.stockmanagement.domain.coupon.controller;
 
 import com.stockmanagement.common.dto.ApiResponse;
+import com.stockmanagement.common.security.SecurityUtils;
 import com.stockmanagement.domain.coupon.dto.CouponClaimRequest;
 import com.stockmanagement.domain.coupon.dto.CouponCreateRequest;
 import com.stockmanagement.domain.coupon.dto.CouponIssueRequest;
@@ -20,6 +21,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 
 import java.util.List;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -71,9 +73,9 @@ public class CouponController {
                description = "usable=true: 사용 가능한 쿠폰만, usable=false: 만료/소진된 쿠폰만, 미지정: 전체.")
     @GetMapping("/my")
     public ApiResponse<List<MyCouponResponse>> getMyCoupons(
-            @AuthenticationPrincipal String username,
+            @AuthenticationPrincipal String username, Authentication authentication,
             @RequestParam(required = false) Boolean usable) {
-        Long userId = userService.resolveUserId(username);
+        Long userId = SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username));
         return ApiResponse.ok(couponService.getMyCoupons(userId, usable));
     }
 
@@ -81,18 +83,18 @@ public class CouponController {
     @PostMapping("/claim")
     @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<MyCouponResponse> claim(
-            @AuthenticationPrincipal String username,
+            @AuthenticationPrincipal String username, Authentication authentication,
             @Valid @RequestBody CouponClaimRequest request) {
-        Long userId = userService.resolveUserId(username);
+        Long userId = SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username));
         return ApiResponse.ok(couponService.claim(userId, request));
     }
 
     @Operation(summary = "쿠폰 유효성 확인 + 할인 금액 미리보기 [USER]")
     @PostMapping("/validate")
     public ApiResponse<CouponValidateResponse> validate(
-            @AuthenticationPrincipal String username,
+            @AuthenticationPrincipal String username, Authentication authentication,
             @Valid @RequestBody CouponValidateRequest request) {
-        Long userId = userService.resolveUserId(username);
+        Long userId = SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username));
         return ApiResponse.ok(couponService.validate(userId, request));
     }
 }

--- a/src/main/java/com/stockmanagement/domain/order/cart/controller/CartController.java
+++ b/src/main/java/com/stockmanagement/domain/order/cart/controller/CartController.java
@@ -1,6 +1,7 @@
 package com.stockmanagement.domain.order.cart.controller;
 
 import com.stockmanagement.common.dto.ApiResponse;
+import com.stockmanagement.common.security.SecurityUtils;
 import com.stockmanagement.domain.order.cart.dto.CartCheckoutRequest;
 import com.stockmanagement.domain.order.cart.dto.CartItemRequest;
 import com.stockmanagement.domain.order.cart.dto.CartItemResponse;
@@ -13,6 +14,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -41,33 +43,39 @@ public class CartController {
 
     @Operation(summary = "장바구니 조회")
     @GetMapping
-    public ApiResponse<CartResponse> getCart(@AuthenticationPrincipal String username) {
-        return ApiResponse.ok(cartService.getCart(userService.resolveUserId(username)));
+    public ApiResponse<CartResponse> getCart(
+            @AuthenticationPrincipal String username, Authentication authentication) {
+        Long userId = SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username));
+        return ApiResponse.ok(cartService.getCart(userId));
     }
 
     @Operation(summary = "상품 추가 또는 수량 변경",
                description = "동일 상품이 이미 있으면 수량을 요청값으로 교체한다.")
     @PostMapping("/items")
     public ApiResponse<CartItemResponse> addOrUpdate(
-            @AuthenticationPrincipal String username,
+            @AuthenticationPrincipal String username, Authentication authentication,
             @RequestBody @Valid CartItemRequest request) {
-        return ApiResponse.ok(cartService.addOrUpdate(userService.resolveUserId(username), request));
+        Long userId = SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username));
+        return ApiResponse.ok(cartService.addOrUpdate(userId, request));
     }
 
     @Operation(summary = "특정 상품 제거")
     @DeleteMapping("/items/{productId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void removeItem(
-            @AuthenticationPrincipal String username,
+            @AuthenticationPrincipal String username, Authentication authentication,
             @PathVariable Long productId) {
-        cartService.removeItem(userService.resolveUserId(username), productId);
+        Long userId = SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username));
+        cartService.removeItem(userId, productId);
     }
 
     @Operation(summary = "장바구니 전체 비우기")
     @DeleteMapping
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void clear(@AuthenticationPrincipal String username) {
-        cartService.clear(userService.resolveUserId(username));
+    public void clear(
+            @AuthenticationPrincipal String username, Authentication authentication) {
+        Long userId = SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username));
+        cartService.clear(userId);
     }
 
     @Operation(summary = "장바구니 → 주문 전환",
@@ -75,8 +83,9 @@ public class CartController {
     @PostMapping("/checkout")
     @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<OrderResponse> checkout(
-            @AuthenticationPrincipal String username,
+            @AuthenticationPrincipal String username, Authentication authentication,
             @RequestBody @Valid CartCheckoutRequest request) {
-        return ApiResponse.ok(cartService.checkout(userService.resolveUserId(username), request));
+        Long userId = SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username));
+        return ApiResponse.ok(cartService.checkout(userId, request));
     }
 }

--- a/src/main/java/com/stockmanagement/domain/order/controller/OrderController.java
+++ b/src/main/java/com/stockmanagement/domain/order/controller/OrderController.java
@@ -76,8 +76,9 @@ public class OrderController {
     @RateLimit(limit = 10, windowSeconds = 60)
     public ApiResponse<OrderResponse> create(
             @RequestBody @Valid OrderCreateRequest request,
-            @AuthenticationPrincipal String username) {
-        Long userId = userService.resolveUserId(username);
+            @AuthenticationPrincipal String username,
+            Authentication authentication) {
+        Long userId = SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username));
         return ApiResponse.ok(orderService.create(request, userId));
     }
 

--- a/src/main/java/com/stockmanagement/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/stockmanagement/domain/payment/service/PaymentService.java
@@ -347,10 +347,9 @@ public class PaymentService {
 
     public Optional<PaymentResponse> getByOrderId(Long orderId, Long userId, boolean isAdmin) {
         if (!isAdmin) {
-            // JWT claim에서 추출한 userId로 소유권 검증 — DB 조회 불필요
-            Order order = orderRepository.findById(orderId)
+            Long ownerUserId = orderRepository.findUserIdById(orderId)
                     .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
-            if (!order.getUserId().equals(userId)) {
+            if (!ownerUserId.equals(userId)) {
                 throw new BusinessException(ErrorCode.ORDER_ACCESS_DENIED);
             }
         }

--- a/src/main/java/com/stockmanagement/domain/user/address/controller/DeliveryAddressController.java
+++ b/src/main/java/com/stockmanagement/domain/user/address/controller/DeliveryAddressController.java
@@ -1,6 +1,7 @@
 package com.stockmanagement.domain.user.address.controller;
 
 import com.stockmanagement.common.dto.ApiResponse;
+import com.stockmanagement.common.security.SecurityUtils;
 import com.stockmanagement.domain.user.address.dto.DeliveryAddressRequest;
 import com.stockmanagement.domain.user.address.dto.DeliveryAddressResponse;
 import com.stockmanagement.domain.user.address.service.DeliveryAddressService;
@@ -10,6 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -40,49 +42,55 @@ public class DeliveryAddressController {
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<DeliveryAddressResponse> create(
-            @AuthenticationPrincipal String username,
+            @AuthenticationPrincipal String username, Authentication authentication,
             @RequestBody @Valid DeliveryAddressRequest request) {
-        return ApiResponse.ok(deliveryAddressService.create(userService.resolveUserId(username), request));
+        Long userId = SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username));
+        return ApiResponse.ok(deliveryAddressService.create(userId, request));
     }
 
     @Operation(summary = "내 배송지 목록 조회", description = "기본 배송지가 맨 앞에 온다.")
     @GetMapping
     public ApiResponse<List<DeliveryAddressResponse>> getList(
-            @AuthenticationPrincipal String username) {
-        return ApiResponse.ok(deliveryAddressService.getList(userService.resolveUserId(username)));
+            @AuthenticationPrincipal String username, Authentication authentication) {
+        Long userId = SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username));
+        return ApiResponse.ok(deliveryAddressService.getList(userId));
     }
 
     @Operation(summary = "배송지 단건 조회")
     @GetMapping("/{id}")
     public ApiResponse<DeliveryAddressResponse> getById(
-            @AuthenticationPrincipal String username,
+            @AuthenticationPrincipal String username, Authentication authentication,
             @PathVariable Long id) {
-        return ApiResponse.ok(deliveryAddressService.getById(id, userService.resolveUserId(username)));
+        Long userId = SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username));
+        return ApiResponse.ok(deliveryAddressService.getById(id, userId));
     }
 
     @Operation(summary = "배송지 수정")
     @PutMapping("/{id}")
     public ApiResponse<DeliveryAddressResponse> update(
-            @AuthenticationPrincipal String username,
+            @AuthenticationPrincipal String username, Authentication authentication,
             @PathVariable Long id,
             @RequestBody @Valid DeliveryAddressRequest request) {
-        return ApiResponse.ok(deliveryAddressService.update(id, userService.resolveUserId(username), request));
+        Long userId = SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username));
+        return ApiResponse.ok(deliveryAddressService.update(id, userId, request));
     }
 
     @Operation(summary = "배송지 삭제", description = "기본 배송지 삭제 시 다른 배송지가 자동으로 기본으로 승격된다.")
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(
-            @AuthenticationPrincipal String username,
+            @AuthenticationPrincipal String username, Authentication authentication,
             @PathVariable Long id) {
-        deliveryAddressService.delete(id, userService.resolveUserId(username));
+        Long userId = SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username));
+        deliveryAddressService.delete(id, userId);
     }
 
     @Operation(summary = "기본 배송지 설정", description = "기존 기본 배송지를 해제하고 지정된 배송지를 기본으로 변경한다.")
     @PostMapping("/{id}/default")
     public ApiResponse<DeliveryAddressResponse> setDefault(
-            @AuthenticationPrincipal String username,
+            @AuthenticationPrincipal String username, Authentication authentication,
             @PathVariable Long id) {
-        return ApiResponse.ok(deliveryAddressService.setDefault(id, userService.resolveUserId(username)));
+        Long userId = SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username));
+        return ApiResponse.ok(deliveryAddressService.setDefault(id, userId));
     }
 }

--- a/src/test/java/com/stockmanagement/domain/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/payment/service/PaymentServiceTest.java
@@ -588,7 +588,7 @@ class PaymentServiceTest {
         @Test
         @DisplayName("본인 주문이면 결제 정보를 반환한다")
         void returnsPaymentForOwner() {
-            given(orderRepository.findById(10L)).willReturn(Optional.of(confirmedOrder(10L, 1L)));
+            given(orderRepository.findUserIdById(10L)).willReturn(Optional.of(1L));
             given(paymentRepository.findByOrderId(10L)).willReturn(Optional.of(pendingPayment));
 
             Optional<PaymentResponse> result = paymentService.getByOrderId(10L, 1L, false);
@@ -599,7 +599,7 @@ class PaymentServiceTest {
         @Test
         @DisplayName("타인 주문 접근 시 ORDER_ACCESS_DENIED 예외 발생")
         void throwsForNonOwner() {
-            given(orderRepository.findById(10L)).willReturn(Optional.of(confirmedOrder(10L, 99L)));
+            given(orderRepository.findUserIdById(10L)).willReturn(Optional.of(99L));
 
             assertThatThrownBy(() -> paymentService.getByOrderId(10L, 1L, false))
                     .isInstanceOf(BusinessException.class)


### PR DESCRIPTION
## Summary
- `PaymentService.getByOrderId()`: `orderRepository.findById()` → `findUserIdById()` 스칼라 프로젝션으로 교체 — Order 전체 로드 제거 (#97)
- `CartController`, `DeliveryAddressController`, `CouponController`, `OrderController.create()`: `userService.resolveUserId(username)` → `SecurityUtils.resolveUserId(authentication, fallback)` 패턴 전환 — JWT claim 활용 시 DB 조회 제거 (#99)

## Test plan
- [x] PaymentServiceTest stub 수정 완료
- [x] 전체 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)