### PR TITLE
feat: 주문 시점 배송지 스냅샷 저장 (#112)

### DIFF
--- a/src/main/java/com/stockmanagement/domain/order/dto/OrderResponse.java
+++ b/src/main/java/com/stockmanagement/domain/order/dto/OrderResponse.java
@@ -1,6 +1,7 @@
 package com.stockmanagement.domain.order.dto;
 
 import com.stockmanagement.domain.order.entity.Order;
+import com.stockmanagement.domain.order.entity.OrderDeliverySnapshot;
 import com.stockmanagement.domain.order.entity.OrderStatus;
 import com.stockmanagement.domain.shipment.entity.ShipmentStatus;
 import lombok.Builder;
@@ -56,22 +57,54 @@ public class OrderResponse {
     /** 취소 사유 — CANCELLED 상태가 아니거나 사유 미입력 시 null */
     private final String cancelReason;
 
+    /** 주문 시점 배송지 스냅샷 — 배송지 미지정 또는 스냅샷 미생성 시 null */
+    private final SnapshotAddress snapshotAddress;
+
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
 
+    /** 주문 시점 배송지 스냅샷 DTO. */
+    @Getter
+    @Builder
+    @Jacksonized
+    public static class SnapshotAddress {
+        private final String recipient;
+        private final String phone;
+        private final String zipCode;
+        private final String address1;
+        private final String address2;
+
+        public static SnapshotAddress from(OrderDeliverySnapshot snapshot) {
+            if (snapshot == null) return null;
+            return SnapshotAddress.builder()
+                    .recipient(snapshot.getRecipient())
+                    .phone(snapshot.getPhone())
+                    .zipCode(snapshot.getZipCode())
+                    .address1(snapshot.getAddress1())
+                    .address2(snapshot.getAddress2())
+                    .build();
+        }
+    }
+
     /** Order 엔티티를 응답 DTO로 변환하는 정적 팩토리 메서드 */
     public static OrderResponse from(Order order) {
-        return from(order, null, null);
+        return from(order, null, null, null);
     }
 
     /**
-     * Order 엔티티를 hasReview + shipmentStatus 포함 응답 DTO로 변환한다.
+     * Order 엔티티를 hasReview + shipmentStatus + 배송지 스냅샷 포함 응답 DTO로 변환한다.
      *
      * @param reviewedProductIds 현재 사용자가 리뷰를 작성한 상품 ID 집합 (null이면 hasReview=null)
      * @param shipmentStatus     배송 상태 (null이면 배송 미생성)
      */
     public static OrderResponse from(Order order, java.util.Set<Long> reviewedProductIds,
                                      ShipmentStatus shipmentStatus) {
+        return from(order, reviewedProductIds, shipmentStatus, null);
+    }
+
+    public static OrderResponse from(Order order, java.util.Set<Long> reviewedProductIds,
+                                     ShipmentStatus shipmentStatus,
+                                     OrderDeliverySnapshot snapshot) {
         String orderNumber = order.getCreatedAt() != null
                 ? order.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyyMMdd"))
                         + "-" + String.format("%07d", order.getId())
@@ -96,6 +129,7 @@ public class OrderResponse {
                         .toList())
                 .shipmentStatus(shipmentStatus)
                 .cancelReason(order.getCancelReason())
+                .snapshotAddress(SnapshotAddress.from(snapshot))
                 .createdAt(order.getCreatedAt())
                 .updatedAt(order.getUpdatedAt())
                 .build();

--- a/src/main/java/com/stockmanagement/domain/order/entity/OrderDeliverySnapshot.java
+++ b/src/main/java/com/stockmanagement/domain/order/entity/OrderDeliverySnapshot.java
@@ -1,0 +1,55 @@
+package com.stockmanagement.domain.order.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+/** 주문 시점 배송지 스냅샷. 원본 배송지가 삭제·변경되어도 주문 당시 주소를 보존한다. */
+@Entity
+@Table(name = "order_delivery_snapshots")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrderDeliverySnapshot {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private Long orderId;
+
+    @Column(nullable = false, length = 50)
+    private String recipient;
+
+    @Column(nullable = false, length = 20)
+    private String phone;
+
+    @Column(nullable = false, length = 10)
+    private String zipCode;
+
+    @Column(nullable = false, length = 200)
+    private String address1;
+
+    @Column(length = 100)
+    private String address2;
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    private OrderDeliverySnapshot(Long orderId, String recipient, String phone,
+                                   String zipCode, String address1, String address2) {
+        this.orderId = orderId;
+        this.recipient = recipient;
+        this.phone = phone;
+        this.zipCode = zipCode;
+        this.address1 = address1;
+        this.address2 = address2;
+    }
+}

--- a/src/main/java/com/stockmanagement/domain/order/repository/OrderDeliverySnapshotRepository.java
+++ b/src/main/java/com/stockmanagement/domain/order/repository/OrderDeliverySnapshotRepository.java
@@ -1,0 +1,15 @@
+package com.stockmanagement.domain.order.repository;
+
+import com.stockmanagement.domain.order.entity.OrderDeliverySnapshot;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface OrderDeliverySnapshotRepository extends JpaRepository<OrderDeliverySnapshot, Long> {
+
+    Optional<OrderDeliverySnapshot> findByOrderId(Long orderId);
+
+    /** 여러 주문의 배송지 스냅샷을 한 번에 조회한다 (목록 조회 N+1 방지). */
+    List<OrderDeliverySnapshot> findByOrderIdIn(List<Long> orderIds);
+}

--- a/src/main/java/com/stockmanagement/domain/order/service/OrderCommandService.java
+++ b/src/main/java/com/stockmanagement/domain/order/service/OrderCommandService.java
@@ -11,8 +11,10 @@ import com.stockmanagement.domain.order.dto.OrderItemRequest;
 import com.stockmanagement.domain.order.dto.OrderResponse;
 import com.stockmanagement.domain.order.entity.Order;
 import com.stockmanagement.domain.order.entity.OrderItem;
+import com.stockmanagement.domain.order.entity.OrderDeliverySnapshot;
 import com.stockmanagement.domain.order.entity.OrderStatus;
 import com.stockmanagement.domain.order.entity.OrderStatusHistory;
+import com.stockmanagement.domain.order.repository.OrderDeliverySnapshotRepository;
 import com.stockmanagement.domain.order.repository.OrderRepository;
 import com.stockmanagement.domain.order.repository.OrderStatusHistoryRepository;
 import com.stockmanagement.domain.product.entity.Product;
@@ -58,6 +60,7 @@ public class OrderCommandService {
     private final PointService pointService;
     private final OutboxEventStore outboxEventStore;
     private final DeliveryAddressService deliveryAddressService;
+    private final OrderDeliverySnapshotRepository deliverySnapshotRepository;
 
     /**
      * 주문을 생성한다 (내부 호출 전용 — 장바구니 결제 등).
@@ -119,10 +122,10 @@ public class OrderCommandService {
             totalAmount = totalAmount.add(item.getSubtotal());
         }
 
-        // 3. 배송지 소유권 검증
-        if (request.getDeliveryAddressId() != null) {
-            deliveryAddressService.getById(request.getDeliveryAddressId(), userId);
-        }
+        // 3. 배송지 소유권 검증 + 스냅샷 데이터 확보
+        var deliveryAddress = request.getDeliveryAddressId() != null
+                ? deliveryAddressService.getById(request.getDeliveryAddressId(), userId)
+                : null;
 
         // 4. Order 생성
         long usePointsLong = request.getUsePoints() != null ? request.getUsePoints() : 0L;
@@ -151,6 +154,18 @@ public class OrderCommandService {
             return orderRepository.findByIdempotencyKey(request.getIdempotencyKey())
                     .map(OrderResponse::from)
                     .orElseThrow(() -> e);
+        }
+
+        // 5-1. 배송지 스냅샷 저장
+        if (deliveryAddress != null) {
+            deliverySnapshotRepository.save(OrderDeliverySnapshot.builder()
+                    .orderId(savedOrder.getId())
+                    .recipient(deliveryAddress.getRecipient())
+                    .phone(deliveryAddress.getPhone())
+                    .zipCode(deliveryAddress.getZipCode())
+                    .address1(deliveryAddress.getAddress1())
+                    .address2(deliveryAddress.getAddress2())
+                    .build());
         }
 
         // 6. 재고 예약 (productId 오름차순 — 데드락 방지)

--- a/src/main/java/com/stockmanagement/domain/order/service/OrderDetailService.java
+++ b/src/main/java/com/stockmanagement/domain/order/service/OrderDetailService.java
@@ -5,7 +5,9 @@ import com.stockmanagement.common.exception.ErrorCode;
 import com.stockmanagement.domain.order.dto.OrderDetailResponse;
 import com.stockmanagement.domain.order.dto.OrderResponse;
 import com.stockmanagement.domain.order.entity.Order;
+import com.stockmanagement.domain.order.entity.OrderDeliverySnapshot;
 import com.stockmanagement.domain.order.entity.OrderItem;
+import com.stockmanagement.domain.order.repository.OrderDeliverySnapshotRepository;
 import com.stockmanagement.domain.order.repository.OrderRepository;
 import com.stockmanagement.domain.payment.dto.PaymentResponse;
 import com.stockmanagement.domain.payment.repository.PaymentRepository;
@@ -38,6 +40,7 @@ public class OrderDetailService {
     private final ShipmentRepository shipmentRepository;
     private final RefundRepository refundRepository;
     private final ReviewRepository reviewRepository;
+    private final OrderDeliverySnapshotRepository deliverySnapshotRepository;
 
     /**
      * 주문 + 결제 + 배송 정보를 단일 응답으로 반환한다 (프론트 상세 페이지용).
@@ -59,11 +62,12 @@ public class OrderDetailService {
                 .map(RefundResponse::from)
                 .orElse(null);
         Set<Long> reviewedIds = reviewedProductIds(order.getUserId(), order.getItems());
+        OrderDeliverySnapshot snapshot = deliverySnapshotRepository.findByOrderId(id).orElse(null);
 
         com.stockmanagement.domain.shipment.entity.ShipmentStatus shipmentStatus =
                 shipment != null ? shipment.getStatus() : null;
         return OrderDetailResponse.builder()
-                .order(OrderResponse.from(order, reviewedIds, shipmentStatus))
+                .order(OrderResponse.from(order, reviewedIds, shipmentStatus, snapshot))
                 .payment(payment)
                 .shipment(shipment)
                 .refund(refund)

--- a/src/main/java/com/stockmanagement/domain/order/service/OrderQueryService.java
+++ b/src/main/java/com/stockmanagement/domain/order/service/OrderQueryService.java
@@ -12,7 +12,9 @@ import com.stockmanagement.domain.order.dto.OrderResponse;
 import com.stockmanagement.domain.order.dto.OrderSearchRequest;
 import com.stockmanagement.domain.order.dto.OrderStatusHistoryResponse;
 import com.stockmanagement.domain.order.entity.Order;
+import com.stockmanagement.domain.order.entity.OrderDeliverySnapshot;
 import com.stockmanagement.domain.order.entity.OrderStatus;
+import com.stockmanagement.domain.order.repository.OrderDeliverySnapshotRepository;
 import com.stockmanagement.domain.order.repository.OrderRepository;
 import com.stockmanagement.domain.order.repository.OrderSpecification;
 import com.stockmanagement.domain.order.repository.OrderStatusHistoryRepository;
@@ -52,6 +54,7 @@ public class OrderQueryService {
     private final ProductRepository productRepository;
     private final ShipmentRepository shipmentRepository;
     private final OrderStatusHistoryRepository historyRepository;
+    private final OrderDeliverySnapshotRepository deliverySnapshotRepository;
     private final CouponService couponService;
     private final PointService pointService;
 
@@ -66,7 +69,8 @@ public class OrderQueryService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
         ShipmentStatus shipmentStatus = shipmentRepository.findByOrderId(id)
                 .map(s -> s.getStatus()).orElse(null);
-        return OrderResponse.from(order, null, shipmentStatus);
+        OrderDeliverySnapshot snapshot = deliverySnapshotRepository.findByOrderId(id).orElse(null);
+        return OrderResponse.from(order, null, shipmentStatus, snapshot);
     }
 
     /**
@@ -82,7 +86,8 @@ public class OrderQueryService {
         validateOrderOwnership(order, userId, isAdmin);
         ShipmentStatus shipmentStatus = shipmentRepository.findByOrderId(id)
                 .map(s -> s.getStatus()).orElse(null);
-        return OrderResponse.from(order, null, shipmentStatus);
+        OrderDeliverySnapshot snapshot = deliverySnapshotRepository.findByOrderId(id).orElse(null);
+        return OrderResponse.from(order, null, shipmentStatus, snapshot);
     }
 
     /**
@@ -99,11 +104,13 @@ public class OrderQueryService {
         Long forceUserId = isAdmin ? null : userId;
         Page<Order> page = orderRepository.findAll(OrderSpecification.of(request, forceUserId), pageable);
 
-        // 배송 상태 배치 조회 (N+1 방지)
+        // 배송 상태 + 배송지 스냅샷 배치 조회 (N+1 방지)
         List<Long> orderIds = page.map(Order::getId).toList();
         Map<Long, ShipmentStatus> statusMap = shipmentRepository.findStatusMapByOrderIds(orderIds);
+        Map<Long, OrderDeliverySnapshot> snapshotMap = deliverySnapshotRepository.findByOrderIdIn(orderIds)
+                .stream().collect(Collectors.toMap(OrderDeliverySnapshot::getOrderId, s -> s));
 
-        return page.map(o -> OrderResponse.from(o, null, statusMap.get(o.getId())));
+        return page.map(o -> OrderResponse.from(o, null, statusMap.get(o.getId()), snapshotMap.get(o.getId())));
     }
 
     /**
@@ -117,12 +124,14 @@ public class OrderQueryService {
         List<Order> items = lastId == null
                 ? orderRepository.findCursorByUserId(userId, status, limit)
                 : orderRepository.findCursorByUserIdAfter(userId, status, lastId, limit);
-        // 배송 상태 배치 조회 (N+1 방지)
+        // 배송 상태 + 배송지 스냅샷 배치 조회 (N+1 방지)
         List<Long> orderIds = items.stream().map(Order::getId).toList();
         Map<Long, ShipmentStatus> statusMap = shipmentRepository.findStatusMapByOrderIds(orderIds);
+        Map<Long, OrderDeliverySnapshot> snapshotMap = deliverySnapshotRepository.findByOrderIdIn(orderIds)
+                .stream().collect(Collectors.toMap(OrderDeliverySnapshot::getOrderId, s -> s));
 
         return CursorPage.of(
-                items.stream().map(o -> OrderResponse.from(o, null, statusMap.get(o.getId()))).toList(),
+                items.stream().map(o -> OrderResponse.from(o, null, statusMap.get(o.getId()), snapshotMap.get(o.getId()))).toList(),
                 size,
                 OrderResponse::getId);
     }

--- a/src/main/resources/db/migration/V43__create_order_delivery_snapshots.sql
+++ b/src/main/resources/db/migration/V43__create_order_delivery_snapshots.sql
@@ -1,0 +1,14 @@
+CREATE TABLE order_delivery_snapshots (
+    id            BIGINT       NOT NULL AUTO_INCREMENT,
+    order_id      BIGINT       NOT NULL,
+    recipient     VARCHAR(50)  NOT NULL,
+    phone         VARCHAR(20)  NOT NULL,
+    zip_code      VARCHAR(10)  NOT NULL,
+    address1      VARCHAR(200) NOT NULL,
+    address2      VARCHAR(100),
+    created_at    DATETIME(6)  NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id),
+    CONSTRAINT uk_order_delivery_snapshots_order_id UNIQUE (order_id),
+    CONSTRAINT fk_order_delivery_snapshots_order
+        FOREIGN KEY (order_id) REFERENCES orders(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/src/test/java/com/stockmanagement/domain/order/service/OrderCommandServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/order/service/OrderCommandServiceTest.java
@@ -14,6 +14,7 @@ import com.stockmanagement.domain.order.dto.OrderResponse;
 import com.stockmanagement.domain.order.entity.Order;
 import com.stockmanagement.domain.order.entity.OrderItem;
 import com.stockmanagement.domain.order.entity.OrderStatus;
+import com.stockmanagement.domain.order.repository.OrderDeliverySnapshotRepository;
 import com.stockmanagement.domain.order.repository.OrderRepository;
 import com.stockmanagement.domain.order.repository.OrderStatusHistoryRepository;
 import com.stockmanagement.domain.product.entity.Product;
@@ -66,6 +67,9 @@ class OrderCommandServiceTest {
 
     @Mock
     private DeliveryAddressService deliveryAddressService;
+
+    @Mock
+    private OrderDeliverySnapshotRepository deliverySnapshotRepository;
 
     @InjectMocks
     private OrderCommandService orderCommandService;

--- a/src/test/java/com/stockmanagement/domain/order/service/OrderQueryServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/order/service/OrderQueryServiceTest.java
@@ -8,6 +8,7 @@ import com.stockmanagement.domain.order.dto.OrderSearchRequest;
 import com.stockmanagement.domain.order.entity.Order;
 import com.stockmanagement.domain.order.entity.OrderItem;
 import com.stockmanagement.domain.order.entity.OrderStatus;
+import com.stockmanagement.domain.order.repository.OrderDeliverySnapshotRepository;
 import com.stockmanagement.domain.order.repository.OrderRepository;
 import com.stockmanagement.domain.order.repository.OrderStatusHistoryRepository;
 import com.stockmanagement.domain.point.service.PointService;
@@ -52,6 +53,9 @@ class OrderQueryServiceTest {
 
     @Mock
     private OrderStatusHistoryRepository historyRepository;
+
+    @Mock
+    private OrderDeliverySnapshotRepository deliverySnapshotRepository;
 
     @Mock
     private CouponService couponService;


### PR DESCRIPTION
## Summary
- `order_delivery_snapshots` 테이블 추가 (V43 migration, order_id UNIQUE, ON DELETE CASCADE)
- `OrderDeliverySnapshot` 엔티티 + Repository 생성
- 주문 생성 시 배송지 정보를 스냅샷으로 저장 (원본 배송지 삭제·변경 시 주소 유실 방지)
- `OrderResponse.snapshotAddress` 필드 추가 (recipient, phone, zipCode, address1, address2)
- 목록 조회 시 `findByOrderIdIn()` 배치 조회로 N+1 방지

## 응답 예시
```json
{
  "deliveryAddressId": 5,
  "snapshotAddress": {
    "recipient": "홍길동",
    "phone": "010-1234-5678",
    "zipCode": "06123",
    "address1": "서울시 강남구 테헤란로 123",
    "address2": "4층 401호"
  }
}
```

## Test plan
- [x] 647개 전체 테스트 통과 확인

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)