### PR TITLE
perf: 어드민 목록 조회 페이지네이션 인덱스 추가 (#153)

### DIFF
--- a/src/main/resources/db/migration/V47__add_admin_list_indexes.sql
+++ b/src/main/resources/db/migration/V47__add_admin_list_indexes.sql
@@ -1,0 +1,12 @@
+-- 어드민 목록 조회 페이지네이션 성능 개선
+-- users, products, coupons 테이블에 created_at 인덱스 추가
+-- (orders 테이블은 V27에서 이미 idx_orders_created_at 존재)
+
+ALTER TABLE users
+    ADD INDEX idx_users_created_at (created_at);
+
+ALTER TABLE products
+    ADD INDEX idx_products_created_at (created_at);
+
+ALTER TABLE coupons
+    ADD INDEX idx_coupons_created_at (created_at);


### PR DESCRIPTION
## Summary
- `users`, `products`, `coupons` 테이블에 `created_at` 인덱스 추가 (V47 migration)
- `orders` 테이블은 V27에서 이미 `idx_orders_created_at` 존재하므로 제외
- 어드민 목록 조회(`AdminService.getOrders/getUsers/getAllProducts`, `CouponService.getList`)의 `ORDER BY created_at DESC` 페이지네이션 성능 개선
- `max-page-size=100` 이미 설정되어 deep OFFSET 제한 확인

## Test plan
- [x] 전체 테스트 통과 확인 (BUILD SUCCESSFUL)
- [ ] 운영 DB에 마이그레이션 적용 후 EXPLAIN으로 인덱스 사용 확인

Closes #153