### PR TITLE
feat: 내 결제 목록에 주문 상품 요약 정보 포함 (#114)

### DIFF
--- a/src/main/java/com/stockmanagement/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/stockmanagement/domain/order/repository/OrderRepository.java
@@ -54,6 +54,10 @@ public interface OrderRepository extends JpaRepository<Order, Long>, JpaSpecific
      */
     Page<Order> findByUserId(Long userId, Pageable pageable);
 
+    /** 여러 주문을 항목+상품 포함하여 한 번에 조회한다 (결제 목록 주문 요약용). */
+    @Query("SELECT DISTINCT o FROM Order o LEFT JOIN FETCH o.items i LEFT JOIN FETCH i.product WHERE o.id IN :ids")
+    List<Order> findByIdsWithItems(@Param("ids") List<Long> ids);
+
     /** 주문 목록 전체 페이징 조회 (관리자용) */
     Page<Order> findByStatus(OrderStatus status, Pageable pageable);
 

--- a/src/main/java/com/stockmanagement/domain/payment/dto/PaymentResponse.java
+++ b/src/main/java/com/stockmanagement/domain/payment/dto/PaymentResponse.java
@@ -31,8 +31,19 @@ public class PaymentResponse {
     private String failureMessage;
     private LocalDateTime createdAt;
 
+    /** 주문 요약 정보 (상품명, 건수, 썸네일) — getMyPayments 등에서 제공. */
+    private OrderSummary orderSummary;
+
+    /** 결제에 연결된 주문의 요약 정보. */
+    public record OrderSummary(String orderName, int itemCount, String thumbnailUrl) {}
+
     /** Converts a {@link Payment} entity to a response DTO. */
     public static PaymentResponse from(Payment payment) {
+        return from(payment, null);
+    }
+
+    /** Converts a {@link Payment} entity to a response DTO with order summary. */
+    public static PaymentResponse from(Payment payment, OrderSummary orderSummary) {
         return PaymentResponse.builder()
                 .id(payment.getId())
                 .orderId(payment.getOrderId())
@@ -48,6 +59,7 @@ public class PaymentResponse {
                 .failureCode(payment.getFailureCode())
                 .failureMessage(payment.getFailureMessage())
                 .createdAt(payment.getCreatedAt())
+                .orderSummary(orderSummary)
                 .build();
     }
 }

--- a/src/main/java/com/stockmanagement/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/stockmanagement/domain/payment/service/PaymentService.java
@@ -25,8 +25,10 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -343,9 +345,22 @@ public class PaymentService {
      * @param isAdmin  ADMIN 여부
      * @return 결제 정보 (없으면 Optional.empty())
      */
-    /** 현재 인증 사용자의 결제 목록을 최신순으로 페이징 조회한다. */
+    /** 현재 인증 사용자의 결제 목록을 최신순으로 페이징 조회한다. 주문 요약 정보 포함. */
     public Page<PaymentResponse> getMyPayments(Long userId, Pageable pageable) {
-        return paymentRepository.findByUserId(userId, pageable).map(PaymentResponse::from);
+        Page<Payment> payments = paymentRepository.findByUserId(userId, pageable);
+        if (payments.isEmpty()) {
+            return payments.map(PaymentResponse::from);
+        }
+
+        List<Long> orderIds = payments.getContent().stream()
+                .map(Payment::getOrderId).toList();
+        Map<Long, Order> orderMap = orderRepository.findByIdsWithItems(orderIds).stream()
+                .collect(Collectors.toMap(Order::getId, o -> o));
+
+        return payments.map(p -> {
+            Order order = orderMap.get(p.getOrderId());
+            return PaymentResponse.from(p, buildOrderSummary(order));
+        });
     }
 
     public Optional<PaymentResponse> getByOrderId(Long orderId, Long userId, boolean isAdmin) {
@@ -391,6 +406,13 @@ public class PaymentService {
         String firstName = items.get(0).getProduct().getName();
         if (items.size() == 1) return firstName;
         return firstName + " 외 " + (items.size() - 1) + "건";
+    }
+
+    private PaymentResponse.OrderSummary buildOrderSummary(Order order) {
+        if (order == null) return null;
+        List<OrderItem> items = order.getItems();
+        String thumbnailUrl = items.isEmpty() ? null : items.get(0).getProduct().getThumbnailUrl();
+        return new PaymentResponse.OrderSummary(buildOrderName(order), items.size(), thumbnailUrl);
     }
 
 }


### PR DESCRIPTION
## Summary
- `PaymentResponse`에 `orderSummary` 필드 추가 (`orderName`, `itemCount`, `thumbnailUrl`)
- `OrderRepository.findByIdsWithItems()` 배치 쿼리 추가 (N+1 방지)
- `PaymentService.getMyPayments()`에서 주문 요약 정보를 한 번에 로드

## 응답 예시
```json
{
  "orderId": 42,
  "amount": 35000,
  "status": "DONE",
  "orderSummary": {
    "orderName": "MacBook Pro 외 2건",
    "itemCount": 3,
    "thumbnailUrl": "https://cdn.example.com/img.jpg"
  }
}
```
`getMyPayments()` 외 다른 조회 API에서는 `orderSummary`가 `null`.

## Test plan
- [x] 647개 전체 테스트 통과 확인

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)