### PR TITLE
feat: 비밀번호 찾기/재설정 API (#110)

### DIFF
--- a/src/main/java/com/stockmanagement/common/email/EmailService.java
+++ b/src/main/java/com/stockmanagement/common/email/EmailService.java
@@ -116,6 +116,21 @@ public class EmailService {
         send(to, "[StockMall] 배송이 완료되었습니다 (#" + orderId + ")", wrap(content));
     }
 
+    public void sendPasswordResetEmail(String to, String token) {
+        String content = """
+                <h2 style="margin:0 0 6px;font-size:18px;color:#111;">비밀번호 재설정 요청 🔑</h2>
+                <p style="margin:0 0 20px;color:#666;font-size:14px;">비밀번호 재설정이 요청되었습니다. 아래 토큰을 사용하여 비밀번호를 재설정해 주세요.</p>
+                %s
+                <p style="font-size:13px;color:#555;margin-top:20px;">
+                  이 토큰은 30분 동안 유효하며 1회만 사용할 수 있습니다.<br>
+                  본인이 요청하지 않은 경우 이 메일을 무시해 주세요.
+                </p>
+                """.formatted(infoBox(
+                row("재설정 토큰", token)
+        ));
+        send(to, "[StockMall] 비밀번호 재설정 안내", wrap(content));
+    }
+
     // ══ 내부 헬퍼 ══
 
     /**

--- a/src/main/java/com/stockmanagement/common/exception/ErrorCode.java
+++ b/src/main/java/com/stockmanagement/common/exception/ErrorCode.java
@@ -104,6 +104,7 @@ public enum ErrorCode {
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 올바르지 않습니다."),
     SAME_PASSWORD(HttpStatus.BAD_REQUEST, "현재 비밀번호와 동일한 비밀번호로는 변경할 수 없습니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않거나 만료된 Refresh Token입니다."),
+    INVALID_RESET_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않거나 만료된 비밀번호 재설정 토큰입니다."),
 
     // ===== Admin =====
     LAST_ADMIN(HttpStatus.CONFLICT, "마지막 관리자의 권한은 해제할 수 없습니다."),

--- a/src/main/java/com/stockmanagement/common/security/PasswordResetTokenStore.java
+++ b/src/main/java/com/stockmanagement/common/security/PasswordResetTokenStore.java
@@ -1,0 +1,49 @@
+package com.stockmanagement.common.security;
+
+import com.stockmanagement.common.exception.BusinessException;
+import com.stockmanagement.common.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.redisson.api.RBucket;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * 비밀번호 재설정 토큰 저장소 (Redis 기반).
+ *
+ * <p>키 구조: {@code reset:token:{uuid}} → username (TTL: 30분)
+ * <p>일회용 — {@link #consume(String)} 호출 시 즉시 삭제된다.
+ */
+@Component
+@RequiredArgsConstructor
+public class PasswordResetTokenStore {
+
+    private static final String TOKEN_PREFIX = "reset:token:";
+    private static final long TTL_MINUTES = 30;
+
+    private final RedissonClient redissonClient;
+
+    /** 비밀번호 재설정 토큰 발급. UUID 생성 후 Redis에 저장하고 토큰 문자열을 반환한다. */
+    public String issue(String username) {
+        String token = UUID.randomUUID().toString();
+        redissonClient.<String>getBucket(TOKEN_PREFIX + token)
+                .set(username, TTL_MINUTES, TimeUnit.MINUTES);
+        return token;
+    }
+
+    /**
+     * 토큰 소비(일회용). 토큰을 삭제하고 저장된 username을 반환한다.
+     *
+     * @throws BusinessException 토큰이 존재하지 않거나 만료된 경우
+     */
+    public String consume(String token) {
+        RBucket<String> bucket = redissonClient.getBucket(TOKEN_PREFIX + token);
+        String username = bucket.getAndDelete();
+        if (username == null) {
+            throw new BusinessException(ErrorCode.INVALID_RESET_TOKEN);
+        }
+        return username;
+    }
+}

--- a/src/main/java/com/stockmanagement/domain/user/controller/AuthController.java
+++ b/src/main/java/com/stockmanagement/domain/user/controller/AuthController.java
@@ -4,9 +4,11 @@ import com.stockmanagement.common.dto.ApiResponse;
 import com.stockmanagement.common.ratelimit.RateLimit;
 import com.stockmanagement.common.security.JwtBlacklist;
 import com.stockmanagement.common.security.RefreshTokenStore;
+import com.stockmanagement.domain.user.dto.ForgotPasswordRequest;
 import com.stockmanagement.domain.user.dto.LoginRequest;
 import com.stockmanagement.domain.user.dto.LoginResponse;
 import com.stockmanagement.domain.user.dto.RefreshRequest;
+import com.stockmanagement.domain.user.dto.ResetPasswordRequest;
 import com.stockmanagement.domain.user.dto.SignupRequest;
 import com.stockmanagement.domain.user.dto.UserResponse;
 import com.stockmanagement.domain.user.service.UserService;
@@ -24,10 +26,12 @@ import org.springframework.web.bind.annotation.*;
  * POST /api/auth/signup   회원가입 → 201 Created
  * POST /api/auth/login    로그인 (Access Token + Refresh Token 발급) → 200 OK
  * POST /api/auth/refresh  Access Token 재발급 (Refresh Token rotation) → 200 OK
- * POST /api/auth/logout   로그아웃 (Access Token 블랙리스트 + Refresh Token 무효화) → 200 OK
+ * POST /api/auth/logout            로그아웃 (Access Token 블랙리스트 + Refresh Token 무효화) → 200 OK
+ * POST /api/auth/forgot-password   비밀번호 재설정 이메일 발송 → 200 OK
+ * POST /api/auth/reset-password    비밀번호 재설정 (토큰 검증) → 200 OK
  * </pre>
  */
-@Tag(name = "인증", description = "회원가입 · 로그인 · 토큰 재발급 · 로그아웃")
+@Tag(name = "인증", description = "회원가입 · 로그인 · 토큰 재발급 · 로그아웃 · 비밀번호 재설정")
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
@@ -70,6 +74,24 @@ public class AuthController {
         if (refreshRequest != null && refreshRequest.refreshToken() != null) {
             refreshTokenStore.revoke(refreshRequest.refreshToken());
         }
+        return ApiResponse.ok(null);
+    }
+
+    @Operation(summary = "비밀번호 재설정 요청",
+               description = "등록된 이메일로 비밀번호 재설정 토큰을 발송한다. 이메일 존재 여부와 무관하게 200 OK를 반환한다.")
+    @PostMapping("/forgot-password")
+    @RateLimit(limit = 3, windowSeconds = 3600, keyType = RateLimit.KeyType.IP)
+    public ApiResponse<Void> forgotPassword(@RequestBody @Valid ForgotPasswordRequest request) {
+        userService.sendPasswordResetEmail(request.email());
+        return ApiResponse.ok(null);
+    }
+
+    @Operation(summary = "비밀번호 재설정",
+               description = "재설정 토큰으로 비밀번호를 변경한다. 토큰은 1회용이며 30분간 유효하다.")
+    @PostMapping("/reset-password")
+    @RateLimit(limit = 5, windowSeconds = 3600, keyType = RateLimit.KeyType.IP)
+    public ApiResponse<Void> resetPassword(@RequestBody @Valid ResetPasswordRequest request) {
+        userService.resetPassword(request.token(), request.newPassword());
         return ApiResponse.ok(null);
     }
 }

--- a/src/main/java/com/stockmanagement/domain/user/dto/ForgotPasswordRequest.java
+++ b/src/main/java/com/stockmanagement/domain/user/dto/ForgotPasswordRequest.java
@@ -1,0 +1,10 @@
+package com.stockmanagement.domain.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record ForgotPasswordRequest(
+        @NotBlank
+        @Email
+        String email
+) {}

--- a/src/main/java/com/stockmanagement/domain/user/dto/ResetPasswordRequest.java
+++ b/src/main/java/com/stockmanagement/domain/user/dto/ResetPasswordRequest.java
@@ -1,0 +1,18 @@
+package com.stockmanagement.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record ResetPasswordRequest(
+        @NotBlank
+        String token,
+
+        @NotBlank
+        @Size(min = 8, max = 100)
+        @Pattern(
+                regexp = "^(?=.*[A-Z])(?=.*[0-9])(?=.*[^A-Za-z0-9]).+$",
+                message = "비밀번호는 대문자, 숫자, 특수문자를 각 1개 이상 포함해야 합니다."
+        )
+        String newPassword
+) {}

--- a/src/main/java/com/stockmanagement/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/stockmanagement/domain/user/repository/UserRepository.java
@@ -14,6 +14,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByUsername(String username);
 
+    Optional<User> findByEmail(String email);
+
     boolean existsByUsername(String username);
 
     boolean existsByEmail(String email);

--- a/src/main/java/com/stockmanagement/domain/user/service/UserService.java
+++ b/src/main/java/com/stockmanagement/domain/user/service/UserService.java
@@ -23,16 +23,22 @@ import com.stockmanagement.domain.user.dto.UserResponse;
 import com.stockmanagement.domain.user.entity.User;
 import com.stockmanagement.domain.user.entity.UserRole;
 import com.stockmanagement.domain.user.repository.UserRepository;
+import com.stockmanagement.common.email.EmailService;
 import com.stockmanagement.common.security.JwtBlacklist;
 import com.stockmanagement.common.security.LoginRateLimiter;
+import com.stockmanagement.common.security.PasswordResetTokenStore;
 import com.stockmanagement.common.security.RefreshTokenStore;
 import com.stockmanagement.common.security.JwtTokenProvider;
-import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.lang.Nullable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
 
 import java.util.HashSet;
 import java.util.List;
@@ -45,6 +51,7 @@ import java.util.stream.Collectors;
  *
  * <p>회원가입, 로그인(JWT + Refresh Token 발급), 토큰 재발급, 내 정보 조회, 내 주문 목록 조회를 담당한다.
  */
+@Slf4j
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -64,6 +71,11 @@ public class UserService {
     private final JwtBlacklist jwtBlacklist;
     private final LoginRateLimiter loginRateLimiter;
     private final RefreshTokenStore refreshTokenStore;
+    private final PasswordResetTokenStore passwordResetTokenStore;
+
+    @Nullable
+    @Autowired(required = false)
+    private EmailService emailService;
 
     /** 회원가입. username/email 중복 시 예외. */
     @Transactional
@@ -229,5 +241,38 @@ public class UserService {
         Map<Long, com.stockmanagement.domain.shipment.entity.ShipmentStatus> statusMap =
                 shipmentRepository.findStatusMapByOrderIds(orderIds);
         return orders.map(o -> OrderResponse.from(o, reviewedIds, statusMap.get(o.getId())));
+    }
+
+    /**
+     * 비밀번호 재설정 이메일 발송.
+     *
+     * <p>보안: 사용자가 존재하지 않아도 동일한 응답을 반환하여 이메일 존재 여부를 노출하지 않는다.
+     */
+    public void sendPasswordResetEmail(String email) {
+        userRepository.findByEmail(email).ifPresentOrElse(
+                user -> {
+                    String token = passwordResetTokenStore.issue(user.getUsername());
+                    if (emailService != null) {
+                        emailService.sendPasswordResetEmail(email, token);
+                    } else {
+                        log.warn("[PasswordReset] mail.enabled=false — 토큰 발급됨(token={})", token);
+                    }
+                },
+                () -> log.debug("[PasswordReset] 존재하지 않는 이메일 요청: {}", email)
+        );
+    }
+
+    /**
+     * 비밀번호 재설정 — 토큰 검증 후 새 비밀번호로 교체.
+     *
+     * <p>비밀번호 변경 후 해당 사용자의 모든 Refresh Token을 폐기하여 기존 세션을 무효화한다.
+     */
+    @Transactional
+    public void resetPassword(String token, String newPassword) {
+        String username = passwordResetTokenStore.consume(token);
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        user.updatePassword(passwordEncoder.encode(newPassword));
+        refreshTokenStore.revokeAll(username);
     }
 }

--- a/src/test/java/com/stockmanagement/domain/user/controller/AuthControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/user/controller/AuthControllerTest.java
@@ -21,7 +21,10 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -216,6 +219,93 @@ class AuthControllerTest {
         void unauthorizedWithoutAuth() throws Exception {
             mockMvc.perform(post("/api/auth/logout"))
                     .andExpect(status().isUnauthorized());
+        }
+    }
+
+    // ===== POST /api/auth/forgot-password =====
+
+    @Nested
+    @DisplayName("POST /api/auth/forgot-password")
+    class ForgotPassword {
+
+        @Test
+        @DisplayName("유효한 이메일 요청 → 200 (인증 불필요)")
+        void forgotPasswordSuccess() throws Exception {
+            mockMvc.perform(post("/api/auth/forgot-password")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"email\":\"test@example.com\"}"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true));
+
+            verify(userService).sendPasswordResetEmail("test@example.com");
+        }
+
+        @Test
+        @DisplayName("이메일 형식 불량 → 400")
+        void invalidEmailFormat() throws Exception {
+            mockMvc.perform(post("/api/auth/forgot-password")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"email\":\"not-an-email\"}"))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("이메일 누락 → 400")
+        void missingEmail() throws Exception {
+            mockMvc.perform(post("/api/auth/forgot-password")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{}"))
+                    .andExpect(status().isBadRequest());
+        }
+    }
+
+    // ===== POST /api/auth/reset-password =====
+
+    @Nested
+    @DisplayName("POST /api/auth/reset-password")
+    class ResetPassword {
+
+        @Test
+        @DisplayName("유효한 토큰 + 비밀번호 → 200 (인증 불필요)")
+        void resetPasswordSuccess() throws Exception {
+            mockMvc.perform(post("/api/auth/reset-password")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"token\":\"reset-uuid\",\"newPassword\":\"NewPassword1!\"}"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true));
+
+            verify(userService).resetPassword("reset-uuid", "NewPassword1!");
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 토큰 → 401")
+        void invalidToken() throws Exception {
+            doThrow(new BusinessException(ErrorCode.INVALID_RESET_TOKEN))
+                    .when(userService).resetPassword(anyString(), anyString());
+
+            mockMvc.perform(post("/api/auth/reset-password")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"token\":\"bad-token\",\"newPassword\":\"NewPassword1!\"}"))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.success").value(false));
+        }
+
+        @Test
+        @DisplayName("비밀번호 정책 미충족 (대문자 없음) → 400")
+        void weakPassword() throws Exception {
+            mockMvc.perform(post("/api/auth/reset-password")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"token\":\"reset-uuid\",\"newPassword\":\"password1!\"}"))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("토큰 누락 → 400")
+        void missingToken() throws Exception {
+            mockMvc.perform(post("/api/auth/reset-password")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"newPassword\":\"NewPassword1!\"}"))
+                    .andExpect(status().isBadRequest());
         }
     }
 }

--- a/src/test/java/com/stockmanagement/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/user/service/UserServiceTest.java
@@ -20,8 +20,10 @@ import com.stockmanagement.domain.user.dto.UserResponse;
 import com.stockmanagement.domain.user.entity.User;
 import com.stockmanagement.domain.user.entity.UserRole;
 import com.stockmanagement.domain.user.repository.UserRepository;
+import com.stockmanagement.common.email.EmailService;
 import com.stockmanagement.common.security.JwtBlacklist;
 import com.stockmanagement.common.security.LoginRateLimiter;
+import com.stockmanagement.common.security.PasswordResetTokenStore;
 import com.stockmanagement.common.security.RefreshTokenStore;
 import com.stockmanagement.common.security.JwtTokenProvider;
 import org.junit.jupiter.api.BeforeEach;
@@ -89,7 +91,13 @@ class UserServiceTest {
     private RefreshTokenStore refreshTokenStore;
 
     @Mock
+    private PasswordResetTokenStore passwordResetTokenStore;
+
+    @Mock
     private ShipmentRepository shipmentRepository;
+
+    @Mock
+    private EmailService emailService;
 
     @InjectMocks
     private UserService userService;
@@ -106,6 +114,8 @@ class UserServiceTest {
                 .role(UserRole.USER)
                 .build();
         lenient().when(shipmentRepository.findStatusMapByOrderIds(any())).thenReturn(new java.util.HashMap<>());
+        // @Autowired(required=false) 필드는 @InjectMocks가 주입하지 않으므로 수동 설정
+        org.springframework.test.util.ReflectionTestUtils.setField(userService, "emailService", emailService);
     }
 
     // ===== signup() =====
@@ -426,6 +436,71 @@ class UserServiceTest {
                             .isEqualTo(ErrorCode.USER_NOT_FOUND));
 
             verify(userRepository, never()).delete(any(User.class));
+        }
+    }
+
+    // ===== sendPasswordResetEmail() =====
+
+    @Nested
+    @DisplayName("sendPasswordResetEmail()")
+    class SendPasswordResetEmail {
+
+        @Test
+        @DisplayName("존재하는 이메일 — 토큰 발급 + 이메일 발송")
+        void issuesTokenAndSendsEmail() {
+            given(userRepository.findByEmail("test@example.com")).willReturn(Optional.of(user));
+            given(passwordResetTokenStore.issue("testuser")).willReturn("reset-uuid");
+
+            userService.sendPasswordResetEmail("test@example.com");
+
+            verify(passwordResetTokenStore).issue("testuser");
+            verify(emailService).sendPasswordResetEmail("test@example.com", "reset-uuid");
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 이메일 — 예외 없이 정상 종료 (이메일 존재 여부 비노출)")
+        void doesNotThrowForNonexistentEmail() {
+            given(userRepository.findByEmail("unknown@example.com")).willReturn(Optional.empty());
+
+            assertThatCode(() -> userService.sendPasswordResetEmail("unknown@example.com"))
+                    .doesNotThrowAnyException();
+
+            verifyNoInteractions(passwordResetTokenStore);
+            verify(emailService, never()).sendPasswordResetEmail(anyString(), anyString());
+        }
+    }
+
+    // ===== resetPassword() =====
+
+    @Nested
+    @DisplayName("resetPassword()")
+    class ResetPassword {
+
+        @Test
+        @DisplayName("유효한 토큰 — 비밀번호 변경 + Refresh Token 전체 폐기")
+        void resetsPasswordAndRevokesTokens() {
+            given(passwordResetTokenStore.consume("reset-uuid")).willReturn("testuser");
+            given(userRepository.findByUsername("testuser")).willReturn(Optional.of(user));
+            given(passwordEncoder.encode("NewPassword1!")).willReturn("new-encoded-pw");
+
+            userService.resetPassword("reset-uuid", "NewPassword1!");
+
+            verify(passwordEncoder).encode("NewPassword1!");
+            verify(refreshTokenStore).revokeAll("testuser");
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 토큰 — INVALID_RESET_TOKEN 예외 발생")
+        void throwsWhenTokenInvalid() {
+            given(passwordResetTokenStore.consume("invalid-uuid"))
+                    .willThrow(new BusinessException(ErrorCode.INVALID_RESET_TOKEN));
+
+            assertThatThrownBy(() -> userService.resetPassword("invalid-uuid", "NewPassword1!"))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.INVALID_RESET_TOKEN));
+
+            verify(passwordEncoder, never()).encode(anyString());
         }
     }
 }


### PR DESCRIPTION
## Summary
- `POST /api/auth/forgot-password`: 이메일로 비밀번호 재설정 토큰 발송 (Rate Limit 3회/시간, IP)
- `POST /api/auth/reset-password`: 토큰 검증 후 비밀번호 변경 (Rate Limit 5회/시간, IP)
- `PasswordResetTokenStore`: Redis 기반 일회용 토큰 (TTL 30분, `reset:token:{uuid}` → username)
- 보안: 미등록 이메일에도 동일 200 응답 (이메일 존재 여부 비노출)
- 비밀번호 변경 후 해당 사용자의 모든 Refresh Token 폐기

## 변경 파일
| 파일 | 변경 |
|---|---|
| `PasswordResetTokenStore` | 신규 — Redis 토큰 저장소 |
| `ForgotPasswordRequest` / `ResetPasswordRequest` | 신규 DTO |
| `ErrorCode` | `INVALID_RESET_TOKEN` 추가 |
| `EmailService` | `sendPasswordResetEmail()` 추가 |
| `UserService` | `sendPasswordResetEmail()`, `resetPassword()` 추가 |
| `AuthController` | 2개 엔드포인트 추가 |
| `UserRepository` | `findByEmail()` 추가 |

## Test plan
- [x] UserServiceTest: sendPasswordResetEmail 2개 + resetPassword 2개
- [x] AuthControllerTest: forgot-password 3개 + reset-password 4개
- [x] 전체 테스트 통과

Closes #110