### PR TITLE
fix: 코드 리뷰 9개 이슈 일괄 수정 (#137 #139 #140 #141 #146 #147 #149 #150 #152)

### DIFF
--- a/src/main/java/com/stockmanagement/common/config/AsyncConfig.java
+++ b/src/main/java/com/stockmanagement/common/config/AsyncConfig.java
@@ -1,7 +1,10 @@
 package com.stockmanagement.common.config;
 
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
@@ -14,9 +17,10 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
  *
  * <p>두 빈 모두 Micrometer가 자동 계측하여 executor.* 메트릭으로 노출된다.
  */
+@Slf4j
 @EnableAsync
 @Configuration
-public class AsyncConfig {
+public class AsyncConfig implements AsyncConfigurer {
 
     /**
      * 도메인 이벤트 처리 전용 스레드 풀.
@@ -35,6 +39,13 @@ public class AsyncConfig {
         executor.setAwaitTerminationSeconds(30);
         executor.initialize();
         return executor;
+    }
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return (ex, method, params) ->
+                log.error("[Async] 비동기 이벤트 처리 실패 — method={}, error={}",
+                        method.getName(), ex.getMessage(), ex);
     }
 
     /**

--- a/src/main/java/com/stockmanagement/common/outbox/OutboxEventProcessor.java
+++ b/src/main/java/com/stockmanagement/common/outbox/OutboxEventProcessor.java
@@ -51,8 +51,7 @@ class OutboxEventProcessor {
      *
      * <p>이미 발행된 이벤트는 건너뛴다 (멱등성).
      * 발행 성공 시 {@code publishedAt}을 기록하고, 실패 시 {@code retryCount}를 증가시킨다.
-     */
-    /**
+     *
      * @return true = 발행 성공 또는 이미 발행됨, false = 발행 실패
      */
     @Transactional(propagation = Propagation.REQUIRES_NEW)

--- a/src/main/java/com/stockmanagement/common/util/SqlUtils.java
+++ b/src/main/java/com/stockmanagement/common/util/SqlUtils.java
@@ -1,0 +1,29 @@
+package com.stockmanagement.common.util;
+
+/**
+ * SQL LIKE 패턴 이스케이프 유틸리티.
+ *
+ * <p>JPQL {@code ESCAPE '!'} 용도와 Criteria API {@code ESCAPE '\'} 용도를 모두 지원한다.
+ */
+public final class SqlUtils {
+
+    private SqlUtils() {}
+
+    /**
+     * LIKE 패턴 와일드카드를 이스케이프한다.
+     *
+     * @param value   이스케이프할 문자열
+     * @param escape  이스케이프 문자 ('!' 또는 '\\')
+     */
+    public static String escapeLike(String value, char escape) {
+        String esc = String.valueOf(escape);
+        return value.replace(esc, esc + esc)
+                    .replace("%", esc + "%")
+                    .replace("_", esc + "_");
+    }
+
+    /** JPQL {@code ESCAPE '!'} 기준 이스케이프. */
+    public static String escapeLike(String value) {
+        return escapeLike(value, '!');
+    }
+}

--- a/src/main/java/com/stockmanagement/domain/admin/dto/DashboardResponse.java
+++ b/src/main/java/com/stockmanagement/domain/admin/dto/DashboardResponse.java
@@ -8,6 +8,8 @@ public record DashboardResponse(
         long pendingOrders,
         long confirmedOrders,
         long cancelledOrders,
+        long paymentInProgressOrders,
+        long cancelInProgressOrders,
         BigDecimal totalRevenue,
         long totalUsers,
         List<LowStockItem> lowStockItems

--- a/src/main/java/com/stockmanagement/domain/admin/service/AdminService.java
+++ b/src/main/java/com/stockmanagement/domain/admin/service/AdminService.java
@@ -64,6 +64,8 @@ public class AdminService {
         long pendingOrders   = countFromMap(statsMap, OrderStatus.PENDING);
         long confirmedOrders = countFromMap(statsMap, OrderStatus.CONFIRMED);
         long cancelledOrders = countFromMap(statsMap, OrderStatus.CANCELLED);
+        long paymentInProgressOrders = countFromMap(statsMap, OrderStatus.PAYMENT_IN_PROGRESS);
+        long cancelInProgressOrders  = countFromMap(statsMap, OrderStatus.CANCEL_IN_PROGRESS);
         var  totalRevenue    = statsMap.containsKey(OrderStatus.CONFIRMED)
                 ? statsMap.get(OrderStatus.CONFIRMED).getTotalAmount()
                 : java.math.BigDecimal.ZERO;
@@ -79,6 +81,7 @@ public class AdminService {
 
         return new DashboardResponse(
                 totalOrders, pendingOrders, confirmedOrders, cancelledOrders,
+                paymentInProgressOrders, cancelInProgressOrders,
                 totalRevenue, totalUsers, lowStockItems
         );
     }
@@ -154,6 +157,6 @@ public class AdminService {
 
     /** LIKE 패턴 와일드카드(!, %, _)를 이스케이프한다. ESCAPE ! 기준. */
     private static String escapeLike(String value) {
-        return value.replace("!", "!!").replace("%", "!%").replace("_", "!_");
+        return com.stockmanagement.common.util.SqlUtils.escapeLike(value);
     }
 }

--- a/src/main/java/com/stockmanagement/domain/inventory/repository/InventorySpecification.java
+++ b/src/main/java/com/stockmanagement/domain/inventory/repository/InventorySpecification.java
@@ -25,9 +25,7 @@ public class InventorySpecification {
 
     /** LIKE 패턴에서 와일드카드 문자(%,_,\)를 이스케이프한다. */
     private static String escapeLike(String value) {
-        return value.replace("\\", "\\\\")
-                    .replace("%", "\\%")
-                    .replace("_", "\\_");
+        return com.stockmanagement.common.util.SqlUtils.escapeLike(value, '\\');
     }
 
     /**

--- a/src/main/java/com/stockmanagement/domain/order/dto/OrderCreateRequest.java
+++ b/src/main/java/com/stockmanagement/domain/order/dto/OrderCreateRequest.java
@@ -1,5 +1,6 @@
 package com.stockmanagement.domain.order.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -29,6 +30,7 @@ public class OrderCreateRequest {
      * 주문자 ID — 내부 호출(장바구니 결제) 전용.
      * 외부 API에서는 JWT에서 추출한 userId를 사용하므로 이 필드는 무시된다.
      */
+    @JsonIgnore
     private Long userId;
 
     /**

--- a/src/main/java/com/stockmanagement/domain/order/service/OrderCommandService.java
+++ b/src/main/java/com/stockmanagement/domain/order/service/OrderCommandService.java
@@ -239,6 +239,7 @@ public class OrderCommandService {
     /**
      * 회원 탈퇴 시 사용자의 모든 PENDING 주문을 강제 취소한다.
      */
+    @Transactional
     public void cancelPendingOrdersByUser(Long userId) {
         orderRepository.findPendingIdsByUserId(userId).forEach(orderId -> {
             try {

--- a/src/main/java/com/stockmanagement/domain/order/service/OrderQueryService.java
+++ b/src/main/java/com/stockmanagement/domain/order/service/OrderQueryService.java
@@ -175,10 +175,16 @@ public class OrderQueryService {
             couponDiscount = couponService.validate(userId, validateReq).getDiscountAmount();
         }
 
-        // 포인트 잔액 검증 (차감은 하지 않음)
+        // 포인트 잔액 + 한도 검증 (차감은 하지 않음)
         long usePoints = request.getUsePoints();
         if (usePoints > 0) {
             pointService.validateBalance(userId, usePoints);
+            BigDecimal maxUsablePoints = originalAmount.subtract(couponDiscount);
+            if (BigDecimal.valueOf(usePoints).compareTo(maxUsablePoints) > 0) {
+                throw new BusinessException(ErrorCode.INVALID_INPUT,
+                        "포인트 사용 금액이 결제 가능 금액을 초과합니다. 최대 사용 가능 포인트: "
+                                + maxUsablePoints.longValue() + "P");
+            }
         }
         BigDecimal pointDiscount = BigDecimal.valueOf(usePoints);
 

--- a/src/main/java/com/stockmanagement/domain/product/review/service/ReviewService.java
+++ b/src/main/java/com/stockmanagement/domain/product/review/service/ReviewService.java
@@ -146,6 +146,7 @@ public class ReviewService {
             throw new BusinessException(ErrorCode.PRODUCT_NOT_FOUND);
         }
 
+        // 분포 조회
         List<Object[]> rows = reviewRepository.findRatingDistributionByProductId(productId);
         Map<Integer, Long> distribution = new HashMap<>();
         for (int i = 1; i <= 5; i++) distribution.put(i, 0L);
@@ -153,11 +154,10 @@ public class ReviewService {
             distribution.put(((Number) row[0]).intValue(), ((Number) row[1]).longValue());
         }
 
-        long total = distribution.values().stream().mapToLong(Long::longValue).sum();
-        double avg = total == 0 ? 0.0
-                : distribution.entrySet().stream()
-                        .mapToDouble(e -> e.getKey() * e.getValue())
-                        .sum() / total;
+        // DB AVG() 사용 — 앱 레벨 재계산과의 정밀도 불일치 방지
+        var stats = reviewRepository.findReviewStatsByProductId(productId);
+        double avg = stats.map(s -> s.getAvgRating()).orElse(0.0);
+        long total = stats.map(s -> s.getReviewCount()).orElse(0L);
 
         return RatingStatsResponse.builder()
                 .avgRating(Math.round(avg * 10) / 10.0)

--- a/src/main/java/com/stockmanagement/domain/product/service/ProductService.java
+++ b/src/main/java/com/stockmanagement/domain/product/service/ProductService.java
@@ -217,7 +217,7 @@ public class ProductService {
 
     /** LIKE 패턴 와일드카드(!, %, _)를 이스케이프한다. ESCAPE ! 기준. */
     private static String escapeLike(String value) {
-        return value.replace("!", "!!").replace("%", "!%").replace("_", "!_");
+        return com.stockmanagement.common.util.SqlUtils.escapeLike(value);
     }
 
     /**

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -86,8 +86,8 @@ management.endpoint.loggers.enabled=false
 management.metrics.tags.application=${spring.application.name}
 
 # ===== 분산 추적 (Micrometer Tracing + Zipkin) =====
-# 개발: 1.0 (전수 수집), 운영: 0.01~0.1 (샘플링 비율 조정 필수)
-management.tracing.sampling.probability=0.1
+# 기본값 1.0 (전수 수집). 운영 배포 시 환경변수로 0.01~0.1 권장
+management.tracing.sampling.probability=${TRACING_SAMPLING:1.0}
 management.zipkin.tracing.endpoint=http://localhost:9411/api/v2/spans
 
 # ===== Rate Limit =====

--- a/src/test/java/com/stockmanagement/domain/admin/service/AdminServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/admin/service/AdminServiceTest.java
@@ -104,6 +104,8 @@ class AdminServiceTest {
             assertThat(response.pendingOrders()).isEqualTo(10L);
             assertThat(response.confirmedOrders()).isEqualTo(80L);
             assertThat(response.cancelledOrders()).isEqualTo(10L);
+            assertThat(response.paymentInProgressOrders()).isEqualTo(0L);
+            assertThat(response.cancelInProgressOrders()).isEqualTo(0L);
             assertThat(response.totalRevenue()).isEqualByComparingTo(BigDecimal.valueOf(500_000));
             assertThat(response.totalUsers()).isEqualTo(200L);
             assertThat(response.lowStockItems()).hasSize(1);


### PR DESCRIPTION
- https://github.com/nameless0422/stock-management-api/issues/150: OutboxEventProcessor Javadoc 블록 중복 합치기
- https://github.com/nameless0422/stock-management-api/issues/152: tracing sampling 환경변수화 (기본값 1.0, 운영 시 조정)
- https://github.com/nameless0422/stock-management-api/issues/137: cancelPendingOrdersByUser() @transactional 명시
- https://github.com/nameless0422/stock-management-api/issues/149: OrderCreateRequest.userId @JsonIgnore 추가
- https://github.com/nameless0422/stock-management-api/issues/141: escapeLike() → SqlUtils 공통 유틸 추출
- https://github.com/nameless0422/stock-management-api/issues/147: AsyncConfig AsyncUncaughtExceptionHandler 등록
- https://github.com/nameless0422/stock-management-api/issues/139: ReviewService.getRatingStats() DB AVG() 전환
- https://github.com/nameless0422/stock-management-api/issues/140: preview() 포인트 한도 검증 추가 (create()와 동일)
- https://github.com/nameless0422/stock-management-api/issues/146: DashboardResponse paymentInProgress/cancelInProgress 집계 추가