### PR TITLE
refactor: @CurrentUserId로 resolveUserId 보일러플레이트 제거 (#142)

### DIFF
--- a/src/main/java/com/stockmanagement/common/config/WebMvcConfig.java
+++ b/src/main/java/com/stockmanagement/common/config/WebMvcConfig.java
@@ -1,19 +1,31 @@
 package com.stockmanagement.common.config;
 
+import com.stockmanagement.common.security.CurrentUserIdResolver;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import java.util.List;
+
 /**
- * 정적 SPA 페이지 라우팅 설정.
- * /shop, /shop/ 접근 시 index.html로 포워드한다.
+ * 정적 SPA 페이지 라우팅 + 커스텀 Argument Resolver 설정.
  */
 @Configuration
+@RequiredArgsConstructor
 public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final CurrentUserIdResolver currentUserIdResolver;
 
     @Override
     public void addViewControllers(ViewControllerRegistry registry) {
         registry.addViewController("/shop").setViewName("forward:/shop/index.html");
         registry.addViewController("/shop/").setViewName("forward:/shop/index.html");
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(currentUserIdResolver);
     }
 }

--- a/src/main/java/com/stockmanagement/common/security/CurrentUserId.java
+++ b/src/main/java/com/stockmanagement/common/security/CurrentUserId.java
@@ -1,0 +1,25 @@
+package com.stockmanagement.common.security;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 현재 인증된 사용자의 userId를 컨트롤러 메서드 파라미터에 주입한다.
+ *
+ * <p>JWT claims의 userId를 우선 사용하고, 없으면 DB fallback으로 조회한다.
+ * {@code required = false}이면 미인증 시 null을 반환한다.
+ *
+ * <pre>
+ * {@literal @}GetMapping
+ * public ApiResponse&lt;CartResponse&gt; getCart(@CurrentUserId Long userId) { ... }
+ * </pre>
+ */
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CurrentUserId {
+
+    /** false이면 미인증 요청에서 null 반환 (기본: 인증 필수) */
+    boolean required() default true;
+}

--- a/src/main/java/com/stockmanagement/common/security/CurrentUserIdResolver.java
+++ b/src/main/java/com/stockmanagement/common/security/CurrentUserIdResolver.java
@@ -1,0 +1,56 @@
+package com.stockmanagement.common.security;
+
+import com.stockmanagement.common.exception.BusinessException;
+import com.stockmanagement.common.exception.ErrorCode;
+import com.stockmanagement.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+/**
+ * {@link CurrentUserId} 어노테이션이 붙은 파라미터에 인증된 사용자의 userId를 주입한다.
+ *
+ * <p>JWT claim의 userId를 우선 사용하고, 없으면 username으로 DB 조회한다.
+ */
+@Component
+@RequiredArgsConstructor
+public class CurrentUserIdResolver implements HandlerMethodArgumentResolver {
+
+    private final UserService userService;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(CurrentUserId.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        boolean required = parameter.getParameterAnnotation(CurrentUserId.class).required();
+
+        if (auth == null || !auth.isAuthenticated() || auth instanceof AnonymousAuthenticationToken) {
+            if (required) {
+                throw new BusinessException(ErrorCode.UNAUTHORIZED);
+            }
+            return null;
+        }
+
+        return SecurityUtils.resolveUserId(auth, () -> {
+            Object principal = auth.getPrincipal();
+            String username = (principal instanceof UserDetails ud)
+                    ? ud.getUsername() : (String) principal;
+            return userService.resolveUserId(username);
+        });
+    }
+}

--- a/src/main/java/com/stockmanagement/domain/coupon/controller/CouponController.java
+++ b/src/main/java/com/stockmanagement/domain/coupon/controller/CouponController.java
@@ -1,7 +1,7 @@
 package com.stockmanagement.domain.coupon.controller;
 
 import com.stockmanagement.common.dto.ApiResponse;
-import com.stockmanagement.common.security.SecurityUtils;
+import com.stockmanagement.common.security.CurrentUserId;
 import com.stockmanagement.domain.coupon.dto.CouponClaimRequest;
 import com.stockmanagement.domain.coupon.dto.CouponCreateRequest;
 import com.stockmanagement.domain.coupon.dto.CouponIssueRequest;
@@ -10,7 +10,6 @@ import com.stockmanagement.domain.coupon.dto.CouponValidateRequest;
 import com.stockmanagement.domain.coupon.dto.CouponValidateResponse;
 import com.stockmanagement.domain.coupon.dto.MyCouponResponse;
 import com.stockmanagement.domain.coupon.service.CouponService;
-import com.stockmanagement.domain.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -21,8 +20,6 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 
 import java.util.List;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Coupon", description = "쿠폰 관리 API")
@@ -32,7 +29,6 @@ import org.springframework.web.bind.annotation.*;
 public class CouponController {
 
     private final CouponService couponService;
-    private final UserService userService;
 
     @Operation(summary = "쿠폰 생성 [ADMIN]")
     @PostMapping
@@ -73,9 +69,8 @@ public class CouponController {
                description = "usable=true: 사용 가능한 쿠폰만, usable=false: 만료/소진된 쿠폰만, 미지정: 전체.")
     @GetMapping("/my")
     public ApiResponse<List<MyCouponResponse>> getMyCoupons(
-            @AuthenticationPrincipal String username, Authentication authentication,
+            @CurrentUserId Long userId,
             @RequestParam(required = false) Boolean usable) {
-        Long userId = SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username));
         return ApiResponse.ok(couponService.getMyCoupons(userId, usable));
     }
 
@@ -83,18 +78,16 @@ public class CouponController {
     @PostMapping("/claim")
     @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<MyCouponResponse> claim(
-            @AuthenticationPrincipal String username, Authentication authentication,
+            @CurrentUserId Long userId,
             @Valid @RequestBody CouponClaimRequest request) {
-        Long userId = SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username));
         return ApiResponse.ok(couponService.claim(userId, request));
     }
 
     @Operation(summary = "쿠폰 유효성 확인 + 할인 금액 미리보기 [USER]")
     @PostMapping("/validate")
     public ApiResponse<CouponValidateResponse> validate(
-            @AuthenticationPrincipal String username, Authentication authentication,
+            @CurrentUserId Long userId,
             @Valid @RequestBody CouponValidateRequest request) {
-        Long userId = SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username));
         return ApiResponse.ok(couponService.validate(userId, request));
     }
 }

--- a/src/main/java/com/stockmanagement/domain/order/cart/controller/CartController.java
+++ b/src/main/java/com/stockmanagement/domain/order/cart/controller/CartController.java
@@ -1,21 +1,18 @@
 package com.stockmanagement.domain.order.cart.controller;
 
 import com.stockmanagement.common.dto.ApiResponse;
-import com.stockmanagement.common.security.SecurityUtils;
+import com.stockmanagement.common.security.CurrentUserId;
 import com.stockmanagement.domain.order.cart.dto.CartCheckoutRequest;
 import com.stockmanagement.domain.order.cart.dto.CartItemRequest;
 import com.stockmanagement.domain.order.cart.dto.CartItemResponse;
 import com.stockmanagement.domain.order.cart.dto.CartResponse;
 import com.stockmanagement.domain.order.cart.service.CartService;
 import com.stockmanagement.domain.order.dto.OrderResponse;
-import com.stockmanagement.domain.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 /**
@@ -30,7 +27,7 @@ import org.springframework.web.bind.annotation.*;
  * </pre>
  *
  * <p>인증된 사용자 본인의 장바구니만 접근 가능하다.
- * {@code @AuthenticationPrincipal}로 현재 사용자명을 받아 userId를 조회한다.
+ * {@code @CurrentUserId}로 현재 사용자의 userId를 주입받는다.
  */
 @Tag(name = "장바구니", description = "상품 담기 · 수량 변경 · 삭제 · 주문 전환")
 @RestController
@@ -39,13 +36,10 @@ import org.springframework.web.bind.annotation.*;
 public class CartController {
 
     private final CartService cartService;
-    private final UserService userService;
 
     @Operation(summary = "장바구니 조회")
     @GetMapping
-    public ApiResponse<CartResponse> getCart(
-            @AuthenticationPrincipal String username, Authentication authentication) {
-        Long userId = SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username));
+    public ApiResponse<CartResponse> getCart(@CurrentUserId Long userId) {
         return ApiResponse.ok(cartService.getCart(userId));
     }
 
@@ -53,28 +47,22 @@ public class CartController {
                description = "동일 상품이 이미 있으면 수량을 요청값으로 교체한다.")
     @PostMapping("/items")
     public ApiResponse<CartItemResponse> addOrUpdate(
-            @AuthenticationPrincipal String username, Authentication authentication,
+            @CurrentUserId Long userId,
             @RequestBody @Valid CartItemRequest request) {
-        Long userId = SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username));
         return ApiResponse.ok(cartService.addOrUpdate(userId, request));
     }
 
     @Operation(summary = "특정 상품 제거")
     @DeleteMapping("/items/{productId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void removeItem(
-            @AuthenticationPrincipal String username, Authentication authentication,
-            @PathVariable Long productId) {
-        Long userId = SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username));
+    public void removeItem(@CurrentUserId Long userId, @PathVariable Long productId) {
         cartService.removeItem(userId, productId);
     }
 
     @Operation(summary = "장바구니 전체 비우기")
     @DeleteMapping
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void clear(
-            @AuthenticationPrincipal String username, Authentication authentication) {
-        Long userId = SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username));
+    public void clear(@CurrentUserId Long userId) {
         cartService.clear(userId);
     }
 
@@ -83,9 +71,8 @@ public class CartController {
     @PostMapping("/checkout")
     @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<OrderResponse> checkout(
-            @AuthenticationPrincipal String username, Authentication authentication,
+            @CurrentUserId Long userId,
             @RequestBody @Valid CartCheckoutRequest request) {
-        Long userId = SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username));
         return ApiResponse.ok(cartService.checkout(userId, request));
     }
 }

--- a/src/main/java/com/stockmanagement/domain/order/controller/OrderController.java
+++ b/src/main/java/com/stockmanagement/domain/order/controller/OrderController.java
@@ -3,6 +3,7 @@ package com.stockmanagement.domain.order.controller;
 import com.stockmanagement.common.dto.ApiResponse;
 import com.stockmanagement.common.dto.CursorPage;
 import com.stockmanagement.common.ratelimit.RateLimit;
+import com.stockmanagement.common.security.CurrentUserId;
 import com.stockmanagement.common.security.SecurityUtils;
 import com.stockmanagement.domain.order.dto.OrderCancelRequest;
 import com.stockmanagement.domain.order.dto.OrderCreateRequest;
@@ -16,7 +17,6 @@ import com.stockmanagement.domain.order.entity.OrderStatus;
 import com.stockmanagement.domain.order.service.OrderCommandService;
 import com.stockmanagement.domain.order.service.OrderDetailService;
 import com.stockmanagement.domain.order.service.OrderQueryService;
-import com.stockmanagement.domain.user.service.UserService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -30,7 +30,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -50,15 +49,13 @@ public class OrderController {
     private final OrderQueryService orderQueryService;
     private final OrderCommandService orderCommandService;
     private final OrderDetailService orderDetailService;
-    private final UserService userService;
 
     @Operation(summary = "주문 금액 미리보기", description = "쿠폰·포인트 적용 시 최종 결제 금액을 계산한다. 주문 생성 없이 순수 계산만 수행.")
     @PostMapping("/preview")
     public ApiResponse<OrderPreviewResponse> preview(
             @RequestBody @Valid OrderPreviewRequest request,
-            @AuthenticationPrincipal String username,
-            Authentication authentication) {
-        return ApiResponse.ok(orderQueryService.preview(request, SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username))));
+            @CurrentUserId Long userId) {
+        return ApiResponse.ok(orderQueryService.preview(request, userId));
     }
 
     @Operation(summary = "주문 생성", description = "재고 예약(reserved++) 후 PENDING 주문 생성. 동일 idempotencyKey 재요청 시 기존 주문 반환.")
@@ -67,9 +64,7 @@ public class OrderController {
     @RateLimit(limit = 10, windowSeconds = 60)
     public ApiResponse<OrderResponse> create(
             @RequestBody @Valid OrderCreateRequest request,
-            @AuthenticationPrincipal String username,
-            Authentication authentication) {
-        Long userId = SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username));
+            @CurrentUserId Long userId) {
         return ApiResponse.ok(orderCommandService.create(request, userId));
     }
 
@@ -77,10 +72,10 @@ public class OrderController {
     @GetMapping("/{id}")
     public ApiResponse<OrderResponse> getById(
             @PathVariable Long id,
-            @AuthenticationPrincipal String username,
+            @CurrentUserId Long userId,
             Authentication authentication) {
         boolean isAdmin = SecurityUtils.isAdmin(authentication);
-        return ApiResponse.ok(orderQueryService.getByIdForUser(id, SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username)), isAdmin));
+        return ApiResponse.ok(orderQueryService.getByIdForUser(id, userId, isAdmin));
     }
 
     @Operation(summary = "주문 상세 통합 조회",
@@ -88,24 +83,24 @@ public class OrderController {
     @GetMapping("/{id}/detail")
     public ApiResponse<OrderDetailResponse> getDetail(
             @PathVariable Long id,
-            @AuthenticationPrincipal String username,
+            @CurrentUserId Long userId,
             Authentication authentication) {
         boolean isAdmin = SecurityUtils.isAdmin(authentication);
-        return ApiResponse.ok(orderDetailService.getDetail(id, SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username)), isAdmin));
+        return ApiResponse.ok(orderDetailService.getDetail(id, userId, isAdmin));
     }
 
     @Operation(summary = "주문 목록 조회 (필터 + 페이징)",
                description = "status / startDate / endDate 필터 지원. ADMIN은 userId 파라미터로 특정 사용자 주문 조회 가능. USER는 본인 주문만 조회된다.")
     @GetMapping
     public ApiResponse<Page<OrderResponse>> getList(
-            @AuthenticationPrincipal String username,
+            @CurrentUserId(required = false) Long userId,
             Authentication authentication,
             @ModelAttribute OrderSearchRequest request,
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
             Pageable pageable) {
         boolean isAdmin = SecurityUtils.isAdmin(authentication);
-        Long userId = isAdmin ? null : SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username));
-        return ApiResponse.ok(orderQueryService.getList(userId, isAdmin, request, pageable));
+        Long effectiveUserId = isAdmin ? null : userId;
+        return ApiResponse.ok(orderQueryService.getList(effectiveUserId, isAdmin, request, pageable));
     }
 
     @Operation(
@@ -121,13 +116,12 @@ public class OrderController {
     )
     @GetMapping("/scroll")
     public ApiResponse<CursorPage<OrderResponse>> scroll(
-            @AuthenticationPrincipal String username,
+            @CurrentUserId Long userId,
             Authentication authentication,
             @RequestParam(required = false) OrderStatus status,
             @RequestParam(required = false) Long lastId,
             @Min(1) @Max(100) @RequestParam(defaultValue = "20") int size) {
         boolean isAdmin = SecurityUtils.isAdmin(authentication);
-        Long userId = SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username));
         return ApiResponse.ok(orderQueryService.getOrderScroll(userId, isAdmin, status, lastId, size));
     }
 
@@ -136,20 +130,20 @@ public class OrderController {
     public ApiResponse<OrderResponse> cancel(
             @PathVariable Long id,
             @RequestBody(required = false) @Valid OrderCancelRequest request,
-            @AuthenticationPrincipal String username,
+            @CurrentUserId Long userId,
             Authentication authentication) {
         boolean isAdmin = SecurityUtils.isAdmin(authentication);
         String reason = request != null ? request.reason() : null;
-        return ApiResponse.ok(orderCommandService.cancel(id, SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username)), isAdmin, reason));
+        return ApiResponse.ok(orderCommandService.cancel(id, userId, isAdmin, reason));
     }
 
     @Operation(summary = "주문 상태 변경 이력 조회", description = "생성·취소·확정·환불 등 모든 상태 전이를 시간순으로 반환. ADMIN은 모든 주문, USER는 본인 주문만 가능.")
     @GetMapping("/{id}/history")
     public ApiResponse<List<OrderStatusHistoryResponse>> getHistory(
             @PathVariable Long id,
-            @AuthenticationPrincipal String username,
+            @CurrentUserId Long userId,
             Authentication authentication) {
         boolean isAdmin = SecurityUtils.isAdmin(authentication);
-        return ApiResponse.ok(orderQueryService.getHistory(id, SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username)), isAdmin));
+        return ApiResponse.ok(orderQueryService.getHistory(id, userId, isAdmin));
     }
 }

--- a/src/main/java/com/stockmanagement/domain/payment/controller/PaymentController.java
+++ b/src/main/java/com/stockmanagement/domain/payment/controller/PaymentController.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import com.stockmanagement.common.dto.ApiResponse;
 import com.stockmanagement.common.ratelimit.RateLimit;
+import com.stockmanagement.common.security.CurrentUserId;
+import com.stockmanagement.common.security.SecurityUtils;
 import com.stockmanagement.domain.payment.dto.*;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -13,14 +15,11 @@ import org.springframework.data.web.PageableDefault;
 import com.stockmanagement.domain.payment.infrastructure.TossWebhookVerifier;
 import com.stockmanagement.domain.payment.infrastructure.dto.TossWebhookEvent;
 import com.stockmanagement.domain.payment.service.PaymentService;
-import com.stockmanagement.domain.user.service.UserService;
 import jakarta.validation.Valid;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import com.stockmanagement.common.security.SecurityUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 /**
@@ -46,15 +45,13 @@ public class PaymentController {
     private final PaymentService paymentService;
     private final TossWebhookVerifier webhookVerifier;
     private final ObjectMapper objectMapper;
-    private final UserService userService;
 
     @Operation(summary = "결제 준비", description = "TossPayments 결제창 렌더링 전 호출. tossOrderId와 amount 반환. 본인 주문만 가능.")
     @PostMapping("/prepare")
     public ApiResponse<PaymentPrepareResponse> prepare(
             @RequestBody @Valid PaymentPrepareRequest request,
-            @AuthenticationPrincipal String username,
-            Authentication authentication) {
-        return ApiResponse.ok(paymentService.prepare(request, SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username))));
+            @CurrentUserId Long userId) {
+        return ApiResponse.ok(paymentService.prepare(request, userId));
     }
 
     @Operation(summary = "결제 승인", description = "결제창 완료 후 paymentKey로 호출. Order → CONFIRMED, reserved→allocated. 본인 주문만 가능.")
@@ -62,9 +59,8 @@ public class PaymentController {
     @RateLimit(limit = 5, windowSeconds = 60)
     public ApiResponse<PaymentResponse> confirm(
             @RequestBody @Valid PaymentConfirmRequest request,
-            @AuthenticationPrincipal String username,
-            Authentication authentication) {
-        return ApiResponse.ok(paymentService.confirm(request, SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username))));
+            @CurrentUserId Long userId) {
+        return ApiResponse.ok(paymentService.confirm(request, userId));
     }
 
     @Operation(summary = "결제 취소/환불", description = "본인 결제만 취소 가능. ADMIN은 전체 취소 가능. Order → CANCELLED, allocated 해제.")
@@ -72,10 +68,10 @@ public class PaymentController {
     public ApiResponse<PaymentResponse> cancel(
             @PathVariable String paymentKey,
             @RequestBody @Valid PaymentCancelRequest request,
-            @AuthenticationPrincipal String username,
+            @CurrentUserId Long userId,
             Authentication authentication) {
         boolean isAdmin = SecurityUtils.isAdmin(authentication);
-        return ApiResponse.ok(paymentService.cancel(paymentKey, request, SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username)), isAdmin));
+        return ApiResponse.ok(paymentService.cancel(paymentKey, request, userId, isAdmin));
     }
 
     @Operation(summary = "TossPayments 웹훅 수신", description = "공개 엔드포인트. Toss-Signature 헤더로 HMAC-SHA256 서명 검증 후 처리.")
@@ -97,29 +93,28 @@ public class PaymentController {
     @Operation(summary = "내 결제 목록", description = "현재 로그인 사용자의 결제 내역을 최신순으로 페이징 조회한다.")
     @GetMapping("/my")
     public ApiResponse<Page<PaymentResponse>> getMyPayments(
-            @AuthenticationPrincipal String username,
-            Authentication authentication,
+            @CurrentUserId Long userId,
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        return ApiResponse.ok(paymentService.getMyPayments(SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username)), pageable));
+        return ApiResponse.ok(paymentService.getMyPayments(userId, pageable));
     }
 
     @Operation(summary = "결제 조회", description = "paymentKey로 결제 상세 조회. 본인 결제만 가능 (ADMIN은 전체 조회).")
     @GetMapping("/{paymentKey}")
     public ApiResponse<PaymentResponse> getByPaymentKey(
             @PathVariable String paymentKey,
-            @AuthenticationPrincipal String username,
+            @CurrentUserId Long userId,
             Authentication authentication) {
         boolean isAdmin = SecurityUtils.isAdmin(authentication);
-        return ApiResponse.ok(paymentService.getByPaymentKey(paymentKey, SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username)), isAdmin));
+        return ApiResponse.ok(paymentService.getByPaymentKey(paymentKey, userId, isAdmin));
     }
 
     @Operation(summary = "주문별 결제 조회", description = "주문 ID로 결제 정보 조회. 결제 전이면 data: null 반환. 본인 주문만 가능.")
     @GetMapping("/order/{orderId}")
     public ApiResponse<PaymentResponse> getByOrderId(
             @PathVariable Long orderId,
-            @AuthenticationPrincipal String username,
+            @CurrentUserId Long userId,
             Authentication authentication) {
         boolean isAdmin = SecurityUtils.isAdmin(authentication);
-        return ApiResponse.ok(paymentService.getByOrderId(orderId, SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username)), isAdmin).orElse(null));
+        return ApiResponse.ok(paymentService.getByOrderId(orderId, userId, isAdmin).orElse(null));
     }
 }

--- a/src/main/java/com/stockmanagement/domain/product/controller/ProductController.java
+++ b/src/main/java/com/stockmanagement/domain/product/controller/ProductController.java
@@ -1,14 +1,13 @@
 package com.stockmanagement.domain.product.controller;
 
 import com.stockmanagement.common.dto.ApiResponse;
-import com.stockmanagement.common.security.SecurityUtils;
+import com.stockmanagement.common.security.CurrentUserId;
 import com.stockmanagement.domain.product.dto.ProductCreateRequest;
 import com.stockmanagement.domain.product.dto.ProductResponse;
 import com.stockmanagement.domain.product.dto.ProductSearchRequest;
 import com.stockmanagement.domain.product.dto.ProductStatusRequest;
 import com.stockmanagement.domain.product.dto.ProductUpdateRequest;
 import com.stockmanagement.domain.product.service.ProductService;
-import com.stockmanagement.domain.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -17,9 +16,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.authentication.AnonymousAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "상품", description = "상품 CRUD — 등록·조회·수정·삭제")
@@ -29,7 +25,6 @@ import org.springframework.web.bind.annotation.*;
 public class ProductController {
 
     private final ProductService productService;
-    private final UserService userService;
 
     @Operation(summary = "상품 등록", description = "ADMIN 전용. SKU 중복 시 409.")
     @PostMapping
@@ -42,10 +37,8 @@ public class ProductController {
     @GetMapping("/{id}")
     public ApiResponse<ProductResponse> getById(
             @PathVariable Long id,
-            @AuthenticationPrincipal String username,
-            Authentication authentication) {
-        if (isAuthenticated(authentication)) {
-            Long userId = SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username));
+            @CurrentUserId(required = false) Long userId) {
+        if (userId != null) {
             return ApiResponse.ok(productService.getByIdForUser(id, userId));
         }
         return ApiResponse.ok(productService.getById(id));
@@ -62,9 +55,7 @@ public class ProductController {
     public ApiResponse<Page<ProductResponse>> getList(
             @ModelAttribute @Valid ProductSearchRequest request,
             @PageableDefault(size = 20, sort = "id") Pageable pageable,
-            @AuthenticationPrincipal String username,
-            Authentication authentication) {
-        Long userId = isAuthenticated(authentication) ? SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username)) : null;
+            @CurrentUserId(required = false) Long userId) {
         return ApiResponse.ok(productService.getList(pageable, request, userId));
     }
 
@@ -89,11 +80,5 @@ public class ProductController {
             @PathVariable Long id,
             @RequestBody @Valid ProductStatusRequest request) {
         return ApiResponse.ok(productService.changeStatus(id, request));
-    }
-
-    /** 실제 인증 여부 확인 — AnonymousAuthenticationToken은 비로그인으로 처리 */
-    private boolean isAuthenticated(Authentication auth) {
-        return auth != null && auth.isAuthenticated()
-                && !(auth instanceof AnonymousAuthenticationToken);
     }
 }

--- a/src/main/java/com/stockmanagement/domain/product/review/controller/ReviewController.java
+++ b/src/main/java/com/stockmanagement/domain/product/review/controller/ReviewController.java
@@ -1,13 +1,12 @@
 package com.stockmanagement.domain.product.review.controller;
 
 import com.stockmanagement.common.dto.ApiResponse;
-import com.stockmanagement.common.security.SecurityUtils;
+import com.stockmanagement.common.security.CurrentUserId;
 import com.stockmanagement.domain.product.review.dto.RatingStatsResponse;
 import com.stockmanagement.domain.product.review.dto.ReviewCreateRequest;
 import com.stockmanagement.domain.product.review.dto.ReviewResponse;
 import com.stockmanagement.domain.product.review.dto.ReviewUpdateRequest;
 import com.stockmanagement.domain.product.review.service.ReviewService;
-import com.stockmanagement.domain.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -17,8 +16,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Review", description = "상품 리뷰 API")
@@ -28,17 +25,15 @@ import org.springframework.web.bind.annotation.*;
 public class ReviewController {
 
     private final ReviewService reviewService;
-    private final UserService userService;
 
     @Operation(summary = "리뷰 작성 (실구매자 한정, 상품당 1회)")
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<ReviewResponse> create(
             @PathVariable Long productId,
-            @AuthenticationPrincipal String username,
-            Authentication authentication,
+            @CurrentUserId Long userId,
             @Valid @RequestBody ReviewCreateRequest request) {
-        return ApiResponse.ok(reviewService.create(productId, SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username)), request));
+        return ApiResponse.ok(reviewService.create(productId, userId, request));
     }
 
     @Operation(summary = "상품 리뷰 목록 조회",
@@ -64,10 +59,9 @@ public class ReviewController {
     public ApiResponse<ReviewResponse> update(
             @PathVariable Long productId,
             @PathVariable Long reviewId,
-            @AuthenticationPrincipal String username,
-            Authentication authentication,
+            @CurrentUserId Long userId,
             @Valid @RequestBody ReviewUpdateRequest request) {
-        return ApiResponse.ok(reviewService.update(productId, reviewId, SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username)), request));
+        return ApiResponse.ok(reviewService.update(productId, reviewId, userId, request));
     }
 
     @Operation(summary = "리뷰 삭제 (작성자 본인)")
@@ -76,8 +70,7 @@ public class ReviewController {
     public void delete(
             @PathVariable Long productId,
             @PathVariable Long reviewId,
-            @AuthenticationPrincipal String username,
-            Authentication authentication) {
-        reviewService.delete(productId, reviewId, SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username)));
+            @CurrentUserId Long userId) {
+        reviewService.delete(productId, reviewId, userId);
     }
 }

--- a/src/main/java/com/stockmanagement/domain/product/wishlist/controller/WishlistController.java
+++ b/src/main/java/com/stockmanagement/domain/product/wishlist/controller/WishlistController.java
@@ -1,10 +1,9 @@
 package com.stockmanagement.domain.product.wishlist.controller;
 
 import com.stockmanagement.common.dto.ApiResponse;
-import com.stockmanagement.common.security.SecurityUtils;
+import com.stockmanagement.common.security.CurrentUserId;
 import com.stockmanagement.domain.product.wishlist.dto.WishlistResponse;
 import com.stockmanagement.domain.product.wishlist.service.WishlistService;
-import com.stockmanagement.domain.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -13,8 +12,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Wishlist", description = "위시리스트 API")
@@ -24,45 +21,36 @@ import org.springframework.web.bind.annotation.*;
 public class WishlistController {
 
     private final WishlistService wishlistService;
-    private final UserService userService;
 
     @Operation(summary = "위시리스트에 상품 추가")
     @PostMapping("/{productId}")
     @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<WishlistResponse> add(
-            @PathVariable Long productId,
-            @AuthenticationPrincipal String username,
-            Authentication authentication) {
-        return ApiResponse.ok(wishlistService.add(productId, SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username))));
+            @PathVariable Long productId, @CurrentUserId Long userId) {
+        return ApiResponse.ok(wishlistService.add(productId, userId));
     }
 
     @Operation(summary = "위시리스트에서 상품 제거")
     @DeleteMapping("/{productId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void remove(
-            @PathVariable Long productId,
-            @AuthenticationPrincipal String username,
-            Authentication authentication) {
-        wishlistService.remove(productId, SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username)));
+    public void remove(@PathVariable Long productId, @CurrentUserId Long userId) {
+        wishlistService.remove(productId, userId);
     }
 
     @Operation(summary = "특정 상품의 위시리스트 추가 여부 조회",
                description = "상품 상세 페이지의 하트 아이콘 상태에 사용. { \"wishlisted\": true/false } 반환.")
     @GetMapping("/{productId}")
     public ApiResponse<java.util.Map<String, Boolean>> isWishlisted(
-            @PathVariable Long productId,
-            @AuthenticationPrincipal String username,
-            Authentication authentication) {
-        boolean wishlisted = wishlistService.isWishlisted(productId, SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username)));
+            @PathVariable Long productId, @CurrentUserId Long userId) {
+        boolean wishlisted = wishlistService.isWishlisted(productId, userId);
         return ApiResponse.ok(java.util.Map.of("wishlisted", wishlisted));
     }
 
     @Operation(summary = "내 위시리스트 목록 조회 (페이지네이션)")
     @GetMapping
     public ApiResponse<Page<WishlistResponse>> getList(
-            @AuthenticationPrincipal String username,
-            Authentication authentication,
+            @CurrentUserId Long userId,
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        return ApiResponse.ok(wishlistService.getList(SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username)), pageable));
+        return ApiResponse.ok(wishlistService.getList(userId, pageable));
     }
 }

--- a/src/main/java/com/stockmanagement/domain/refund/controller/RefundController.java
+++ b/src/main/java/com/stockmanagement/domain/refund/controller/RefundController.java
@@ -1,11 +1,11 @@
 package com.stockmanagement.domain.refund.controller;
 
 import com.stockmanagement.common.dto.ApiResponse;
+import com.stockmanagement.common.security.CurrentUserId;
 import com.stockmanagement.common.security.SecurityUtils;
 import com.stockmanagement.domain.refund.dto.RefundRequest;
 import com.stockmanagement.domain.refund.dto.RefundResponse;
 import com.stockmanagement.domain.refund.service.RefundService;
-import com.stockmanagement.domain.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -16,7 +16,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -28,44 +27,41 @@ import java.util.List;
 public class RefundController {
 
     private final RefundService refundService;
-    private final UserService userService;
 
     @Operation(summary = "환불 요청")
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<RefundResponse> requestRefund(
             @Valid @RequestBody RefundRequest request,
-            @AuthenticationPrincipal String username,
-            Authentication authentication) {
-        return ApiResponse.ok(refundService.requestRefund(request, SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username))));
+            @CurrentUserId Long userId) {
+        return ApiResponse.ok(refundService.requestRefund(request, userId));
     }
 
     @Operation(summary = "내 환불 목록", description = "현재 로그인 사용자의 환불 내역을 최신순으로 페이징 조회한다.")
     @GetMapping("/my")
     public ApiResponse<Page<RefundResponse>> getMyRefunds(
-            @AuthenticationPrincipal String username,
-            Authentication authentication,
+            @CurrentUserId Long userId,
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        return ApiResponse.ok(refundService.getMyRefunds(SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username)), pageable));
+        return ApiResponse.ok(refundService.getMyRefunds(userId, pageable));
     }
 
     @Operation(summary = "환불 단건 조회", description = "ADMIN은 모든 환불 조회 가능. USER는 본인 주문의 환불만 가능.")
     @GetMapping("/{refundId}")
     public ApiResponse<RefundResponse> getById(
             @PathVariable Long refundId,
-            @AuthenticationPrincipal String username,
+            @CurrentUserId Long userId,
             Authentication authentication) {
         boolean isAdmin = SecurityUtils.isAdmin(authentication);
-        return ApiResponse.ok(refundService.getById(refundId, SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username)), isAdmin));
+        return ApiResponse.ok(refundService.getById(refundId, userId, isAdmin));
     }
 
     @Operation(summary = "결제 ID로 환불 목록 조회", description = "부분 취소 시 다건 반환. ADMIN은 모든 환불 조회 가능. USER는 본인 주문의 환불만 가능.")
     @GetMapping("/payments/{paymentId}")
     public ApiResponse<List<RefundResponse>> getByPaymentId(
             @PathVariable Long paymentId,
-            @AuthenticationPrincipal String username,
+            @CurrentUserId Long userId,
             Authentication authentication) {
         boolean isAdmin = SecurityUtils.isAdmin(authentication);
-        return ApiResponse.ok(refundService.getByPaymentId(paymentId, SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username)), isAdmin));
+        return ApiResponse.ok(refundService.getByPaymentId(paymentId, userId, isAdmin));
     }
 }

--- a/src/main/java/com/stockmanagement/domain/shipment/controller/ShipmentController.java
+++ b/src/main/java/com/stockmanagement/domain/shipment/controller/ShipmentController.java
@@ -1,11 +1,11 @@
 package com.stockmanagement.domain.shipment.controller;
 
 import com.stockmanagement.common.dto.ApiResponse;
+import com.stockmanagement.common.security.CurrentUserId;
 import com.stockmanagement.common.security.SecurityUtils;
 import com.stockmanagement.domain.shipment.dto.ShipmentResponse;
 import com.stockmanagement.domain.shipment.dto.ShipmentUpdateRequest;
 import com.stockmanagement.domain.shipment.service.ShipmentService;
-import com.stockmanagement.domain.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -38,15 +38,12 @@ import org.springframework.web.bind.annotation.*;
 public class ShipmentController {
 
     private final ShipmentService shipmentService;
-    private final UserService userService;
 
     @Operation(summary = "내 배송 목록 조회", description = "로그인한 사용자의 배송 목록을 최신순으로 반환한다.")
     @GetMapping("/my")
     public ApiResponse<Page<ShipmentResponse>> getMyShipments(
-            @AuthenticationPrincipal String username,
-            Authentication authentication,
+            @CurrentUserId Long userId,
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        Long userId = SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username));
         return ApiResponse.ok(shipmentService.getMyShipments(userId, pageable));
     }
 

--- a/src/main/java/com/stockmanagement/domain/user/address/controller/DeliveryAddressController.java
+++ b/src/main/java/com/stockmanagement/domain/user/address/controller/DeliveryAddressController.java
@@ -1,18 +1,15 @@
 package com.stockmanagement.domain.user.address.controller;
 
 import com.stockmanagement.common.dto.ApiResponse;
-import com.stockmanagement.common.security.SecurityUtils;
+import com.stockmanagement.common.security.CurrentUserId;
 import com.stockmanagement.domain.user.address.dto.DeliveryAddressRequest;
 import com.stockmanagement.domain.user.address.dto.DeliveryAddressResponse;
 import com.stockmanagement.domain.user.address.service.DeliveryAddressService;
-import com.stockmanagement.domain.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -36,61 +33,49 @@ import java.util.List;
 public class DeliveryAddressController {
 
     private final DeliveryAddressService deliveryAddressService;
-    private final UserService userService;
 
     @Operation(summary = "배송지 등록", description = "첫 번째 배송지는 자동으로 기본 배송지로 설정된다.")
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<DeliveryAddressResponse> create(
-            @AuthenticationPrincipal String username, Authentication authentication,
+            @CurrentUserId Long userId,
             @RequestBody @Valid DeliveryAddressRequest request) {
-        Long userId = SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username));
         return ApiResponse.ok(deliveryAddressService.create(userId, request));
     }
 
     @Operation(summary = "내 배송지 목록 조회", description = "기본 배송지가 맨 앞에 온다.")
     @GetMapping
-    public ApiResponse<List<DeliveryAddressResponse>> getList(
-            @AuthenticationPrincipal String username, Authentication authentication) {
-        Long userId = SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username));
+    public ApiResponse<List<DeliveryAddressResponse>> getList(@CurrentUserId Long userId) {
         return ApiResponse.ok(deliveryAddressService.getList(userId));
     }
 
     @Operation(summary = "배송지 단건 조회")
     @GetMapping("/{id}")
     public ApiResponse<DeliveryAddressResponse> getById(
-            @AuthenticationPrincipal String username, Authentication authentication,
-            @PathVariable Long id) {
-        Long userId = SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username));
+            @CurrentUserId Long userId, @PathVariable Long id) {
         return ApiResponse.ok(deliveryAddressService.getById(id, userId));
     }
 
     @Operation(summary = "배송지 수정")
     @PutMapping("/{id}")
     public ApiResponse<DeliveryAddressResponse> update(
-            @AuthenticationPrincipal String username, Authentication authentication,
+            @CurrentUserId Long userId,
             @PathVariable Long id,
             @RequestBody @Valid DeliveryAddressRequest request) {
-        Long userId = SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username));
         return ApiResponse.ok(deliveryAddressService.update(id, userId, request));
     }
 
     @Operation(summary = "배송지 삭제", description = "기본 배송지 삭제 시 다른 배송지가 자동으로 기본으로 승격된다.")
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void delete(
-            @AuthenticationPrincipal String username, Authentication authentication,
-            @PathVariable Long id) {
-        Long userId = SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username));
+    public void delete(@CurrentUserId Long userId, @PathVariable Long id) {
         deliveryAddressService.delete(id, userId);
     }
 
     @Operation(summary = "기본 배송지 설정", description = "기존 기본 배송지를 해제하고 지정된 배송지를 기본으로 변경한다.")
     @PostMapping("/{id}/default")
     public ApiResponse<DeliveryAddressResponse> setDefault(
-            @AuthenticationPrincipal String username, Authentication authentication,
-            @PathVariable Long id) {
-        Long userId = SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username));
+            @CurrentUserId Long userId, @PathVariable Long id) {
         return ApiResponse.ok(deliveryAddressService.setDefault(id, userId));
     }
 }

--- a/src/main/java/com/stockmanagement/domain/user/controller/UserController.java
+++ b/src/main/java/com/stockmanagement/domain/user/controller/UserController.java
@@ -1,7 +1,7 @@
 package com.stockmanagement.domain.user.controller;
 
 import com.stockmanagement.common.dto.ApiResponse;
-import com.stockmanagement.common.security.SecurityUtils;
+import com.stockmanagement.common.security.CurrentUserId;
 import com.stockmanagement.domain.order.dto.OrderResponse;
 import com.stockmanagement.domain.product.review.dto.ReviewResponse;
 import com.stockmanagement.domain.product.review.service.ReviewService;
@@ -18,7 +18,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -88,12 +87,10 @@ public class UserController {
                description = "별점 필터 지원 (?rating=1~5). sort 파라미터로 정렬 지정 (createdAt DESC 기본).")
     @GetMapping("/me/reviews")
     public ApiResponse<Page<ReviewResponse>> getMyReviews(
-            @AuthenticationPrincipal String username,
-            Authentication authentication,
+            @CurrentUserId Long userId,
             @RequestParam(required = false) Integer rating,
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
             Pageable pageable) {
-        Long userId = SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username));
         return ApiResponse.ok(reviewService.getMyReviews(userId, pageable, rating));
     }
 }

--- a/src/test/java/com/stockmanagement/domain/admin/controller/AdminControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/admin/controller/AdminControllerTest.java
@@ -2,6 +2,7 @@ package com.stockmanagement.domain.admin.controller;
 
 import com.stockmanagement.common.config.SecurityConfig;
 import com.stockmanagement.common.security.JwtBlacklist;
+import com.stockmanagement.domain.user.service.UserService;
 import com.stockmanagement.domain.admin.dto.AdminOrderResponse;
 import com.stockmanagement.domain.admin.dto.DashboardResponse;
 import com.stockmanagement.domain.admin.service.AdminService;
@@ -46,6 +47,7 @@ class AdminControllerTest {
     @MockBean private SystemSettingService systemSettingService;
     @MockBean private JwtTokenProvider jwtTokenProvider;
     @MockBean private JwtBlacklist jwtBlacklist;
+    @MockBean private UserService userService;
 
     // ===== GET /api/admin/dashboard =====
 

--- a/src/test/java/com/stockmanagement/domain/inventory/controller/InventoryControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/inventory/controller/InventoryControllerTest.java
@@ -9,6 +9,7 @@ import com.stockmanagement.domain.inventory.dto.InventoryResponse;
 import com.stockmanagement.domain.inventory.service.InventoryService;
 import com.stockmanagement.common.security.JwtBlacklist;
 import com.stockmanagement.common.security.JwtTokenProvider;
+import com.stockmanagement.domain.user.service.UserService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -45,6 +46,9 @@ class InventoryControllerTest {
 
     @MockBean
     private JwtBlacklist jwtBlacklist;
+
+    @MockBean
+    private UserService userService;
 
     // ===== GET /api/inventory =====
 

--- a/src/test/java/com/stockmanagement/domain/point/controller/PointControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/point/controller/PointControllerTest.java
@@ -2,6 +2,7 @@ package com.stockmanagement.domain.point.controller;
 
 import com.stockmanagement.common.config.SecurityConfig;
 import com.stockmanagement.common.security.JwtBlacklist;
+import com.stockmanagement.domain.user.service.UserService;
 import com.stockmanagement.domain.point.dto.PointBalanceResponse;
 import com.stockmanagement.domain.point.dto.PointTransactionResponse;
 import com.stockmanagement.domain.point.service.PointService;
@@ -40,6 +41,7 @@ class PointControllerTest {
     @MockBean private PointService pointService;
     @MockBean private JwtTokenProvider jwtTokenProvider;
     @MockBean private JwtBlacklist jwtBlacklist;
+    @MockBean private UserService userService;
 
     private static final UsernamePasswordAuthenticationToken USER_AUTH =
             new UsernamePasswordAuthenticationToken("user1", null,

--- a/src/test/java/com/stockmanagement/domain/product/category/controller/CategoryControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/product/category/controller/CategoryControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.stockmanagement.common.config.SecurityConfig;
 import com.stockmanagement.common.security.JwtBlacklist;
 import com.stockmanagement.common.security.RefreshTokenStore;
+import com.stockmanagement.domain.user.service.UserService;
 import com.stockmanagement.domain.product.category.dto.CategoryResponse;
 import com.stockmanagement.domain.product.category.service.CategoryService;
 import com.stockmanagement.common.security.JwtTokenProvider;
@@ -48,6 +49,9 @@ class CategoryControllerTest {
 
     @MockBean
     private RefreshTokenStore refreshTokenStore;
+
+    @MockBean
+    private UserService userService;
 
     private static final String VALID_CREATE_JSON = "{\"name\":\"전자\"}";
 

--- a/src/test/java/com/stockmanagement/domain/product/image/controller/ProductImageControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/product/image/controller/ProductImageControllerTest.java
@@ -3,6 +3,7 @@ package com.stockmanagement.domain.product.image.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.stockmanagement.common.config.SecurityConfig;
 import com.stockmanagement.common.security.JwtBlacklist;
+import com.stockmanagement.domain.user.service.UserService;
 import com.stockmanagement.domain.product.image.dto.*;
 import com.stockmanagement.domain.product.image.entity.ImageType;
 import com.stockmanagement.domain.product.image.service.ProductImageService;
@@ -39,6 +40,7 @@ class ProductImageControllerTest {
     @MockBean private ProductImageService productImageService;
     @MockBean private JwtTokenProvider jwtTokenProvider;
     @MockBean private JwtBlacklist jwtBlacklist;
+    @MockBean private UserService userService;
 
     private static final String BASE_URL = "/api/products/1/images";
 


### PR DESCRIPTION
## Summary
- `@CurrentUserId` 커스텀 어노테이션 + `CurrentUserIdResolver` (HandlerMethodArgumentResolver) 도입
- 11개 컨트롤러 30+ 메서드에서 반복되던 `SecurityUtils.resolveUserId(authentication, () -> userService.resolveUserId(username))` 패턴을 `@CurrentUserId Long userId` 단일 파라미터로 통일
- 컨트롤러에서 `UserService` 의존성 제거 (resolver로 이동)
- `required=false` 옵션으로 미인증 허용 케이스 지원 (ProductController 등)

## 변경 파일
| 구분 | 파일 |
|------|------|
| 신규 | `CurrentUserId.java`, `CurrentUserIdResolver.java` |
| 수정 | `WebMvcConfig.java` + 11개 컨트롤러 + 5개 테스트 |

## Test plan
- [x] 647개 전체 테스트 통과 확인
- [x] `@WithMockUser` 및 `authentication()` 기반 테스트 모두 정상 동작
- [x] `required=false` (미인증 → null) 케이스 검증

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)