### PR TITLE
feat: MyCouponResponse에 쿠폰 사용 주문 정보 추가 (#115)

### DIFF
--- a/src/main/java/com/stockmanagement/domain/coupon/dto/MyCouponResponse.java
+++ b/src/main/java/com/stockmanagement/domain/coupon/dto/MyCouponResponse.java
@@ -2,6 +2,7 @@ package com.stockmanagement.domain.coupon.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.stockmanagement.domain.coupon.entity.Coupon;
+import com.stockmanagement.domain.coupon.entity.CouponUsage;
 import com.stockmanagement.domain.coupon.entity.DiscountType;
 import com.stockmanagement.domain.coupon.entity.UserCoupon;
 import lombok.Builder;
@@ -34,7 +35,15 @@ public class MyCouponResponse {
     @JsonProperty("isPublic")
     private final boolean isPublic;
 
-    public static MyCouponResponse from(UserCoupon userCoupon, boolean isUsable) {
+    /** 쿠폰 사용 일시 (미사용 시 null) */
+    private final LocalDateTime usedAt;
+    /** 쿠폰이 사용된 주문 ID (미사용 시 null) */
+    private final Long usedOrderId;
+    /** 실제 할인 금액 (미사용 시 null) */
+    private final BigDecimal actualDiscountAmount;
+
+    public static MyCouponResponse from(UserCoupon userCoupon, boolean isUsable,
+                                         CouponUsage usage) {
         Coupon c = userCoupon.getCoupon();
         return MyCouponResponse.builder()
                 .id(c.getId())
@@ -50,6 +59,9 @@ public class MyCouponResponse {
                 .issuedAt(userCoupon.getIssuedAt())
                 .isUsable(isUsable)
                 .isPublic(userCoupon.getCoupon().isPublic())
+                .usedAt(usage != null ? usage.getUsedAt() : null)
+                .usedOrderId(usage != null ? usage.getOrderId() : null)
+                .actualDiscountAmount(usage != null ? usage.getDiscountAmount() : null)
                 .build();
     }
 }

--- a/src/main/java/com/stockmanagement/domain/coupon/repository/CouponUsageRepository.java
+++ b/src/main/java/com/stockmanagement/domain/coupon/repository/CouponUsageRepository.java
@@ -24,6 +24,12 @@ public interface CouponUsageRepository extends JpaRepository<CouponUsage, Long> 
             @Param("couponIds") List<Long> couponIds,
             @Param("userId") Long userId);
 
+    /** 사용자의 쿠폰 사용 이력 배치 조회 — couponId를 key로 매핑 용도. */
+    @Query("SELECT cu FROM CouponUsage cu WHERE cu.coupon.id IN :couponIds AND cu.userId = :userId")
+    List<CouponUsage> findByCouponIdsAndUserId(
+            @Param("couponIds") List<Long> couponIds,
+            @Param("userId") Long userId);
+
     /** 주문 취소 시 쿠폰 반환을 위한 조회. */
     Optional<CouponUsage> findByOrderId(Long orderId);
 }

--- a/src/main/java/com/stockmanagement/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/stockmanagement/domain/coupon/service/CouponService.java
@@ -156,11 +156,21 @@ public class CouponService {
                         row -> ((Long) row[1]).intValue()
                 ));
 
+        // 배치 조회: couponId → 사용 이력 (usedAt, orderId, discountAmount)
+        Map<Long, CouponUsage> usageMap = couponUsageRepository
+                .findByCouponIdsAndUserId(couponIds, userId).stream()
+                .collect(Collectors.toMap(
+                        cu -> cu.getCoupon().getId(),
+                        cu -> cu,
+                        (a, b) -> a  // 동일 쿠폰 다중 사용 시 첫 번째 유지
+                ));
+
         LocalDateTime now = LocalDateTime.now();
         return userCoupons.stream()
                 .map(uc -> {
                     int usedCount = usedCountMap.getOrDefault(uc.getCoupon().getId(), 0);
-                    return MyCouponResponse.from(uc, isUsable(uc.getCoupon(), usedCount, now));
+                    CouponUsage usage = usageMap.get(uc.getCoupon().getId());
+                    return MyCouponResponse.from(uc, isUsable(uc.getCoupon(), usedCount, now), usage);
                 })
                 .filter(r -> usable == null || r.isUsable() == usable)
                 .toList();
@@ -200,7 +210,7 @@ public class CouponService {
 
         log.info("[Coupon] 등록: userId={}, couponCode={}, couponId={}", userId, request.getCouponCode(), coupon.getId());
         int usedCount = couponUsageRepository.countByCoupon_IdAndUserId(coupon.getId(), userId);
-        return MyCouponResponse.from(userCoupon, isUsable(coupon, usedCount, LocalDateTime.now()));
+        return MyCouponResponse.from(userCoupon, isUsable(coupon, usedCount, LocalDateTime.now()), null);
     }
 
     /**


### PR DESCRIPTION
## Summary
- `MyCouponResponse`에 `usedAt`, `usedOrderId`, `actualDiscountAmount` 3개 필드 추가
- `CouponUsageRepository.findByCouponIdsAndUserId()` 배치 조회 메서드 추가 (N+1 방지)
- `CouponService.getMyCoupons()`에서 사용 이력을 한 번에 로드하여 DTO에 매핑

## 응답 예시 (사용된 쿠폰)
```json
{
  "usedAt": "2026-05-10T14:30:00",
  "usedOrderId": 42,
  "actualDiscountAmount": 3000
}
```
미사용 쿠폰은 세 필드 모두 `null`.

## Test plan
- [x] 647개 전체 테스트 통과 확인
- [x] CouponServiceTest, CouponIntegrationTest, CouponControllerTest 통과

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)