### PR TITLE
feat: 가상계좌 입금 정보 노출 (#132)

### DIFF
--- a/src/main/java/com/stockmanagement/domain/payment/dto/PaymentResponse.java
+++ b/src/main/java/com/stockmanagement/domain/payment/dto/PaymentResponse.java
@@ -31,8 +31,14 @@ public class PaymentResponse {
     private String failureMessage;
     private LocalDateTime createdAt;
 
+    /** 가상계좌 입금 정보 — 가상계좌 결제 시에만 non-null. */
+    private VirtualAccount virtualAccount;
+
     /** 주문 요약 정보 (상품명, 건수, 썸네일) — getMyPayments 등에서 제공. */
     private OrderSummary orderSummary;
+
+    /** 가상계좌 입금 정보. */
+    public record VirtualAccount(String bank, String accountNumber, LocalDateTime dueDate) {}
 
     /** 결제에 연결된 주문의 요약 정보. */
     public record OrderSummary(String orderName, int itemCount, String thumbnailUrl) {}
@@ -44,6 +50,11 @@ public class PaymentResponse {
 
     /** Converts a {@link Payment} entity to a response DTO with order summary. */
     public static PaymentResponse from(Payment payment, OrderSummary orderSummary) {
+        VirtualAccount va = payment.getVirtualAccountBank() != null
+                ? new VirtualAccount(payment.getVirtualAccountBank(),
+                        payment.getVirtualAccountNumber(),
+                        payment.getVirtualAccountDueDate())
+                : null;
         return PaymentResponse.builder()
                 .id(payment.getId())
                 .orderId(payment.getOrderId())
@@ -59,6 +70,7 @@ public class PaymentResponse {
                 .failureCode(payment.getFailureCode())
                 .failureMessage(payment.getFailureMessage())
                 .createdAt(payment.getCreatedAt())
+                .virtualAccount(va)
                 .orderSummary(orderSummary)
                 .build();
     }

--- a/src/main/java/com/stockmanagement/domain/payment/entity/Payment.java
+++ b/src/main/java/com/stockmanagement/domain/payment/entity/Payment.java
@@ -87,6 +87,17 @@ public class Payment {
     @Column(length = 200)
     private String failureMessage;
 
+    /** 가상계좌 은행명 (가상계좌 결제 시에만 값이 있음). */
+    @Column(length = 20)
+    private String virtualAccountBank;
+
+    /** 가상계좌 계좌번호 (가상계좌 결제 시에만 값이 있음). */
+    @Column(length = 30)
+    private String virtualAccountNumber;
+
+    /** 가상계좌 입금 기한 (가상계좌 결제 시에만 값이 있음). */
+    private LocalDateTime virtualAccountDueDate;
+
     @CreationTimestamp
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
@@ -188,5 +199,18 @@ public class Payment {
         this.failureCode = null;
         this.failureMessage = null;
         this.status = PaymentStatus.PENDING;
+    }
+
+    /**
+     * 가상계좌 입금 정보를 저장한다 — prepare 단계에서 Toss 응답 수신 후 호출.
+     *
+     * @param bank       은행명 (예: "우리은행")
+     * @param accountNumber 가상계좌 번호
+     * @param dueDate    입금 기한
+     */
+    public void setVirtualAccountInfo(String bank, String accountNumber, LocalDateTime dueDate) {
+        this.virtualAccountBank = bank;
+        this.virtualAccountNumber = accountNumber;
+        this.virtualAccountDueDate = dueDate;
     }
 }

--- a/src/main/resources/db/migration/V44__add_payments_virtual_account.sql
+++ b/src/main/resources/db/migration/V44__add_payments_virtual_account.sql
@@ -1,0 +1,4 @@
+ALTER TABLE payments
+    ADD COLUMN virtual_account_bank VARCHAR(20) NULL,
+    ADD COLUMN virtual_account_number VARCHAR(30) NULL,
+    ADD COLUMN virtual_account_due_date DATETIME(6) NULL;


### PR DESCRIPTION
## Summary
- Payment 엔티티에 가상계좌 정보 필드(bank, accountNumber, dueDate) 추가
- PaymentResponse에 `virtualAccount` 필드로 노출 (가상계좌 결제 시에만 non-null)
- V44 마이그레이션으로 payments 테이블에 컬럼 추가

## Changes
- `Payment.java`: virtualAccountBank/Number/DueDate 필드 + setVirtualAccountInfo() 메서드
- `PaymentResponse.java`: VirtualAccount record + from() 매핑
- `V44__add_payments_virtual_account.sql`: ALTER TABLE payments

## Test plan
- [x] 전체 테스트 통과 (647개)
- [ ] 가상계좌 결제 시 입금 정보가 응답에 포함되는지 확인
- [ ] 일반 결제(카드 등) 시 virtualAccount가 null인지 확인