### PR TITLE
feat: 홈 화면 전용 집계 API (#127)

### DIFF
--- a/src/main/java/com/stockmanagement/common/config/CacheConfig.java
+++ b/src/main/java/com/stockmanagement/common/config/CacheConfig.java
@@ -74,6 +74,8 @@ public class CacheConfig {
                         "orders", base.entryTtl(Duration.ofMinutes(5)),
                         // 카테고리 트리: 변경 빈도 매우 낮음 → 30분 + 명시적 evict
                         "categories", base.entryTtl(Duration.ofMinutes(30)),
+                        // 홈 화면 집계: 5분 TTL — 신상품/인기상품/카테고리 통합
+                        "home", base.entryTtl(Duration.ofMinutes(5)),
                         // 시스템 설정: 변경 빈도 매우 낮음 → 1시간 + 명시적 evict
                         "settings", base.entryTtl(Duration.ofHours(1))
                 ))

--- a/src/main/java/com/stockmanagement/common/config/SecurityConfig.java
+++ b/src/main/java/com/stockmanagement/common/config/SecurityConfig.java
@@ -98,6 +98,8 @@ public class SecurityConfig {
                         .requestMatchers("/shop/**").permitAll()
                         // 결제 테스트 페이지
                         .requestMatchers("/payment-test.html").permitAll()
+                        // 홈 화면 집계 — 비로그인 허용
+                        .requestMatchers(HttpMethod.GET, "/api/home").permitAll()
                         // 상품 조회 — 비로그인 허용 (쇼핑몰 특성상 누구나 열람 가능)
                         .requestMatchers(HttpMethod.GET, "/api/products/**").permitAll()
                         // 상품 이미지 — Presigned URL 발급·저장·삭제는 ADMIN 전용

--- a/src/main/java/com/stockmanagement/domain/product/controller/HomeController.java
+++ b/src/main/java/com/stockmanagement/domain/product/controller/HomeController.java
@@ -1,0 +1,33 @@
+package com.stockmanagement.domain.product.controller;
+
+import com.stockmanagement.common.dto.ApiResponse;
+import com.stockmanagement.domain.product.dto.HomeResponse;
+import com.stockmanagement.domain.product.service.HomeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 홈 화면 REST API 컨트롤러.
+ *
+ * <pre>
+ * GET /api/home   홈 화면 집계 데이터 (신상품·인기상품·카테고리) → 200 OK
+ * </pre>
+ */
+@Tag(name = "홈", description = "홈 화면 전용 집계 API")
+@RestController
+@RequestMapping("/api/home")
+@RequiredArgsConstructor
+public class HomeController {
+
+    private final HomeService homeService;
+
+    @Operation(summary = "홈 화면 데이터", description = "신상품, 인기 상품, 추천 카테고리를 단일 응답으로 반환한다. Redis 캐시(TTL 5분).")
+    @GetMapping
+    public ApiResponse<HomeResponse> getHome() {
+        return ApiResponse.ok(homeService.getHomeScreen());
+    }
+}

--- a/src/main/java/com/stockmanagement/domain/product/dto/HomeResponse.java
+++ b/src/main/java/com/stockmanagement/domain/product/dto/HomeResponse.java
@@ -1,0 +1,29 @@
+package com.stockmanagement.domain.product.dto;
+
+import com.stockmanagement.domain.product.category.dto.CategoryResponse;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.extern.jackson.Jacksonized;
+
+import java.util.List;
+
+/**
+ * 홈 화면 집계 응답 DTO.
+ *
+ * <p>신상품, 인기 상품, 추천 카테고리를 단일 응답으로 반환한다.
+ * Redis 캐시(TTL 5분)를 통해 DB 부하를 최소화한다.
+ */
+@Getter
+@Builder
+@Jacksonized
+public class HomeResponse {
+
+    /** 최신 ACTIVE 상품 (최대 8개, createdAt DESC) */
+    private final List<ProductResponse> newArrivals;
+
+    /** 인기 ACTIVE 상품 (최대 8개, 리뷰 수 DESC) */
+    private final List<ProductResponse> popularProducts;
+
+    /** 추천 카테고리 트리 (루트 카테고리 + 하위) */
+    private final List<CategoryResponse> featuredCategories;
+}

--- a/src/main/java/com/stockmanagement/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/stockmanagement/domain/product/repository/ProductRepository.java
@@ -77,6 +77,18 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     @Query("SELECT p.category.id, COUNT(p) FROM Product p WHERE p.category.id IN :ids AND p.status <> 'DISCONTINUED' GROUP BY p.category.id")
     List<Object[]> countActiveProductsByCategoryIds(@Param("ids") Collection<Long> ids);
 
+    /**
+     * 리뷰 수가 많은 ACTIVE 상품을 조회한다 (홈 화면 인기 상품용).
+     * LEFT JOIN으로 리뷰 없는 상품도 포함, 리뷰 수 내림차순 → 최신순 정렬.
+     */
+    @Query(value = "SELECT p FROM Product p LEFT JOIN FETCH p.category " +
+                   "LEFT JOIN Review r ON r.productId = p.id " +
+                   "WHERE p.status = :status " +
+                   "GROUP BY p " +
+                   "ORDER BY COUNT(r) DESC, p.createdAt DESC",
+           countQuery = "SELECT COUNT(DISTINCT p) FROM Product p LEFT JOIN Review r ON r.productId = p.id WHERE p.status = :status")
+    Page<Product> findPopularByStatus(@Param("status") ProductStatus status, Pageable pageable);
+
     /** countActiveProductsByCategoryIds() 결과를 Map으로 변환한다. */
     default Map<Long, Long> countMapByCategoryIds(Collection<Long> ids) {
         return countActiveProductsByCategoryIds(ids).stream()

--- a/src/main/java/com/stockmanagement/domain/product/service/HomeService.java
+++ b/src/main/java/com/stockmanagement/domain/product/service/HomeService.java
@@ -1,0 +1,105 @@
+package com.stockmanagement.domain.product.service;
+
+import com.stockmanagement.domain.inventory.entity.Inventory;
+import com.stockmanagement.domain.inventory.repository.InventoryRepository;
+import com.stockmanagement.domain.product.category.dto.CategoryResponse;
+import com.stockmanagement.domain.product.category.service.CategoryService;
+import com.stockmanagement.domain.product.dto.HomeResponse;
+import com.stockmanagement.domain.product.dto.ProductResponse;
+import com.stockmanagement.domain.product.entity.Product;
+import com.stockmanagement.domain.product.entity.ProductStatus;
+import com.stockmanagement.domain.product.repository.ProductRepository;
+import com.stockmanagement.domain.product.review.repository.ReviewRepository;
+import com.stockmanagement.domain.product.review.repository.ReviewStatsProjection;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * 홈 화면 집계 서비스.
+ *
+ * <p>신상품, 인기 상품, 추천 카테고리를 단일 응답으로 조합한다.
+ * Redis 캐시(TTL 5분)로 DB 부하를 최소화한다.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class HomeService {
+
+    private static final int HOME_PRODUCT_SIZE = 8;
+
+    private final ProductRepository productRepository;
+    private final InventoryRepository inventoryRepository;
+    private final ReviewRepository reviewRepository;
+    private final CategoryService categoryService;
+
+    @Cacheable(cacheNames = "home", key = "'screen'")
+    public HomeResponse getHomeScreen() {
+        // 1. 신상품: 최신 ACTIVE 상품 8개
+        List<Product> newArrivals = productRepository.findByStatus(
+                ProductStatus.ACTIVE,
+                PageRequest.of(0, HOME_PRODUCT_SIZE, Sort.by(Sort.Direction.DESC, "createdAt"))
+        ).getContent();
+
+        // 2. 인기 상품: 리뷰 많은 순 ACTIVE 상품 8개
+        List<Product> popular = productRepository.findPopularByStatus(
+                ProductStatus.ACTIVE,
+                PageRequest.of(0, HOME_PRODUCT_SIZE)
+        ).getContent();
+
+        // 3. 배치 조회: 두 목록의 상품 ID를 합쳐 review/inventory 한 번에 조회
+        List<Long> allProductIds = Stream.of(newArrivals, popular)
+                .flatMap(Collection::stream)
+                .map(Product::getId)
+                .distinct()
+                .collect(Collectors.toList());
+
+        Map<Long, ReviewStatsProjection> reviewStatsMap = allProductIds.isEmpty()
+                ? Map.of()
+                : reviewRepository.findReviewStatsByProductIdIn(allProductIds).stream()
+                        .collect(Collectors.toMap(ReviewStatsProjection::getProductId, r -> r));
+
+        Map<Long, Integer> inventoryMap = allProductIds.isEmpty()
+                ? Map.of()
+                : inventoryRepository.findAllByProductIdIn(allProductIds).stream()
+                        .collect(Collectors.toMap(
+                                inv -> inv.getProduct().getId(),
+                                Inventory::getAvailable,
+                                (a, b) -> a));
+
+        // 4. DTO 변환
+        List<ProductResponse> newArrivalResponses = toProductResponses(newArrivals, reviewStatsMap, inventoryMap);
+        List<ProductResponse> popularResponses = toProductResponses(popular, reviewStatsMap, inventoryMap);
+
+        // 5. 추천 카테고리 (기존 캐시된 트리 재사용)
+        List<CategoryResponse> categories = categoryService.getTree();
+
+        return HomeResponse.builder()
+                .newArrivals(newArrivalResponses)
+                .popularProducts(popularResponses)
+                .featuredCategories(categories)
+                .build();
+    }
+
+    private List<ProductResponse> toProductResponses(
+            List<Product> products,
+            Map<Long, ReviewStatsProjection> reviewStatsMap,
+            Map<Long, Integer> inventoryMap) {
+        return products.stream().map(p -> {
+            ReviewStatsProjection stats = reviewStatsMap.get(p.getId());
+            Double avgRating = stats != null ? stats.getAvgRating() : null;
+            Long reviewCount = stats != null ? stats.getReviewCount() : null;
+            Integer available = inventoryMap.get(p.getId());
+            return ProductResponse.from(p, available, avgRating, reviewCount);
+        }).collect(Collectors.toList());
+    }
+}

--- a/src/test/java/com/stockmanagement/domain/product/controller/HomeControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/product/controller/HomeControllerTest.java
@@ -1,0 +1,91 @@
+package com.stockmanagement.domain.product.controller;
+
+import com.stockmanagement.common.config.SecurityConfig;
+import com.stockmanagement.domain.product.category.dto.CategoryResponse;
+import com.stockmanagement.domain.product.dto.HomeResponse;
+import com.stockmanagement.domain.product.dto.ProductResponse;
+import com.stockmanagement.domain.product.entity.ProductStatus;
+import com.stockmanagement.domain.product.service.HomeService;
+import com.stockmanagement.common.security.JwtBlacklist;
+import com.stockmanagement.common.security.JwtTokenProvider;
+import com.stockmanagement.domain.user.service.UserService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(HomeController.class)
+@Import(SecurityConfig.class)
+@DisplayName("HomeController 단위 테스트")
+class HomeControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private HomeService homeService;
+
+    @MockBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockBean
+    private JwtBlacklist jwtBlacklist;
+
+    @MockBean
+    private UserService userService;
+
+    @Test
+    @DisplayName("GET /api/home — 인증 없이 200 반환")
+    void returnsHomeScreenWithoutAuth() throws Exception {
+        ProductResponse product = ProductResponse.builder()
+                .id(1L).name("테스트 상품").price(BigDecimal.valueOf(10000))
+                .status(ProductStatus.ACTIVE).build();
+        CategoryResponse category = CategoryResponse.builder()
+                .id(1L).name("전자기기").build();
+        HomeResponse response = HomeResponse.builder()
+                .newArrivals(List.of(product))
+                .popularProducts(List.of(product))
+                .featuredCategories(List.of(category))
+                .build();
+
+        given(homeService.getHomeScreen()).willReturn(response);
+
+        mockMvc.perform(get("/api/home"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.newArrivals").isArray())
+                .andExpect(jsonPath("$.data.newArrivals[0].name").value("테스트 상품"))
+                .andExpect(jsonPath("$.data.popularProducts").isArray())
+                .andExpect(jsonPath("$.data.featuredCategories").isArray())
+                .andExpect(jsonPath("$.data.featuredCategories[0].name").value("전자기기"));
+    }
+
+    @Test
+    @DisplayName("GET /api/home — 빈 데이터도 정상 반환")
+    void returnsEmptyHome() throws Exception {
+        HomeResponse response = HomeResponse.builder()
+                .newArrivals(List.of())
+                .popularProducts(List.of())
+                .featuredCategories(List.of())
+                .build();
+
+        given(homeService.getHomeScreen()).willReturn(response);
+
+        mockMvc.perform(get("/api/home"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.newArrivals").isEmpty())
+                .andExpect(jsonPath("$.data.popularProducts").isEmpty())
+                .andExpect(jsonPath("$.data.featuredCategories").isEmpty());
+    }
+}

--- a/src/test/java/com/stockmanagement/domain/product/service/HomeServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/product/service/HomeServiceTest.java
@@ -1,0 +1,99 @@
+package com.stockmanagement.domain.product.service;
+
+import com.stockmanagement.domain.inventory.entity.Inventory;
+import com.stockmanagement.domain.inventory.repository.InventoryRepository;
+import com.stockmanagement.domain.product.category.dto.CategoryResponse;
+import com.stockmanagement.domain.product.category.service.CategoryService;
+import com.stockmanagement.domain.product.dto.HomeResponse;
+import com.stockmanagement.domain.product.entity.Product;
+import com.stockmanagement.domain.product.entity.ProductStatus;
+import com.stockmanagement.domain.product.repository.ProductRepository;
+import com.stockmanagement.domain.product.review.repository.ReviewRepository;
+import com.stockmanagement.domain.product.review.repository.ReviewStatsProjection;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("HomeService 단위 테스트")
+class HomeServiceTest {
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @Mock
+    private InventoryRepository inventoryRepository;
+
+    @Mock
+    private ReviewRepository reviewRepository;
+
+    @Mock
+    private CategoryService categoryService;
+
+    @InjectMocks
+    private HomeService homeService;
+
+    @Test
+    @DisplayName("홈 화면 데이터 — 신상품, 인기 상품, 카테고리 반환")
+    void returnsHomeScreenData() {
+        // given
+        Product product1 = Product.builder()
+                .name("상품A").price(BigDecimal.valueOf(10000)).sku("SKU-A").build();
+        Product product2 = Product.builder()
+                .name("상품B").price(BigDecimal.valueOf(20000)).sku("SKU-B").build();
+
+        given(productRepository.findByStatus(eq(ProductStatus.ACTIVE), any(Pageable.class)))
+                .willReturn(new PageImpl<>(List.of(product1, product2)));
+        given(productRepository.findPopularByStatus(eq(ProductStatus.ACTIVE), any(Pageable.class)))
+                .willReturn(new PageImpl<>(List.of(product2)));
+
+        given(reviewRepository.findReviewStatsByProductIdIn(any())).willReturn(List.of());
+        given(inventoryRepository.findAllByProductIdIn(any())).willReturn(List.of());
+
+        CategoryResponse category = CategoryResponse.builder().id(1L).name("전자기기").build();
+        given(categoryService.getTree()).willReturn(List.of(category));
+
+        // when
+        HomeResponse response = homeService.getHomeScreen();
+
+        // then
+        assertThat(response.getNewArrivals()).hasSize(2);
+        assertThat(response.getPopularProducts()).hasSize(1);
+        assertThat(response.getFeaturedCategories()).hasSize(1);
+        assertThat(response.getFeaturedCategories().get(0).getName()).isEqualTo("전자기기");
+
+        verify(productRepository).findByStatus(eq(ProductStatus.ACTIVE), any(Pageable.class));
+        verify(productRepository).findPopularByStatus(eq(ProductStatus.ACTIVE), any(Pageable.class));
+        verify(categoryService).getTree();
+    }
+
+    @Test
+    @DisplayName("상품이 없을 때 — 빈 목록 반환")
+    void returnsEmptyListsWhenNoProducts() {
+        given(productRepository.findByStatus(eq(ProductStatus.ACTIVE), any(Pageable.class)))
+                .willReturn(new PageImpl<>(List.of()));
+        given(productRepository.findPopularByStatus(eq(ProductStatus.ACTIVE), any(Pageable.class)))
+                .willReturn(new PageImpl<>(List.of()));
+        given(categoryService.getTree()).willReturn(List.of());
+
+        HomeResponse response = homeService.getHomeScreen();
+
+        assertThat(response.getNewArrivals()).isEmpty();
+        assertThat(response.getPopularProducts()).isEmpty();
+        assertThat(response.getFeaturedCategories()).isEmpty();
+    }
+}


### PR DESCRIPTION
## Summary
- `GET /api/home`: 신상품·인기상품·추천 카테고리를 **단일 응답**으로 반환
- Redis 캐시(TTL 5분)로 DB 부하 최소화
- 리뷰/재고 **배치 조회**로 N+1 방지

## 변경 파일
| 파일 | 변경 |
|---|---|
| `HomeResponse` | 신규 DTO — newArrivals, popularProducts, featuredCategories |
| `HomeService` | 신규 — 집계 로직 + `@Cacheable("home")` |
| `HomeController` | 신규 — `GET /api/home` 엔드포인트 |
| `ProductRepository` | `findPopularByStatus()` 추가 (리뷰 수 기반 인기 상품) |
| `CacheConfig` | `"home"` TTL 5분 추가 |
| `SecurityConfig` | `GET /api/home` permitAll 추가 |

## Test plan
- [x] HomeServiceTest: 정상 반환 + 빈 목록 케이스 (2개)
- [x] HomeControllerTest: 인증 없이 200 + 빈 데이터 (2개)
- [x] 전체 테스트 통과

Closes #127