### PR TITLE
fix: 다건 환불 조회 + 탈퇴 취소 실패 격리 + 포인트 멱등성 (#89 #90 #91)

### DIFF
--- a/src/main/java/com/stockmanagement/domain/order/service/OrderService.java
+++ b/src/main/java/com/stockmanagement/domain/order/service/OrderService.java
@@ -38,6 +38,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.dao.DataIntegrityViolationException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -66,6 +67,7 @@ import java.util.stream.Collectors;
  * </ul>
  * 모두 하나의 트랜잭션 내에서 처리되므로, 재고 부족 예외 시 주문과 모든 예약이 함께 롤백된다.
  */
+@Slf4j
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -422,8 +424,13 @@ public class OrderService {
      * @param userId 탈퇴 대상 사용자 ID
      */
     public void cancelPendingOrdersByUser(Long userId) {
-        orderRepository.findPendingIdsByUserId(userId)
-                .forEach(this::cancelBySystem);
+        orderRepository.findPendingIdsByUserId(userId).forEach(orderId -> {
+            try {
+                cancelBySystem(orderId);
+            } catch (Exception e) {
+                log.warn("[탈퇴] 주문 취소 실패 — orderId={}, reason={}", orderId, e.getMessage());
+            }
+        });
     }
 
     /**

--- a/src/main/java/com/stockmanagement/domain/point/service/PointService.java
+++ b/src/main/java/com/stockmanagement/domain/point/service/PointService.java
@@ -168,6 +168,10 @@ public class PointService {
      */
     @Transactional
     public void refundByOrder(Long userId, Long orderId) {
+        // 멱등성: 이미 REFUND 처리된 주문이면 중복 실행 방지
+        if (pointTransactionRepository.existsByOrderIdAndType(orderId, PointTransactionType.REFUND)) {
+            return;
+        }
         // 포인트 트랜잭션이 없으면 early return — getOrCreate(SELECT FOR UPDATE + 잠재적 INSERT) 불필요
         List<PointTransaction> orderTxns = pointTransactionRepository.findByOrderId(orderId);
         if (orderTxns.isEmpty()) return;

--- a/src/main/java/com/stockmanagement/domain/refund/controller/RefundController.java
+++ b/src/main/java/com/stockmanagement/domain/refund/controller/RefundController.java
@@ -19,6 +19,8 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @Tag(name = "Refund", description = "환불 API")
 @RestController
 @RequestMapping("/api/refunds")
@@ -57,9 +59,9 @@ public class RefundController {
         return ApiResponse.ok(refundService.getById(refundId, SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username)), isAdmin));
     }
 
-    @Operation(summary = "결제 ID로 환불 조회", description = "ADMIN은 모든 환불 조회 가능. USER는 본인 주문의 환불만 가능.")
+    @Operation(summary = "결제 ID로 환불 목록 조회", description = "부분 취소 시 다건 반환. ADMIN은 모든 환불 조회 가능. USER는 본인 주문의 환불만 가능.")
     @GetMapping("/payments/{paymentId}")
-    public ApiResponse<RefundResponse> getByPaymentId(
+    public ApiResponse<List<RefundResponse>> getByPaymentId(
             @PathVariable Long paymentId,
             @AuthenticationPrincipal String username,
             Authentication authentication) {

--- a/src/main/java/com/stockmanagement/domain/refund/repository/RefundRepository.java
+++ b/src/main/java/com/stockmanagement/domain/refund/repository/RefundRepository.java
@@ -5,11 +5,14 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface RefundRepository extends JpaRepository<Refund, Long> {
 
     Optional<Refund> findByPaymentId(Long paymentId);
+
+    List<Refund> findAllByPaymentIdOrderByCreatedAtDesc(Long paymentId);
 
     /** 결제별 가장 최근 환불 조회 (부분 취소 여러 건 허용 후 requestRefund에서 사용). */
     Optional<Refund> findFirstByPaymentIdOrderByCreatedAtDesc(Long paymentId);

--- a/src/main/java/com/stockmanagement/domain/refund/service/RefundService.java
+++ b/src/main/java/com/stockmanagement/domain/refund/service/RefundService.java
@@ -6,6 +6,7 @@ import com.stockmanagement.domain.order.repository.OrderRepository;
 import com.stockmanagement.domain.payment.dto.PaymentCancelRequest;
 import com.stockmanagement.domain.payment.entity.Payment;
 import com.stockmanagement.domain.payment.entity.PaymentStatus;
+import java.util.List;
 import java.util.Optional;
 import com.stockmanagement.domain.payment.repository.PaymentRepository;
 import com.stockmanagement.domain.payment.service.PaymentService;
@@ -136,12 +137,14 @@ public class RefundService {
                 .map(RefundResponse::from);
     }
 
-    /** 결제 ID로 환불 정보를 조회한다. 본인 또는 ADMIN만 가능. */
-    public RefundResponse getByPaymentId(Long paymentId, Long userId, boolean isAdmin) {
-        Refund refund = refundRepository.findByPaymentId(paymentId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.REFUND_NOT_FOUND));
-        validateOwnership(refund, userId, isAdmin);
-        return RefundResponse.from(refund);
+    /** 결제 ID로 환불 목록을 조회한다. 부분 취소 시 다건 반환. 본인 또는 ADMIN만 가능. */
+    public List<RefundResponse> getByPaymentId(Long paymentId, Long userId, boolean isAdmin) {
+        List<Refund> refunds = refundRepository.findAllByPaymentIdOrderByCreatedAtDesc(paymentId);
+        if (refunds.isEmpty()) {
+            throw new BusinessException(ErrorCode.REFUND_NOT_FOUND);
+        }
+        validateOwnership(refunds.get(0), userId, isAdmin);
+        return refunds.stream().map(RefundResponse::from).toList();
     }
 
     /**

--- a/src/test/java/com/stockmanagement/domain/refund/controller/RefundControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/refund/controller/RefundControllerTest.java
@@ -149,7 +149,7 @@ class RefundControllerTest {
         @Test
         @DisplayName("인증된 사용자 — 결제 ID로 환불 조회 → 200")
         void returnsRefundByPaymentId() throws Exception {
-            given(refundService.getByPaymentId(eq(1L), any(), eq(false))).willReturn(mock(RefundResponse.class));
+            given(refundService.getByPaymentId(eq(1L), any(), eq(false))).willReturn(List.of(mock(RefundResponse.class)));
 
             mockMvc.perform(get("/api/refunds/payments/1").with(authentication(USER_AUTH)))
                     .andExpect(status().isOk())

--- a/src/test/java/com/stockmanagement/domain/refund/service/RefundServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/refund/service/RefundServiceTest.java
@@ -9,6 +9,7 @@ import com.stockmanagement.domain.payment.repository.PaymentRepository;
 import com.stockmanagement.domain.payment.service.PaymentService;
 import com.stockmanagement.domain.refund.dto.RefundRequest;
 import com.stockmanagement.domain.refund.dto.RefundResponse;
+import java.util.List;
 import com.stockmanagement.domain.refund.entity.Refund;
 import com.stockmanagement.domain.refund.entity.RefundStatus;
 import com.stockmanagement.domain.refund.repository.RefundRepository;
@@ -151,25 +152,25 @@ class RefundServiceTest {
     class GetByPaymentId {
 
         @Test
-        @DisplayName("존재하면 반환")
+        @DisplayName("존재하면 목록 반환")
         void found() {
             Refund refund = Refund.builder()
                     .paymentId(10L).orderId(100L).userId(1L)
                     .amount(BigDecimal.valueOf(50000)).reason("변심")
                     .build();
             ReflectionTestUtils.setField(refund, "id", 5L);
-            given(refundRepository.findByPaymentId(10L)).willReturn(Optional.of(refund));
+            given(refundRepository.findAllByPaymentIdOrderByCreatedAtDesc(10L)).willReturn(List.of(refund));
 
-            RefundResponse response = refundService.getByPaymentId(10L, 1L, false);
+            List<RefundResponse> responses = refundService.getByPaymentId(10L, 1L, false);
 
-            assertThat(response.getId()).isEqualTo(5L);
-            verify(orderRepository, never()).findById(any());
+            assertThat(responses).hasSize(1);
+            assertThat(responses.get(0).getId()).isEqualTo(5L);
         }
 
         @Test
         @DisplayName("없으면 REFUND_NOT_FOUND")
         void notFound() {
-            given(refundRepository.findByPaymentId(10L)).willReturn(Optional.empty());
+            given(refundRepository.findAllByPaymentIdOrderByCreatedAtDesc(10L)).willReturn(List.of());
 
             assertThatThrownBy(() -> refundService.getByPaymentId(10L, 1L, false))
                     .isInstanceOf(BusinessException.class)
@@ -184,12 +185,12 @@ class RefundServiceTest {
                     .amount(BigDecimal.valueOf(50000)).reason("변심")
                     .build();
             ReflectionTestUtils.setField(refund, "id", 5L);
-            given(refundRepository.findByPaymentId(10L)).willReturn(Optional.of(refund));
+            given(refundRepository.findAllByPaymentIdOrderByCreatedAtDesc(10L)).willReturn(List.of(refund));
 
-            RefundResponse response = refundService.getByPaymentId(10L, 99L, true);
+            List<RefundResponse> responses = refundService.getByPaymentId(10L, 99L, true);
 
-            assertThat(response.getId()).isEqualTo(5L);
-            verify(orderRepository, never()).findById(any());
+            assertThat(responses).hasSize(1);
+            assertThat(responses.get(0).getId()).isEqualTo(5L);
         }
     }
 }

--- a/src/test/java/com/stockmanagement/integration/RefundIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/RefundIntegrationTest.java
@@ -126,8 +126,8 @@ class RefundIntegrationTest extends AbstractIntegrationTest {
         mockMvc.perform(get("/api/refunds/payments/" + payment.getId())
                         .header("Authorization", "Bearer " + userToken))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.paymentId").value(payment.getId()))
-                .andExpect(jsonPath("$.data.status").value("COMPLETED"));
+                .andExpect(jsonPath("$.data[0].paymentId").value(payment.getId()))
+                .andExpect(jsonPath("$.data[0].status").value("COMPLETED"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `RefundService.getByPaymentId()`: `findByPaymentId()` (Optional 단건) → `findAllByPaymentIdOrderByCreatedAtDesc()` (List 다건) — 부분 취소 2회+ 시 500 에러 해결 (#89)
- `OrderService.cancelPendingOrdersByUser()`: 개별 주문 취소 실패를 catch+로그 후 나머지 계속 처리 — 1건 실패 시 탈퇴 전체 롤백 방지 (#90)
- `PointService.refundByOrder()`: `existsByOrderIdAndType(orderId, REFUND)` 선검사 추가 — 동시 취소 경합 시 uk_point_txn_order_type 충돌 방지 (#91)

## Test plan
- [x] RefundServiceTest/RefundControllerTest stub 수정
- [x] RefundIntegrationTest jsonPath `$.data` → `$.data[0]` 수정
- [x] 전체 테스트 통과 (647개)

🤖 Generated with [Claude Code](https://claude.com/claude-code)