### PR TITLE
feat: 최근 본 상품 API (#124)

### DIFF
--- a/src/main/java/com/stockmanagement/domain/user/controller/UserController.java
+++ b/src/main/java/com/stockmanagement/domain/user/controller/UserController.java
@@ -3,11 +3,14 @@ package com.stockmanagement.domain.user.controller;
 import com.stockmanagement.common.dto.ApiResponse;
 import com.stockmanagement.common.security.CurrentUserId;
 import com.stockmanagement.domain.order.dto.OrderResponse;
+import com.stockmanagement.domain.product.dto.ProductResponse;
 import com.stockmanagement.domain.product.review.dto.ReviewResponse;
 import com.stockmanagement.domain.product.review.service.ReviewService;
 import com.stockmanagement.domain.user.dto.ChangePasswordRequest;
+import com.stockmanagement.domain.user.dto.RecentlyViewedRequest;
 import com.stockmanagement.domain.user.dto.UpdateProfileRequest;
 import com.stockmanagement.domain.user.dto.UserResponse;
+import com.stockmanagement.domain.user.service.RecentlyViewedService;
 import com.stockmanagement.domain.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -19,6 +22,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import java.util.List;
 import org.springframework.web.bind.annotation.*;
 
 /**
@@ -38,6 +42,7 @@ public class UserController {
 
     private final UserService userService;
     private final ReviewService reviewService;
+    private final RecentlyViewedService recentlyViewedService;
 
     @Operation(summary = "내 정보 조회", description = "포인트 잔액(pointBalance) 포함.")
     @GetMapping("/me")
@@ -92,5 +97,22 @@ public class UserController {
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
             Pageable pageable) {
         return ApiResponse.ok(reviewService.getMyReviews(userId, pageable, rating));
+    }
+
+    @Operation(summary = "최근 본 상품 기록", description = "상품 조회 시 자동 호출. Redis ZSet에 저장.")
+    @PostMapping("/me/recently-viewed")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void recordRecentlyViewed(
+            @CurrentUserId Long userId,
+            @Valid @RequestBody RecentlyViewedRequest request) {
+        recentlyViewedService.record(userId, request.getProductId());
+    }
+
+    @Operation(summary = "최근 본 상품 목록", description = "최신순 반환. 기본 10개, 최대 50개.")
+    @GetMapping("/me/recently-viewed")
+    public ApiResponse<List<ProductResponse>> getRecentlyViewed(
+            @CurrentUserId Long userId,
+            @RequestParam(defaultValue = "10") int size) {
+        return ApiResponse.ok(recentlyViewedService.getRecentlyViewed(userId, size));
     }
 }

--- a/src/main/java/com/stockmanagement/domain/user/dto/RecentlyViewedRequest.java
+++ b/src/main/java/com/stockmanagement/domain/user/dto/RecentlyViewedRequest.java
@@ -1,0 +1,13 @@
+package com.stockmanagement.domain.user.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class RecentlyViewedRequest {
+
+    @NotNull(message = "상품 ID는 필수입니다.")
+    private Long productId;
+}

--- a/src/main/java/com/stockmanagement/domain/user/service/RecentlyViewedService.java
+++ b/src/main/java/com/stockmanagement/domain/user/service/RecentlyViewedService.java
@@ -1,0 +1,77 @@
+package com.stockmanagement.domain.user.service;
+
+import com.stockmanagement.domain.product.dto.ProductResponse;
+import com.stockmanagement.domain.product.entity.Product;
+import com.stockmanagement.domain.product.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.redisson.api.RScoredSortedSet;
+import org.redisson.api.RedissonClient;
+import org.redisson.client.codec.LongCodec;
+import org.springframework.stereotype.Service;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * 최근 본 상품 서비스 — Redis Sorted Set 기반.
+ *
+ * <p>key: "recently-viewed:{userId}", score: timestamp(ms), member: productId.
+ * 최대 50개 유지, 초과 시 가장 오래된 항목 자동 제거.
+ */
+@Service
+@RequiredArgsConstructor
+public class RecentlyViewedService {
+
+    private static final String KEY_PREFIX = "recently-viewed:";
+    private static final int MAX_SIZE = 50;
+
+    private final RedissonClient redissonClient;
+    private final ProductRepository productRepository;
+
+    /**
+     * 상품 조회 기록을 저장한다.
+     *
+     * @param userId    사용자 ID
+     * @param productId 조회한 상품 ID
+     */
+    public void record(Long userId, Long productId) {
+        RScoredSortedSet<Long> set = redissonClient.getScoredSortedSet(KEY_PREFIX + userId, LongCodec.INSTANCE);
+        set.add(System.currentTimeMillis(), productId);
+
+        // 최대 크기 초과 시 가장 오래된 항목 제거
+        int size = set.size();
+        if (size > MAX_SIZE) {
+            set.removeRangeByRank(0, size - MAX_SIZE - 1);
+        }
+    }
+
+    /**
+     * 최근 본 상품 목록을 조회한다 (최신순).
+     *
+     * @param userId 사용자 ID
+     * @param size   조회할 개수 (최대 50)
+     * @return 최근 본 상품 목록 (삭제된 상품 제외)
+     */
+    public List<ProductResponse> getRecentlyViewed(Long userId, int size) {
+        int limit = Math.min(size, MAX_SIZE);
+        RScoredSortedSet<Long> set = redissonClient.getScoredSortedSet(KEY_PREFIX + userId, LongCodec.INSTANCE);
+
+        // 최신순으로 limit개 조회 (높은 score = 최신)
+        Collection<Long> productIds = set.valueRangeReversed(0, limit - 1);
+        if (productIds.isEmpty()) {
+            return List.of();
+        }
+
+        // 배치 조회 후 순서 유지
+        Map<Long, Product> productMap = productRepository.findAllById(productIds).stream()
+                .collect(Collectors.toMap(Product::getId, Function.identity()));
+
+        return productIds.stream()
+                .filter(productMap::containsKey)
+                .map(id -> ProductResponse.from(productMap.get(id)))
+                .toList();
+    }
+}

--- a/src/test/java/com/stockmanagement/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/user/controller/UserControllerTest.java
@@ -58,6 +58,9 @@ class UserControllerTest {
     private ReviewService reviewService;
 
     @MockBean
+    private com.stockmanagement.domain.user.service.RecentlyViewedService recentlyViewedService;
+
+    @MockBean
     private JwtBlacklist jwtBlacklist;
 
     /** String principal을 가진 인증 토큰 생성 헬퍼 */


### PR DESCRIPTION
## Summary
- `POST /api/users/me/recently-viewed` — 상품 조회 기록 (Redis ZSet, score=timestamp)
- `GET /api/users/me/recently-viewed?size=10` — 최근 본 상품 목록 (최신순, 최대 50개)
- ZSet 최대 50개 유지, 초과 시 가장 오래된 항목 자동 제거

## Changes
- `RecentlyViewedService.java` (NEW): Redis ZSet 기반 기록/조회
- `RecentlyViewedRequest.java` (NEW): productId 필수 DTO
- `UserController.java`: POST/GET 엔드포인트 추가
- `UserControllerTest.java`: @MockBean RecentlyViewedService 추가

## Test plan
- [x] 전체 테스트 통과 (647개)
- [ ] 상품 조회 기록 후 목록에 반영되는지 확인
- [ ] 50개 초과 시 오래된 항목 제거 확인