### PR TITLE
fix: swagger.public 기본값 false + ES 검색 결과 재고·리뷰 보강 (#93 #47)

### DIFF
--- a/src/main/java/com/stockmanagement/common/config/SecurityConfig.java
+++ b/src/main/java/com/stockmanagement/common/config/SecurityConfig.java
@@ -43,8 +43,8 @@ public class SecurityConfig {
     @Value("${cors.allowed-origins:http://localhost:3000}")
     private String allowedOrigins;
 
-    /** true(기본값)이면 Swagger UI를 공개 접근 허용. 운영 배포 시 false로 설정할 것. */
-    @Value("${swagger.public:true}")
+    /** true이면 Swagger UI 공개 접근 허용. 기본값 false — 운영 환경 보호. 개발 시 SWAGGER_PUBLIC=true 환경변수로 오버라이드. */
+    @Value("${swagger.public:false}")
     private boolean swaggerPublic;
 
     @Bean

--- a/src/main/java/com/stockmanagement/domain/product/document/ProductDocument.java
+++ b/src/main/java/com/stockmanagement/domain/product/document/ProductDocument.java
@@ -54,6 +54,9 @@ public class ProductDocument {
     @Field(type = FieldType.Keyword)
     private String status;
 
+    @Field(type = FieldType.Keyword, index = false)
+    private String thumbnailUrl;
+
     @Field(type = FieldType.Date, format = {}, pattern = "uuuu-MM-dd'T'HH:mm:ss.SSSSSS||uuuu-MM-dd'T'HH:mm:ss.SSS||uuuu-MM-dd'T'HH:mm:ss")
     private LocalDateTime createdAt;
 
@@ -67,6 +70,7 @@ public class ProductDocument {
                 .sku(product.getSku())
                 .category(product.getCategoryName())
                 .status(product.getStatus() != null ? product.getStatus().name() : null)
+                .thumbnailUrl(product.getThumbnailUrl())
                 .createdAt(product.getCreatedAt())
                 .build();
     }
@@ -84,6 +88,7 @@ public class ProductDocument {
                 .price(getPriceAsBigDecimal())
                 .sku(sku)
                 .category(category)
+                .thumbnailUrl(thumbnailUrl)
                 .status(status != null ? ProductStatus.valueOf(status) : null)
                 .createdAt(createdAt)
                 .build();

--- a/src/main/java/com/stockmanagement/domain/product/service/ProductService.java
+++ b/src/main/java/com/stockmanagement/domain/product/service/ProductService.java
@@ -27,6 +27,7 @@ import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -125,7 +126,8 @@ public class ProductService {
     public Page<ProductResponse> getList(Pageable pageable, ProductSearchRequest request, Long userId) {
         if (request != null && request.hasSearchCondition()) {
             try {
-                return productSearchService.search(request, pageable);
+                Page<ProductResponse> esResult = productSearchService.search(request, pageable);
+                return enrichSearchResult(esResult, userId);
             } catch (Exception e) {
                 log.warn("Elasticsearch 검색 실패, MySQL fallback 사용. query={}", request.getQ(), e);
             }
@@ -288,6 +290,51 @@ public class ProductService {
                     null,
                     userId != null ? wishlistedIds.contains(p.getId()) : null);
         });
+    }
+
+    /**
+     * ES 검색 결과(Page&lt;ProductResponse&gt;)에 재고·리뷰·위시리스트 통계를 보강한다.
+     * ES에는 동적 데이터(재고/리뷰)가 없으므로 DB 배치 조회로 채운다.
+     */
+    private Page<ProductResponse> enrichSearchResult(Page<ProductResponse> esPage, Long userId) {
+        if (esPage.isEmpty()) return esPage;
+
+        List<Long> ids = esPage.getContent().stream().map(ProductResponse::getId).toList();
+
+        Map<Long, Integer> availableMap = inventoryRepository.findAllByProductIdIn(ids).stream()
+                .collect(Collectors.toMap(i -> i.getProduct().getId(), Inventory::getAvailable));
+
+        Map<Long, ReviewStatsProjection> statsMap = reviewRepository
+                .findReviewStatsByProductIdIn(ids).stream()
+                .collect(Collectors.toMap(ReviewStatsProjection::getProductId, s -> s));
+
+        Set<Long> wishlistedIds = (userId != null)
+                ? wishlistRepository.findWishlistedProductIds(userId, ids)
+                : Set.of();
+
+        List<ProductResponse> enriched = esPage.getContent().stream().map(r -> {
+            ReviewStatsProjection stats = statsMap.get(r.getId());
+            return ProductResponse.builder()
+                    .id(r.getId())
+                    .name(r.getName())
+                    .description(r.getDescription())
+                    .price(r.getPrice())
+                    .sku(r.getSku())
+                    .categoryId(r.getCategoryId())
+                    .category(r.getCategory())
+                    .thumbnailUrl(r.getThumbnailUrl())
+                    .status(r.getStatus())
+                    .createdAt(r.getCreatedAt())
+                    .updatedAt(r.getUpdatedAt())
+                    .availableQuantity(availableMap.getOrDefault(r.getId(), 0))
+                    .avgRating(stats != null && stats.getAvgRating() != null
+                            ? Math.round(stats.getAvgRating() * 10.0) / 10.0 : null)
+                    .reviewCount(stats != null ? stats.getReviewCount() : 0L)
+                    .wishlisted(userId != null ? wishlistedIds.contains(r.getId()) : null)
+                    .build();
+        }).toList();
+
+        return new PageImpl<>(enriched, esPage.getPageable(), esPage.getTotalElements());
     }
 
     /** 공통 조회 헬퍼 — 없으면 PRODUCT_NOT_FOUND 예외 발생 */

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -178,3 +178,7 @@ outbox.purge.retention-days=7
 resilience4j.retry.instances.email.max-attempts=3
 resilience4j.retry.instances.email.wait-duration=2s
 resilience4j.retry.instances.email.retry-exceptions=jakarta.mail.MessagingException,org.springframework.mail.MailException
+
+# ===== Swagger UI =====
+# 운영 환경에서는 false(기본값) — ADMIN 인증 필요. 개발 환경에서는 SWAGGER_PUBLIC=true 환경변수로 오버라이드.
+swagger.public=${SWAGGER_PUBLIC:false}


### PR DESCRIPTION
## Summary
- **#93**: `swagger.public` 기본값 `true` → `false` 전환 — 운영 환경 API 명세 무인증 노출 차단
- **#47**: ES 검색 결과에 재고·리뷰·위시리스트 통계 DB 보강 조회 추가 — MySQL 응답과 동일 구조 반환
- `ProductDocument`에 `thumbnailUrl` 필드 추가 (색인 + 응답)

## Changes
| 파일 | 변경 |
|------|------|
| `SecurityConfig.java` | `swagger.public` 기본값 `true` → `false` |
| `application.properties` | `swagger.public=${SWAGGER_PUBLIC:false}` 추가 |
| `ProductDocument.java` | `thumbnailUrl` 필드 + `from()`/`toProductResponse()` 반영 |
| `ProductService.java` | `enrichSearchResult()` 메서드 추가, ES 검색 결과 보강 |

## Test plan
- [x] 전체 647개 테스트 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)