### PR TITLE
fix: CANCELED Webhook에서 Payment/Order 취소 + 재고 해제 (#144)

### DIFF
--- a/src/main/java/com/stockmanagement/domain/order/entity/Order.java
+++ b/src/main/java/com/stockmanagement/domain/order/entity/Order.java
@@ -130,6 +130,23 @@ public class Order {
     }
 
     /**
+     * Webhook에 의한 취소 — PENDING 또는 PAYMENT_IN_PROGRESS 상태에서 취소 가능.
+     *
+     * <p>Toss가 가상계좌 미입금 만료 등으로 CANCELED Webhook을 전송할 때 사용한다.
+     * 사용자가 직접 cancel()할 수 없는 PAYMENT_IN_PROGRESS 상태도 취소 가능하다.
+     *
+     * @param reason 취소 사유
+     * @throws BusinessException PENDING/PAYMENT_IN_PROGRESS가 아닌 상태에서 호출 시
+     */
+    public void cancelByWebhook(String reason) {
+        if (this.status != OrderStatus.PENDING && this.status != OrderStatus.PAYMENT_IN_PROGRESS) {
+            throw new BusinessException(ErrorCode.INVALID_ORDER_STATUS);
+        }
+        this.status = OrderStatus.CANCELLED;
+        this.cancelReason = reason;
+    }
+
+    /**
      * Toss API 호출 직전 결제 진행 중 상태로 전환한다.
      *
      * <p>PENDING → PAYMENT_IN_PROGRESS. 만료 스케줄러({@code findExpiredPendingOrderIds})가

--- a/src/main/java/com/stockmanagement/domain/order/service/OrderPaymentService.java
+++ b/src/main/java/com/stockmanagement/domain/order/service/OrderPaymentService.java
@@ -89,6 +89,35 @@ public class OrderPaymentService {
     }
 
     /**
+     * Toss CANCELED Webhook으로 미결제 주문을 취소한다 — Payment 도메인에서 호출.
+     *
+     * <p>PENDING/PAYMENT_IN_PROGRESS → CANCELLED 전환, reserved 재고 해제, 쿠폰/포인트 반환.
+     * 가상계좌 미입금 만료 등에서 Toss가 CANCELED 이벤트를 전송할 때 사용된다.
+     *
+     * @param id     취소할 주문 ID
+     * @param reason 취소 사유
+     */
+    @Transactional
+    @CacheEvict(cacheNames = "orders", key = "#id")
+    public void cancelByWebhook(Long id, String reason) {
+        Order order = orderRepository.findByIdWithItemsForUpdate(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
+
+        OrderStatus previousStatus = order.getStatus();
+        order.cancelByWebhook(reason);
+
+        for (OrderItem item : order.getItems()) {
+            inventoryService.releaseReservation(item.getProduct().getId(), item.getQuantity());
+        }
+
+        couponService.releaseCoupon(order.getId());
+        pointService.refundByOrder(order.getUserId(), order.getId());
+
+        recordHistory(order.getId(), previousStatus, OrderStatus.CANCELLED, "webhook:toss-canceled");
+        outboxEventStore.save(new OrderCancelledEvent(order.getId(), order.getUserId(), reason));
+    }
+
+    /**
      * 결제 오류로 묶인 PAYMENT_IN_PROGRESS 주문을 PENDING으로 복원한다 (스케줄러 전용).
      *
      * @param id 복원할 주문 ID

--- a/src/main/java/com/stockmanagement/domain/payment/entity/Payment.java
+++ b/src/main/java/com/stockmanagement/domain/payment/entity/Payment.java
@@ -172,6 +172,22 @@ public class Payment {
     }
 
     /**
+     * Toss CANCELED Webhook에 의한 취소 — PENDING/FAILED 상태에서 CANCELLED로 전환.
+     *
+     * <p>가상계좌 미입금 만료 등 Toss 측에서 미결제 건을 취소했을 때 사용한다.
+     * DONE 상태 결제는 {@link #cancel(String, BigDecimal)}을 사용해야 한다.
+     *
+     * @param reason 취소 사유
+     */
+    public void cancelByWebhook(String reason) {
+        if (this.status != PaymentStatus.PENDING && this.status != PaymentStatus.FAILED) {
+            throw new BusinessException(ErrorCode.INVALID_PAYMENT_STATUS);
+        }
+        this.cancelReason = reason;
+        this.status = PaymentStatus.CANCELLED;
+    }
+
+    /**
      * Resets a FAILED payment to PENDING for retry.
      *
      * <p>FAILED 결제가 존재할 때 사용자가 "다시 결제하기"를 선택하면 기존 레코드를 재사용한다.

--- a/src/main/java/com/stockmanagement/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/stockmanagement/domain/payment/service/PaymentService.java
@@ -303,8 +303,11 @@ public class PaymentService {
                                 data.getOrderId(), data.getPaymentKey());
                     }
                 }
-                case "CANCELED" ->
-                    log.info("[Webhook] CANCELED: tossOrderId={}", data.getOrderId());
+                case "CANCELED" -> {
+                    log.info("[Webhook] CANCELED 이벤트 수신 — 취소 처리 진행: tossOrderId={}",
+                            data.getOrderId());
+                    transactionHelper.applyWebhookCancelResult(data.getOrderId());
+                }
                 default ->
                     log.debug("[Webhook] 미처리 status={}: tossOrderId={}", data.getStatus(), data.getOrderId());
             }

--- a/src/main/java/com/stockmanagement/domain/payment/service/PaymentTransactionHelper.java
+++ b/src/main/java/com/stockmanagement/domain/payment/service/PaymentTransactionHelper.java
@@ -368,6 +368,41 @@ class PaymentTransactionHelper {
         return PaymentResponse.from(payment);
     }
 
+    /**
+     * Toss CANCELED Webhook 수신 시 Payment/Order 상태를 취소로 전환하는 트랜잭션.
+     *
+     * <p>가상계좌 미입금 만료, 관리자 취소 등 Toss 측에서 결제를 취소했을 때 호출된다.
+     * Payment가 이미 CANCELLED/DONE이면 무시한다 (중복 Webhook 방어).
+     * Order가 CONFIRMED이면 OrderPaymentService.refund()로 처리하고,
+     * PENDING/PAYMENT_IN_PROGRESS이면 cancelByWebhook()으로 재고 예약을 해제한다.
+     *
+     * @param tossOrderId Toss 주문 ID
+     */
+    @Transactional
+    void applyWebhookCancelResult(String tossOrderId) {
+        Payment payment = paymentRepository.findByTossOrderIdWithLock(tossOrderId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PAYMENT_NOT_FOUND));
+
+        // 이미 취소됐으면 중복 Webhook 무시
+        if (payment.getStatus() == PaymentStatus.CANCELLED) {
+            return;
+        }
+        // 이미 DONE(결제 완료)이면 Toss가 취소한 경우 — 환불 처리
+        if (payment.getStatus() == PaymentStatus.DONE) {
+            payment.cancel("TOSS_WEBHOOK_CANCELED", null);
+            orderPaymentService.refund(payment.getOrderId());
+            log.info("[Webhook] CANCELED — 결제 완료 건 환불 처리: tossOrderId={}, orderId={}",
+                    tossOrderId, payment.getOrderId());
+            return;
+        }
+
+        // PENDING/FAILED 상태 — 미결제 주문 취소 + 재고 예약 해제
+        payment.cancelByWebhook("TOSS_WEBHOOK_CANCELED");
+        orderPaymentService.cancelByWebhook(payment.getOrderId(), "TOSS_WEBHOOK_CANCELED");
+        log.info("[Webhook] CANCELED — 미결제 건 취소 처리: tossOrderId={}, orderId={}",
+                tossOrderId, payment.getOrderId());
+    }
+
     private LocalDateTime parseDateTime(String dateTimeStr) {
         if (dateTimeStr == null) return null;
         return OffsetDateTime.parse(dateTimeStr).toLocalDateTime();


### PR DESCRIPTION
## Summary
- Toss CANCELED Webhook 수신 시 로그만 남기던 문제 수정
- Payment 상태를 CANCELLED로 전환하고, Order 취소 + 재고 예약 해제 처리 추가
- 가상계좌 미입금 만료 시 재고가 만료 스케줄러까지 잠기는 지연 문제 해결

## Changes
- `Payment.cancelByWebhook()`: PENDING/FAILED → CANCELLED 상태 전환 메서드 추가
- `Order.cancelByWebhook()`: PENDING/PAYMENT_IN_PROGRESS → CANCELLED 전환 메서드 추가
- `OrderPaymentService.cancelByWebhook()`: 재고 예약 해제 + 쿠폰/포인트 반환 처리
- `PaymentTransactionHelper.applyWebhookCancelResult()`: DONE이면 refund, PENDING/FAILED이면 cancelByWebhook
- `PaymentService.handleWebhook()`: CANCELED 케이스에서 `applyWebhookCancelResult()` 호출

## Test plan
- [x] 전체 테스트 통과 (647개)
- [ ] CANCELED Webhook 수신 시 Payment/Order 상태 변경 확인
- [ ] 이미 취소된 건 중복 Webhook 무시 확인