### PR TITLE
feat: UserResponse에 전화번호 추가 (#121)

### DIFF
--- a/src/main/java/com/stockmanagement/domain/user/dto/UpdateProfileRequest.java
+++ b/src/main/java/com/stockmanagement/domain/user/dto/UpdateProfileRequest.java
@@ -1,16 +1,20 @@
 package com.stockmanagement.domain.user.dto;
 
 import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-/** 프로필 수정 요청 DTO. 변경할 필드만 포함한다 (null이면 변경하지 않음). */
+/** 프로필 수정 요청 DTO. 변경할 필드만 포함한�� (null이면 변경하�� 않음). */
 @Getter
 @NoArgsConstructor
 public class UpdateProfileRequest {
 
-    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    @Email(message = "올바른 이메일 형식이 아��니다.")
     @Size(max = 100, message = "이메일은 100자 이하여야 합니다.")
     private String email;
+
+    @Pattern(regexp = "^[0-9\\-]{10,20}$", message = "전화번호 형식이 올바르지 않습니다.")
+    private String phoneNumber;
 }

--- a/src/main/java/com/stockmanagement/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/stockmanagement/domain/user/dto/UserResponse.java
@@ -9,9 +9,10 @@ public record UserResponse(
         Long id,
         String username,
         String email,
+        String phoneNumber,
         UserRole role,
         LocalDateTime createdAt,
-        /** 포인트 잔액 — null이면 포인트 레코드 미생성 (첫 적립 전) */
+        /** 포인트 ��액 — null이면 포인트 레코드 미생성 (첫 적립 전) */
         Long pointBalance
 ) {
     public static UserResponse from(User user) {
@@ -23,6 +24,7 @@ public record UserResponse(
                 user.getId(),
                 user.getUsername(),
                 user.getEmail(),
+                user.getPhoneNumber(),
                 user.getRole(),
                 user.getCreatedAt(),
                 pointBalance

--- a/src/main/java/com/stockmanagement/domain/user/entity/User.java
+++ b/src/main/java/com/stockmanagement/domain/user/entity/User.java
@@ -35,6 +35,9 @@ public class User {
     @Column(nullable = false, unique = true, length = 100)
     private String email;
 
+    @Column(length = 20)
+    private String phoneNumber;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
     private UserRole role;
@@ -67,6 +70,11 @@ public class User {
     /** 이메일을 변경한다. */
     public void updateEmail(String email) {
         this.email = email;
+    }
+
+    /** 전화번호를 변경한다. */
+    public void updatePhoneNumber(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
     }
 
     /** 비밀번호를 변경한다 (이미 인코딩된 값을 전달해야 한다). */

--- a/src/main/java/com/stockmanagement/domain/user/service/UserService.java
+++ b/src/main/java/com/stockmanagement/domain/user/service/UserService.java
@@ -183,6 +183,9 @@ public class UserService {
             }
             user.updateEmail(request.getEmail());
         }
+        if (request.getPhoneNumber() != null) {
+            user.updatePhoneNumber(request.getPhoneNumber());
+        }
         return UserResponse.from(user);
     }
 

--- a/src/main/resources/db/migration/V44__add_users_phone_number.sql
+++ b/src/main/resources/db/migration/V44__add_users_phone_number.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN phone_number VARCHAR(20) NULL AFTER email;

--- a/src/test/java/com/stockmanagement/domain/user/controller/AuthControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/user/controller/AuthControllerTest.java
@@ -62,7 +62,7 @@ class AuthControllerTest {
         @Test
         @DisplayName("회원가입 성공 (인증 불필요) → 201")
         void signupSuccess() throws Exception {
-            UserResponse response = new UserResponse(1L, "testuser", "test@example.com", UserRole.USER, null, null);
+            UserResponse response = new UserResponse(1L, "testuser", "test@example.com", null, UserRole.USER, null, null);
             given(userService.signup(any())).willReturn(response);
 
             mockMvc.perform(post("/api/auth/signup")

--- a/src/test/java/com/stockmanagement/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/user/controller/UserControllerTest.java
@@ -75,7 +75,7 @@ class UserControllerTest {
         @Test
         @DisplayName("인증된 사용자 — 내 정보 조회 → 200")
         void returnsMyInfo() throws Exception {
-            UserResponse response = new UserResponse(1L, "testuser", "test@example.com", UserRole.USER, null, null);
+            UserResponse response = new UserResponse(1L, "testuser", "test@example.com", null, UserRole.USER, null, null);
             given(userService.getMe("testuser")).willReturn(response);
 
             mockMvc.perform(get("/api/users/me")


### PR DESCRIPTION
## Summary
- V43 migration: `users.phone_number VARCHAR(20)` 컬럼 추가
- `User` 엔티티에 `phoneNumber` 필드 + `updatePhoneNumber()` 메서드 추가
- `UserResponse`에 `phoneNumber` 필드 포함
- `UpdateProfileRequest`에 `phoneNumber` 필드 + 정규식 형식 검증 (`010-1234-5678`)
- `UserService.updateProfile()`에 전화번호 수정 로직 추가

## Test plan
- [x] User 도메인 테스트 전체 통과
- [x] 전체 테스트 통과 확인
- [ ] 통합 테스트에서 PATCH /api/users/me로 전화번호 수정 검증

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)