### PR TITLE
fix: 코드 리뷰 4개 이슈 일괄 수정 (#136 #138 #143 #145)

### DIFF
--- a/src/main/java/com/stockmanagement/common/event/ShipmentReturnedEvent.java
+++ b/src/main/java/com/stockmanagement/common/event/ShipmentReturnedEvent.java
@@ -1,0 +1,28 @@
+package com.stockmanagement.common.event;
+
+import com.stockmanagement.common.outbox.OutboxEventType;
+import lombok.Getter;
+
+import java.util.Map;
+
+/** 반품 처리 이벤트 — ShipmentService.processReturn() 완료 후 발행 */
+@Getter
+public class ShipmentReturnedEvent extends DomainEvent implements OutboxSupport {
+
+    private final Long orderId;
+
+    public ShipmentReturnedEvent(Long orderId) {
+        super();
+        this.orderId = orderId;
+    }
+
+    @Override
+    public OutboxEventType outboxEventType() {
+        return OutboxEventType.SHIPMENT_RETURNED;
+    }
+
+    @Override
+    public Map<String, Object> toOutboxPayload() {
+        return Map.of("orderId", orderId);
+    }
+}

--- a/src/main/java/com/stockmanagement/common/outbox/OutboxEventProcessor.java
+++ b/src/main/java/com/stockmanagement/common/outbox/OutboxEventProcessor.java
@@ -6,6 +6,7 @@ import com.stockmanagement.common.event.OrderCancelledEvent;
 import com.stockmanagement.common.event.OrderCreatedEvent;
 import com.stockmanagement.common.event.PaymentConfirmedEvent;
 import com.stockmanagement.common.event.ShipmentDeliveredEvent;
+import com.stockmanagement.common.event.ShipmentReturnedEvent;
 import com.stockmanagement.common.event.ShipmentShippedEvent;
 import com.stockmanagement.domain.point.service.PointService;
 import com.stockmanagement.domain.shipment.service.ShipmentService;
@@ -120,6 +121,7 @@ class OutboxEventProcessor {
             case SHIPMENT_SHIPPED -> new ShipmentShippedEvent(
                     toLong(p.get("orderId")), (String) p.get("carrier"), (String) p.get("trackingNumber"));
             case SHIPMENT_DELIVERED -> new ShipmentDeliveredEvent(toLong(p.get("orderId")));
+            case SHIPMENT_RETURNED -> new ShipmentReturnedEvent(toLong(p.get("orderId")));
             default -> throw new IllegalStateException("buildEvent에서 처리되지 않은 타입: " + outbox.getEventType());
         };
     }

--- a/src/main/java/com/stockmanagement/common/outbox/OutboxEventType.java
+++ b/src/main/java/com/stockmanagement/common/outbox/OutboxEventType.java
@@ -9,6 +9,7 @@ public enum OutboxEventType {
     SHIPMENT_DELIVERED,
     /** 결제 확정 후 배송 레코드 생성 요청 — 실패 시 릴레이 스케줄러가 재시도한다. */
     SHIPMENT_CREATE,
+    SHIPMENT_RETURNED,
     /** 결제 확정 후 포인트 적립 요청 — 실패 시 릴레이 스케줄러가 재시도한다. */
     POINT_EARN
 }

--- a/src/main/java/com/stockmanagement/domain/order/service/OrderQueryService.java
+++ b/src/main/java/com/stockmanagement/domain/order/service/OrderQueryService.java
@@ -64,7 +64,9 @@ public class OrderQueryService {
     public OrderResponse getById(Long id) {
         Order order = orderRepository.findByIdWithItems(id)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
-        return OrderResponse.from(order);
+        ShipmentStatus shipmentStatus = shipmentRepository.findByOrderId(id)
+                .map(s -> s.getStatus()).orElse(null);
+        return OrderResponse.from(order, null, shipmentStatus);
     }
 
     /**

--- a/src/main/java/com/stockmanagement/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/stockmanagement/domain/payment/service/PaymentService.java
@@ -96,6 +96,9 @@ public class PaymentService {
             throw new BusinessException(ErrorCode.PAYMENT_AMOUNT_MISMATCH);
         }
 
+        // Toss 결제창에 표시할 사용자 정보 조회 (prepare 내 1회만 조회)
+        User user = userRepository.findById(userId).orElse(null);
+
         // 이번 결제 시도용 고유 tossOrderId 생성
         String tossOrderId = buildTossOrderId(order.getId());
 
@@ -104,12 +107,12 @@ public class PaymentService {
         if (existing.isPresent()) {
             Payment p = existing.get();
             if (p.getStatus() == PaymentStatus.PENDING) {
-                return buildPrepareResponse(p, order);
+                return buildPrepareResponse(p, order, user);
             }
             if (p.getStatus() == PaymentStatus.FAILED) {
                 // FAILED 결제를 새 tossOrderId로 초기화하여 재사용
                 p.resetForRetry(tossOrderId);
-                return buildPrepareResponse(p, order);
+                return buildPrepareResponse(p, order, user);
             }
             throw new BusinessException(ErrorCode.INVALID_ORDER_STATUS);
         }
@@ -128,10 +131,10 @@ public class PaymentService {
             paymentRepository.flush();
         } catch (org.springframework.dao.DataIntegrityViolationException e) {
             return paymentRepository.findByOrderId(order.getId())
-                    .map(p -> buildPrepareResponse(p, order))
+                    .map(p -> buildPrepareResponse(p, order, user))
                     .orElseThrow(() -> e);
         }
-        return buildPrepareResponse(saved, order);
+        return buildPrepareResponse(saved, order, user);
     }
 
     /**
@@ -372,8 +375,7 @@ public class PaymentService {
      * 결제 위젯용 주문명을 생성한다.
      * 예시: "MacBook Pro 외 2건"
      */
-    private PaymentPrepareResponse buildPrepareResponse(Payment payment, Order order) {
-        User user = userRepository.findById(order.getUserId()).orElse(null);
+    private PaymentPrepareResponse buildPrepareResponse(Payment payment, Order order, User user) {
         return new PaymentPrepareResponse(
                 payment.getTossOrderId(),
                 payment.getAmount(),

--- a/src/main/java/com/stockmanagement/domain/product/wishlist/repository/WishlistRepository.java
+++ b/src/main/java/com/stockmanagement/domain/product/wishlist/repository/WishlistRepository.java
@@ -30,6 +30,16 @@ public interface WishlistRepository extends JpaRepository<WishlistItem, Long> {
     Set<Long> findWishlistedProductIds(@Param("userId") Long userId,
                                        @Param("productIds") Collection<Long> productIds);
 
+    /**
+     * 상품이 존재하는 위시리스트 아이템만 페이징 조회한다.
+     * 물리 삭제된 상품의 위시리스트 아이템을 제외하여 totalElements 정확도를 보장한다.
+     */
+    @Query(value = "SELECT w FROM WishlistItem w WHERE w.userId = :userId AND EXISTS " +
+            "(SELECT 1 FROM Product p WHERE p.id = w.productId) ORDER BY w.createdAt DESC",
+            countQuery = "SELECT COUNT(w) FROM WishlistItem w WHERE w.userId = :userId AND EXISTS " +
+                    "(SELECT 1 FROM Product p WHERE p.id = w.productId)")
+    Page<WishlistItem> findByUserIdWithExistingProduct(@Param("userId") Long userId, Pageable pageable);
+
     /** 회원 탈퇴 시 사용자의 위시리스트 전체를 일괄 삭제한다. */
     @Modifying
     @Query("DELETE FROM WishlistItem w WHERE w.userId = :userId")

--- a/src/main/java/com/stockmanagement/domain/product/wishlist/service/WishlistService.java
+++ b/src/main/java/com/stockmanagement/domain/product/wishlist/service/WishlistService.java
@@ -81,7 +81,8 @@ public class WishlistService {
      * <p>userId는 JWT claim에서 추출한 값을 컨트롤러에서 전달받아 DB users 조회를 생략한다.
      */
     public Page<WishlistResponse> getList(Long userId, Pageable pageable) {
-        Page<WishlistItem> page = wishlistRepository.findByUserIdOrderByCreatedAtDesc(userId, pageable);
+        // DB 레벨에서 존재하는 상품만 조회 — totalElements 정확도 보장
+        Page<WishlistItem> page = wishlistRepository.findByUserIdWithExistingProduct(userId, pageable);
         if (page.isEmpty()) {
             return page.map(item -> null); // 빈 페이지 반환
         }
@@ -93,17 +94,9 @@ public class WishlistService {
         Map<Long, Integer> availableMap = inventoryRepository.findAllByProductIdIn(productIds).stream()
                 .collect(Collectors.toMap(i -> i.getProduct().getId(), Inventory::getAvailable));
 
-        // 상품이 삭제(soft delete)된 경우 null로 매핑 후 필터링 — Spring Data Page는 filter 미지원
-        // → toList()로 materialized 후 PageImpl로 래핑
-        List<WishlistResponse> content = page.stream()
-                .filter(item -> productMap.containsKey(item.getProductId()))
-                .map(item -> WishlistResponse.of(
-                        item,
-                        productMap.get(item.getProductId()),
-                        availableMap.get(item.getProductId())))
-                .toList();
-        // 필터링 후 totalElements 보정 — 삭제 상품 수만큼 차감
-        long filteredTotal = page.getTotalElements() - (page.getContent().size() - content.size());
-        return new org.springframework.data.domain.PageImpl<>(content, pageable, Math.max(0, filteredTotal));
+        return page.map(item -> WishlistResponse.of(
+                item,
+                productMap.get(item.getProductId()),
+                availableMap.get(item.getProductId())));
     }
 }

--- a/src/main/java/com/stockmanagement/domain/shipment/service/ShipmentService.java
+++ b/src/main/java/com/stockmanagement/domain/shipment/service/ShipmentService.java
@@ -1,6 +1,7 @@
 package com.stockmanagement.domain.shipment.service;
 
 import com.stockmanagement.common.event.ShipmentDeliveredEvent;
+import com.stockmanagement.common.event.ShipmentReturnedEvent;
 import com.stockmanagement.common.event.ShipmentShippedEvent;
 import com.stockmanagement.common.exception.BusinessException;
 import com.stockmanagement.common.exception.ErrorCode;
@@ -138,6 +139,7 @@ public class ShipmentService {
     public ShipmentResponse processReturn(Long orderId) {
         Shipment shipment = findByOrderIdOrThrow(orderId);
         shipment.processReturn();
+        outboxEventStore.save(new ShipmentReturnedEvent(orderId));
         return ShipmentResponse.from(shipment);
     }
 

--- a/src/test/java/com/stockmanagement/domain/product/wishlist/service/WishlistServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/product/wishlist/service/WishlistServiceTest.java
@@ -120,7 +120,7 @@ class WishlistServiceTest {
             WishlistItem item = mockItem(5L, 1L, 10L);
             Product product = mockProduct(10L);
             Pageable pageable = PageRequest.of(0, 20);
-            given(wishlistRepository.findByUserIdOrderByCreatedAtDesc(1L, pageable))
+            given(wishlistRepository.findByUserIdWithExistingProduct(1L, pageable))
                     .willReturn(new PageImpl<>(List.of(item)));
             given(productRepository.findAllById(List.of(10L))).willReturn(List.of(product));
             given(inventoryRepository.findAllByProductIdIn(List.of(10L))).willReturn(List.of());


### PR DESCRIPTION
## Summary
- **#143**: `OrderQueryService.getById()` 캐시 응답에 `shipmentStatus` 포함 — `getByIdForUser()`와 응답 구조 통일
- **#136**: `PaymentService.buildPrepareResponse()` User 파라미터 수신으로 변경 — 불필요한 N+1 UserRepository 조회 제거
- **#145**: `ShipmentService.processReturn()`에 Outbox 이벤트 추가 — `ShipmentReturnedEvent` 신규 생성, `OutboxEventType.SHIPMENT_RETURNED` 추가
- **#138**: `WishlistService.getList()` totalElements DB 레벨 보정 — `findByUserIdWithExistingProduct()` JPQL로 물리 삭제 상품 제외, 인메모리 보정 로직 제거

## Test plan
- [x] 전체 647개 테스트 통과
- [x] WishlistServiceTest stub 업데이트 확인

Closes #136, #138, #143, #145