### PR TITLE
feat: 공개 쿠폰 다운로드 목록 API (#125)

### DIFF
--- a/src/main/java/com/stockmanagement/common/config/SecurityConfig.java
+++ b/src/main/java/com/stockmanagement/common/config/SecurityConfig.java
@@ -123,6 +123,8 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/api/categories").hasRole("ADMIN")
                         .requestMatchers(HttpMethod.PUT, "/api/categories/**").hasRole("ADMIN")
                         .requestMatchers(HttpMethod.DELETE, "/api/categories/**").hasRole("ADMIN")
+                        // 공개 쿠폰 목록 — 인증 불필요 (ADMIN 쿠폰 패턴보다 먼저 선언)
+                        .requestMatchers(HttpMethod.GET, "/api/coupons/public").permitAll()
                         // 내 쿠폰 목록 — USER 인증 필요 (ADMIN 쿠폰 패턴보다 먼저 선언)
                         .requestMatchers(HttpMethod.GET, "/api/coupons/my").authenticated()
                         // 쿠폰 관리 (생성/발급/비활성화)는 ADMIN 전용

--- a/src/main/java/com/stockmanagement/domain/coupon/controller/CouponController.java
+++ b/src/main/java/com/stockmanagement/domain/coupon/controller/CouponController.java
@@ -37,6 +37,13 @@ public class CouponController {
         return ApiResponse.ok(couponService.create(request));
     }
 
+    @Operation(summary = "공개 쿠폰 목록 — 다운로드 가능한 쿠폰 (인증 불필요)")
+    @GetMapping("/public")
+    public ApiResponse<Page<CouponResponse>> getPublicCoupons(
+            @PageableDefault(size = 20) Pageable pageable) {
+        return ApiResponse.ok(couponService.getPublicCoupons(pageable));
+    }
+
     @Operation(summary = "쿠폰 목록 [ADMIN]")
     @GetMapping
     public ApiResponse<Page<CouponResponse>> getList(

--- a/src/main/java/com/stockmanagement/domain/coupon/repository/CouponRepository.java
+++ b/src/main/java/com/stockmanagement/domain/coupon/repository/CouponRepository.java
@@ -8,10 +8,28 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface CouponRepository extends JpaRepository<Coupon, Long> {
+
+    /**
+     * 공개 쿠폰 목록 조회 — isPublic=true, active=true, 기간 유효, 수량 여유.
+     */
+    @Query("""
+            SELECT c FROM Coupon c
+            WHERE c.isPublic = true
+              AND c.active = true
+              AND c.validFrom <= :now
+              AND c.validUntil > :now
+              AND (c.maxUsageCount IS NULL OR c.usageCount < c.maxUsageCount)
+            ORDER BY c.validUntil ASC
+            """)
+    Page<Coupon> findAvailablePublicCoupons(@Param("now") LocalDateTime now, Pageable pageable);
+
 
     /**
      * 만료된 활성 쿠폰을 단일 벌크 UPDATE로 비활성화한다.

--- a/src/main/java/com/stockmanagement/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/stockmanagement/domain/coupon/service/CouponService.java
@@ -85,6 +85,12 @@ public class CouponService {
         return couponRepository.findAll(pageable).map(CouponResponse::from);
     }
 
+    /** 공개 쿠폰 목록 조회 — 인증 불필요. */
+    public Page<CouponResponse> getPublicCoupons(Pageable pageable) {
+        return couponRepository.findAvailablePublicCoupons(LocalDateTime.now(), pageable)
+                .map(CouponResponse::from);
+    }
+
     public CouponResponse getById(Long id) {
         return CouponResponse.from(findById(id));
     }


### PR DESCRIPTION
## Summary
- `GET /api/coupons/public` 엔드포인트 추가 (인증 불필요)
- isPublic=true, active=true, 기간 유효, 수량 여유인 쿠폰만 반환
- 만료일 임박순 정렬

## Changes
- `CouponRepository.findAvailablePublicCoupons()`: 조건부 JPQL 쿼리
- `CouponService.getPublicCoupons()`: 서비스 메서드 추가
- `CouponController`: `/public` GET 엔드포인트 추가 (ADMIN 패턴보다 선행 배치)
- `SecurityConfig`: `/api/coupons/public` permitAll() 규칙 추가

## Test plan
- [x] 전체 테스트 통과 (647개)
- [ ] 인증 없이 공개 쿠폰 목록 조회 확인
- [ ] 비공개/만료/소진 쿠폰이 제외되는지 확인