### PR TITLE
feat: 상품 재입고 알림 신청 기능 (#123)

### DIFF
--- a/src/main/java/com/stockmanagement/common/config/SecurityConfig.java
+++ b/src/main/java/com/stockmanagement/common/config/SecurityConfig.java
@@ -109,6 +109,9 @@ public class SecurityConfig {
                         // 리뷰 작성/삭제 — 일반 사용자 인증 필요 (ADMIN 패턴보다 먼저 선언)
                         .requestMatchers(HttpMethod.POST, "/api/products/*/reviews").authenticated()
                         .requestMatchers(HttpMethod.DELETE, "/api/products/*/reviews/**").authenticated()
+                        // 재입고 알림 신청/취소 — 일반 사용자 인증 필요 (ADMIN 패턴보다 먼저 선언)
+                        .requestMatchers(HttpMethod.POST, "/api/products/*/restock-notify").authenticated()
+                        .requestMatchers(HttpMethod.DELETE, "/api/products/*/restock-notify").authenticated()
                         // ADMIN 전용
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .requestMatchers(HttpMethod.POST, "/api/products").hasRole("ADMIN")

--- a/src/main/java/com/stockmanagement/common/email/EmailService.java
+++ b/src/main/java/com/stockmanagement/common/email/EmailService.java
@@ -131,6 +131,18 @@ public class EmailService {
         send(to, "[StockMall] 비밀번호 재설정 안내", wrap(content));
     }
 
+    public void sendRestockAvailable(String to, String productName) {
+        String content = """
+                <h2 style="margin:0 0 6px;font-size:18px;color:#111;">재입고 알림 📦</h2>
+                <p style="margin:0 0 20px;color:#666;font-size:14px;">관심 상품이 재입고되었습니다!</p>
+                %s
+                <p style="font-size:13px;color:#555;margin-top:20px;">재고가 한정되어 있으니 서둘러 구매해 주세요.</p>
+                """.formatted(infoBox(
+                row("상품명", productName)
+        ));
+        send(to, "[StockMall] 재입고 알림 — " + HtmlUtils.htmlEscape(productName), wrap(content));
+    }
+
     // ══ 내부 헬퍼 ══
 
     /**

--- a/src/main/java/com/stockmanagement/common/event/RestockEvent.java
+++ b/src/main/java/com/stockmanagement/common/event/RestockEvent.java
@@ -1,0 +1,19 @@
+package com.stockmanagement.common.event;
+
+import lombok.Getter;
+
+/** 재입고 이벤트 — available이 0에서 양수로 전환될 때 발행된다. */
+@Getter
+public class RestockEvent extends DomainEvent {
+
+    private final Long productId;
+    private final String productName;
+    private final int available;
+
+    public RestockEvent(Long productId, String productName, int available) {
+        super();
+        this.productId = productId;
+        this.productName = productName;
+        this.available = available;
+    }
+}

--- a/src/main/java/com/stockmanagement/common/exception/ErrorCode.java
+++ b/src/main/java/com/stockmanagement/common/exception/ErrorCode.java
@@ -88,6 +88,9 @@ public enum ErrorCode {
     WISHLIST_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 위시리스트에 추가된 상품입니다."),
     WISHLIST_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "위시리스트에서 해당 상품을 찾을 수 없습니다."),
 
+    // ===== RestockNotification =====
+    RESTOCK_ALREADY_SUBSCRIBED(HttpStatus.CONFLICT, "이미 재입고 알림을 신청한 상품입니다."),
+
     // ===== Point =====
     INSUFFICIENT_POINTS(HttpStatus.BAD_REQUEST, "포인트 잔액이 부족합니다."),
     INVALID_POINT_AMOUNT(HttpStatus.BAD_REQUEST, "포인트 사용 금액이 올바르지 않습니다."),

--- a/src/main/java/com/stockmanagement/domain/inventory/service/InventoryService.java
+++ b/src/main/java/com/stockmanagement/domain/inventory/service/InventoryService.java
@@ -17,6 +17,7 @@ import com.stockmanagement.domain.inventory.repository.InventorySpecification;
 import com.stockmanagement.domain.inventory.repository.InventoryTransactionRepository;
 import com.stockmanagement.common.dto.CursorPage;
 import com.stockmanagement.common.event.LowStockEvent;
+import com.stockmanagement.common.event.RestockEvent;
 import com.stockmanagement.domain.product.entity.Product;
 import com.stockmanagement.domain.product.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
@@ -133,8 +134,16 @@ public class InventoryService {
                         Inventory.builder().product(product).build()
                 ));
 
+        int availableBefore = inventory.getAvailable();
         inventory.receive(request.getQuantity());
         recordTransaction(inventory, InventoryTransactionType.RECEIVE, request.getQuantity(), request.getNote());
+
+        // 재입고 알림 — 가용 재고가 0에서 양수로 전환될 때 발행
+        if (availableBefore <= 0 && inventory.getAvailable() > 0) {
+            eventPublisher.publishEvent(new RestockEvent(
+                    productId, product.getName(), inventory.getAvailable()));
+        }
+
         return InventoryResponse.from(inventory);
     }
 

--- a/src/main/java/com/stockmanagement/domain/product/notification/controller/RestockNotificationController.java
+++ b/src/main/java/com/stockmanagement/domain/product/notification/controller/RestockNotificationController.java
@@ -1,0 +1,44 @@
+package com.stockmanagement.domain.product.notification.controller;
+
+import com.stockmanagement.common.dto.ApiResponse;
+import com.stockmanagement.common.security.CurrentUserId;
+import com.stockmanagement.domain.product.notification.dto.RestockNotificationResponse;
+import com.stockmanagement.domain.product.notification.service.RestockNotificationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Restock Notification", description = "재입고 알림 API")
+@RestController
+@RequiredArgsConstructor
+public class RestockNotificationController {
+
+    private final RestockNotificationService restockNotificationService;
+
+    @Operation(summary = "재입고 알림 신청")
+    @PostMapping("/api/products/{productId}/restock-notify")
+    @ResponseStatus(HttpStatus.CREATED)
+    public ApiResponse<RestockNotificationResponse> subscribe(
+            @PathVariable Long productId, @CurrentUserId Long userId) {
+        return ApiResponse.ok(restockNotificationService.subscribe(userId, productId));
+    }
+
+    @Operation(summary = "재입고 알림 취소")
+    @DeleteMapping("/api/products/{productId}/restock-notify")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void unsubscribe(
+            @PathVariable Long productId, @CurrentUserId Long userId) {
+        restockNotificationService.unsubscribe(userId, productId);
+    }
+
+    @Operation(summary = "내 재입고 알림 목록 조회")
+    @GetMapping("/api/users/me/restock-notifications")
+    public ApiResponse<List<RestockNotificationResponse>> getMyNotifications(
+            @CurrentUserId Long userId) {
+        return ApiResponse.ok(restockNotificationService.getMyNotifications(userId));
+    }
+}

--- a/src/main/java/com/stockmanagement/domain/product/notification/dto/RestockNotificationResponse.java
+++ b/src/main/java/com/stockmanagement/domain/product/notification/dto/RestockNotificationResponse.java
@@ -1,0 +1,32 @@
+package com.stockmanagement.domain.product.notification.dto;
+
+import com.stockmanagement.domain.product.entity.Product;
+import com.stockmanagement.domain.product.notification.entity.RestockNotification;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class RestockNotificationResponse {
+
+    private Long id;
+    private Long productId;
+    private String productName;
+    private BigDecimal price;
+    private String thumbnailUrl;
+    private LocalDateTime createdAt;
+
+    public static RestockNotificationResponse of(RestockNotification notification, Product product) {
+        return RestockNotificationResponse.builder()
+                .id(notification.getId())
+                .productId(notification.getProductId())
+                .productName(product.getName())
+                .price(product.getPrice())
+                .thumbnailUrl(product.getThumbnailUrl())
+                .createdAt(notification.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/stockmanagement/domain/product/notification/entity/RestockNotification.java
+++ b/src/main/java/com/stockmanagement/domain/product/notification/entity/RestockNotification.java
@@ -1,0 +1,40 @@
+package com.stockmanagement.domain.product.notification.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "restock_notifications",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_restock_notifications_user_product",
+                columnNames = {"user_id", "product_id"}))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RestockNotification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false, updatable = false)
+    private Long userId;
+
+    @Column(name = "product_id", nullable = false, updatable = false)
+    private Long productId;
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    private RestockNotification(Long userId, Long productId) {
+        this.userId = userId;
+        this.productId = productId;
+    }
+}

--- a/src/main/java/com/stockmanagement/domain/product/notification/listener/RestockEventListener.java
+++ b/src/main/java/com/stockmanagement/domain/product/notification/listener/RestockEventListener.java
@@ -1,0 +1,50 @@
+package com.stockmanagement.domain.product.notification.listener;
+
+import com.stockmanagement.common.event.RestockEvent;
+import com.stockmanagement.domain.product.notification.service.RestockNotificationService;
+import com.stockmanagement.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 재입고 이벤트 리스너 — 알림 구독자에게 이메일 발송 후 구독 해제.
+ *
+ * <p>{@link com.stockmanagement.common.email.EmailService}는 {@code mail.enabled=true}에서만
+ * 빈이 생성되므로 Optional 주입으로 처리한다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RestockEventListener {
+
+    private final RestockNotificationService restockNotificationService;
+    private final UserRepository userRepository;
+    private final Optional<com.stockmanagement.common.email.EmailService> emailService;
+
+    @Async("eventTaskExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onRestock(RestockEvent event) {
+        // 구독자 조회 + 구독 삭제 (트랜잭션은 서비스에서 관리)
+        List<Long> userIds = restockNotificationService.consumeSubscribers(event.getProductId());
+        if (userIds.isEmpty()) {
+            return;
+        }
+
+        log.info("[Restock] 재입고 알림 발송 시작: productId={}, subscribers={}", event.getProductId(), userIds.size());
+
+        emailService.ifPresent(service ->
+                userRepository.findAllById(userIds).forEach(user ->
+                        service.sendRestockAvailable(user.getEmail(), event.getProductName())
+                )
+        );
+
+        log.info("[Restock] 재입고 알림 발송 완료: productId={}, notified={}", event.getProductId(), userIds.size());
+    }
+}

--- a/src/main/java/com/stockmanagement/domain/product/notification/repository/RestockNotificationRepository.java
+++ b/src/main/java/com/stockmanagement/domain/product/notification/repository/RestockNotificationRepository.java
@@ -1,0 +1,24 @@
+package com.stockmanagement.domain.product.notification.repository;
+
+import com.stockmanagement.domain.product.notification.entity.RestockNotification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface RestockNotificationRepository extends JpaRepository<RestockNotification, Long> {
+
+    boolean existsByUserIdAndProductId(Long userId, Long productId);
+
+    List<RestockNotification> findByUserIdOrderByCreatedAtDesc(Long userId);
+
+    void deleteByUserIdAndProductId(Long userId, Long productId);
+
+    @Query("SELECT rn.userId FROM RestockNotification rn WHERE rn.productId = :productId")
+    List<Long> findUserIdsByProductId(@Param("productId") Long productId);
+
+    void deleteByProductId(Long productId);
+
+    void deleteByUserId(Long userId);
+}

--- a/src/main/java/com/stockmanagement/domain/product/notification/service/RestockNotificationService.java
+++ b/src/main/java/com/stockmanagement/domain/product/notification/service/RestockNotificationService.java
@@ -1,0 +1,81 @@
+package com.stockmanagement.domain.product.notification.service;
+
+import com.stockmanagement.common.exception.BusinessException;
+import com.stockmanagement.common.exception.ErrorCode;
+import com.stockmanagement.domain.product.entity.Product;
+import com.stockmanagement.domain.product.notification.dto.RestockNotificationResponse;
+import com.stockmanagement.domain.product.notification.entity.RestockNotification;
+import com.stockmanagement.domain.product.notification.repository.RestockNotificationRepository;
+import com.stockmanagement.domain.product.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RestockNotificationService {
+
+    private final RestockNotificationRepository restockNotificationRepository;
+    private final ProductRepository productRepository;
+
+    @Transactional
+    public RestockNotificationResponse subscribe(Long userId, Long productId) {
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND));
+
+        if (restockNotificationRepository.existsByUserIdAndProductId(userId, productId)) {
+            throw new BusinessException(ErrorCode.RESTOCK_ALREADY_SUBSCRIBED);
+        }
+
+        RestockNotification notification = restockNotificationRepository.save(
+                RestockNotification.builder()
+                        .userId(userId)
+                        .productId(productId)
+                        .build()
+        );
+
+        return RestockNotificationResponse.of(notification, product);
+    }
+
+    @Transactional
+    public void unsubscribe(Long userId, Long productId) {
+        restockNotificationRepository.deleteByUserIdAndProductId(userId, productId);
+    }
+
+    /** 재입고 이벤트 처리 — 구독자 userId 목록 조회 후 해당 상품 구독 일괄 삭제. */
+    @Transactional
+    public List<Long> consumeSubscribers(Long productId) {
+        List<Long> userIds = restockNotificationRepository.findUserIdsByProductId(productId);
+        if (!userIds.isEmpty()) {
+            restockNotificationRepository.deleteByProductId(productId);
+        }
+        return userIds;
+    }
+
+    public List<RestockNotificationResponse> getMyNotifications(Long userId) {
+        List<RestockNotification> notifications =
+                restockNotificationRepository.findByUserIdOrderByCreatedAtDesc(userId);
+
+        if (notifications.isEmpty()) {
+            return List.of();
+        }
+
+        List<Long> productIds = notifications.stream()
+                .map(RestockNotification::getProductId)
+                .toList();
+
+        Map<Long, Product> productMap = productRepository.findAllById(productIds).stream()
+                .collect(Collectors.toMap(Product::getId, Function.identity()));
+
+        return notifications.stream()
+                .filter(n -> productMap.containsKey(n.getProductId()))
+                .map(n -> RestockNotificationResponse.of(n, productMap.get(n.getProductId())))
+                .toList();
+    }
+}

--- a/src/main/java/com/stockmanagement/domain/user/service/UserService.java
+++ b/src/main/java/com/stockmanagement/domain/user/service/UserService.java
@@ -10,6 +10,7 @@ import com.stockmanagement.domain.order.service.OrderCommandService;
 import com.stockmanagement.domain.point.entity.UserPoint;
 import com.stockmanagement.domain.point.repository.UserPointRepository;
 import com.stockmanagement.domain.product.review.repository.ReviewRepository;
+import com.stockmanagement.domain.product.notification.repository.RestockNotificationRepository;
 import com.stockmanagement.domain.product.wishlist.repository.WishlistRepository;
 import com.stockmanagement.domain.shipment.repository.ShipmentRepository;
 import com.stockmanagement.domain.user.address.repository.DeliveryAddressRepository;
@@ -66,6 +67,7 @@ public class UserService {
     private final ReviewRepository reviewRepository;
     private final UserPointRepository userPointRepository;
     private final ShipmentRepository shipmentRepository;
+    private final RestockNotificationRepository restockNotificationRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
     private final JwtBlacklist jwtBlacklist;
@@ -168,10 +170,11 @@ public class UserService {
 
         // PENDING 주문 강제 취소 — 재고 예약 해제 + 쿠폰 반환 + 포인트 환불
         orderCommandService.cancelPendingOrdersByUser(user.getId());
-        // 장바구니, 위시리스트, 배송지 일괄 삭제
+        // 장바구니, 위시리스트, 배송지, 재입고 알림 일괄 삭제
         cartRepository.deleteByUserId(user.getId());
         wishlistRepository.deleteByUserId(user.getId());
         deliveryAddressRepository.deleteByUserId(user.getId());
+        restockNotificationRepository.deleteByUserId(user.getId());
 
         // unique 슬롯 해방: 탈퇴 계정이 email/username UNIQUE KEY를 점유하지 않도록 익명화
         user.anonymize(user.getId());

--- a/src/main/resources/db/migration/V48__create_restock_notifications.sql
+++ b/src/main/resources/db/migration/V48__create_restock_notifications.sql
@@ -1,0 +1,14 @@
+-- 재입고 알림 신청 테이블
+CREATE TABLE restock_notifications (
+    id              BIGINT       NOT NULL AUTO_INCREMENT,
+    user_id         BIGINT       NOT NULL,
+    product_id      BIGINT       NOT NULL,
+    created_at      DATETIME(6)  NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id),
+    CONSTRAINT uk_restock_notifications_user_product UNIQUE (user_id, product_id),
+    CONSTRAINT fk_restock_notifications_user
+        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    CONSTRAINT fk_restock_notifications_product
+        FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE,
+    INDEX idx_restock_notifications_product (product_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/src/test/java/com/stockmanagement/domain/product/notification/controller/RestockNotificationControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/product/notification/controller/RestockNotificationControllerTest.java
@@ -1,0 +1,138 @@
+package com.stockmanagement.domain.product.notification.controller;
+
+import com.stockmanagement.common.config.SecurityConfig;
+import com.stockmanagement.common.exception.BusinessException;
+import com.stockmanagement.common.exception.ErrorCode;
+import com.stockmanagement.common.security.JwtBlacklist;
+import com.stockmanagement.common.security.JwtTokenProvider;
+import com.stockmanagement.domain.product.notification.dto.RestockNotificationResponse;
+import com.stockmanagement.domain.product.notification.service.RestockNotificationService;
+import com.stockmanagement.domain.user.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(RestockNotificationController.class)
+@Import(SecurityConfig.class)
+@DisplayName("RestockNotificationController 단위 테스트")
+class RestockNotificationControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+
+    @MockBean private RestockNotificationService restockNotificationService;
+    @MockBean private UserService userService;
+    @MockBean private JwtTokenProvider jwtTokenProvider;
+    @MockBean private JwtBlacklist jwtBlacklist;
+
+    private static final UsernamePasswordAuthenticationToken USER_AUTH =
+            new UsernamePasswordAuthenticationToken("user1", null,
+                    List.of(new SimpleGrantedAuthority("ROLE_USER")));
+
+    @BeforeEach
+    void setUp() {
+        given(userService.resolveUserId(anyString())).willReturn(1L);
+    }
+
+    @Nested
+    @DisplayName("POST /api/products/{productId}/restock-notify")
+    class Subscribe {
+
+        @Test
+        @DisplayName("인증된 사용자 → 201")
+        void subscribes() throws Exception {
+            RestockNotificationResponse response = RestockNotificationResponse.builder()
+                    .id(1L).productId(1L).productName("상품A")
+                    .price(BigDecimal.valueOf(15000))
+                    .createdAt(LocalDateTime.now()).build();
+            given(restockNotificationService.subscribe(anyLong(), anyLong())).willReturn(response);
+
+            mockMvc.perform(post("/api/products/1/restock-notify").with(authentication(USER_AUTH)))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.productId").value(1));
+        }
+
+        @Test
+        @DisplayName("인증 없음 → 401")
+        void unauthenticated() throws Exception {
+            mockMvc.perform(post("/api/products/1/restock-notify"))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("이미 구독 중 → 409")
+        void alreadySubscribed() throws Exception {
+            given(restockNotificationService.subscribe(anyLong(), anyLong()))
+                    .willThrow(new BusinessException(ErrorCode.RESTOCK_ALREADY_SUBSCRIBED));
+
+            mockMvc.perform(post("/api/products/1/restock-notify").with(authentication(USER_AUTH)))
+                    .andExpect(status().isConflict());
+        }
+    }
+
+    @Nested
+    @DisplayName("DELETE /api/products/{productId}/restock-notify")
+    class Unsubscribe {
+
+        @Test
+        @DisplayName("인증된 사용자 → 204")
+        void unsubscribes() throws Exception {
+            mockMvc.perform(delete("/api/products/1/restock-notify").with(authentication(USER_AUTH)))
+                    .andExpect(status().isNoContent());
+        }
+
+        @Test
+        @DisplayName("인증 없음 → 401")
+        void unauthenticated() throws Exception {
+            mockMvc.perform(delete("/api/products/1/restock-notify"))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/users/me/restock-notifications")
+    class GetMyNotifications {
+
+        @Test
+        @DisplayName("인증된 사용자 → 200, 목록 반환")
+        void returnsNotifications() throws Exception {
+            RestockNotificationResponse r = RestockNotificationResponse.builder()
+                    .id(1L).productId(1L).productName("상품A")
+                    .price(BigDecimal.valueOf(15000))
+                    .createdAt(LocalDateTime.now()).build();
+            given(restockNotificationService.getMyNotifications(anyLong())).willReturn(List.of(r));
+
+            mockMvc.perform(get("/api/users/me/restock-notifications").with(authentication(USER_AUTH)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data[0].productId").value(1));
+        }
+
+        @Test
+        @DisplayName("인증 없음 → 401")
+        void unauthenticated() throws Exception {
+            mockMvc.perform(get("/api/users/me/restock-notifications"))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+}

--- a/src/test/java/com/stockmanagement/domain/product/notification/service/RestockNotificationServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/product/notification/service/RestockNotificationServiceTest.java
@@ -1,0 +1,138 @@
+package com.stockmanagement.domain.product.notification.service;
+
+import com.stockmanagement.common.exception.BusinessException;
+import com.stockmanagement.common.exception.ErrorCode;
+import com.stockmanagement.domain.product.entity.Product;
+import com.stockmanagement.domain.product.notification.dto.RestockNotificationResponse;
+import com.stockmanagement.domain.product.notification.entity.RestockNotification;
+import com.stockmanagement.domain.product.notification.repository.RestockNotificationRepository;
+import com.stockmanagement.domain.product.repository.ProductRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RestockNotificationService 단위 테스트")
+class RestockNotificationServiceTest {
+
+    @Mock private RestockNotificationRepository restockNotificationRepository;
+    @Mock private ProductRepository productRepository;
+
+    @InjectMocks private RestockNotificationService restockNotificationService;
+
+    private Product mockProduct(Long id) {
+        Product p = Product.builder().name("상품A").price(BigDecimal.valueOf(15000)).sku("SKU-A").build();
+        ReflectionTestUtils.setField(p, "id", id);
+        return p;
+    }
+
+    private RestockNotification mockNotification(Long id, Long userId, Long productId) {
+        RestockNotification n = RestockNotification.builder().userId(userId).productId(productId).build();
+        ReflectionTestUtils.setField(n, "id", id);
+        return n;
+    }
+
+    @Nested
+    @DisplayName("subscribe()")
+    class Subscribe {
+
+        @Test
+        @DisplayName("정상 구독 → 응답 반환")
+        void subscribes() {
+            Product product = mockProduct(1L);
+            given(productRepository.findById(1L)).willReturn(Optional.of(product));
+            given(restockNotificationRepository.existsByUserIdAndProductId(10L, 1L)).willReturn(false);
+            RestockNotification saved = mockNotification(100L, 10L, 1L);
+            given(restockNotificationRepository.save(any())).willReturn(saved);
+
+            RestockNotificationResponse response = restockNotificationService.subscribe(10L, 1L);
+
+            assertThat(response.getProductId()).isEqualTo(1L);
+            assertThat(response.getProductName()).isEqualTo("상품A");
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 상품 → PRODUCT_NOT_FOUND")
+        void productNotFound() {
+            given(productRepository.findById(999L)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> restockNotificationService.subscribe(10L, 999L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.PRODUCT_NOT_FOUND));
+        }
+
+        @Test
+        @DisplayName("이미 구독 중 → RESTOCK_ALREADY_SUBSCRIBED")
+        void alreadySubscribed() {
+            given(productRepository.findById(1L)).willReturn(Optional.of(mockProduct(1L)));
+            given(restockNotificationRepository.existsByUserIdAndProductId(10L, 1L)).willReturn(true);
+
+            assertThatThrownBy(() -> restockNotificationService.subscribe(10L, 1L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.RESTOCK_ALREADY_SUBSCRIBED));
+        }
+    }
+
+    @Nested
+    @DisplayName("unsubscribe()")
+    class Unsubscribe {
+
+        @Test
+        @DisplayName("정상 구독 취소")
+        void unsubscribes() {
+            restockNotificationService.unsubscribe(10L, 1L);
+            verify(restockNotificationRepository).deleteByUserIdAndProductId(10L, 1L);
+        }
+    }
+
+    @Nested
+    @DisplayName("getMyNotifications()")
+    class GetMyNotifications {
+
+        @Test
+        @DisplayName("구독 목록 반환")
+        void returnsNotifications() {
+            RestockNotification n1 = mockNotification(1L, 10L, 1L);
+            RestockNotification n2 = mockNotification(2L, 10L, 2L);
+            given(restockNotificationRepository.findByUserIdOrderByCreatedAtDesc(10L))
+                    .willReturn(List.of(n1, n2));
+
+            Product p1 = mockProduct(1L);
+            Product p2 = mockProduct(2L);
+            ReflectionTestUtils.setField(p2, "name", "상품B");
+            given(productRepository.findAllById(List.of(1L, 2L))).willReturn(List.of(p1, p2));
+
+            List<RestockNotificationResponse> result = restockNotificationService.getMyNotifications(10L);
+
+            assertThat(result).hasSize(2);
+        }
+
+        @Test
+        @DisplayName("구독 없으면 빈 목록")
+        void emptyList() {
+            given(restockNotificationRepository.findByUserIdOrderByCreatedAtDesc(10L))
+                    .willReturn(List.of());
+
+            List<RestockNotificationResponse> result = restockNotificationService.getMyNotifications(10L);
+
+            assertThat(result).isEmpty();
+        }
+    }
+}

--- a/src/test/java/com/stockmanagement/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/user/service/UserServiceTest.java
@@ -6,6 +6,7 @@ import com.stockmanagement.domain.order.cart.repository.CartRepository;
 import com.stockmanagement.domain.order.dto.OrderResponse;
 import com.stockmanagement.domain.order.repository.OrderRepository;
 import com.stockmanagement.domain.order.service.OrderCommandService;
+import com.stockmanagement.domain.product.notification.repository.RestockNotificationRepository;
 import com.stockmanagement.domain.product.wishlist.repository.WishlistRepository;
 import com.stockmanagement.domain.shipment.repository.ShipmentRepository;
 import com.stockmanagement.domain.user.address.repository.DeliveryAddressRepository;
@@ -95,6 +96,9 @@ class UserServiceTest {
 
     @Mock
     private ShipmentRepository shipmentRepository;
+
+    @Mock
+    private RestockNotificationRepository restockNotificationRepository;
 
     @Mock
     private EmailService emailService;

--- a/src/test/java/com/stockmanagement/integration/AbstractIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/AbstractIntegrationTest.java
@@ -134,6 +134,7 @@ abstract class AbstractIntegrationTest {
             stmt.execute("DELETE FROM shipments");
             stmt.execute("DELETE FROM reviews");
             stmt.execute("DELETE FROM wishlist_items");
+            stmt.execute("DELETE FROM restock_notifications");
             stmt.execute("DELETE FROM refunds");
             stmt.execute("DELETE FROM order_items");
             stmt.execute("DELETE FROM payments");

--- a/src/test/java/com/stockmanagement/integration/RestockNotificationIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/RestockNotificationIntegrationTest.java
@@ -1,0 +1,100 @@
+package com.stockmanagement.integration;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@DisplayName("RestockNotification 통합 테스트")
+class RestockNotificationIntegrationTest extends AbstractIntegrationTest {
+
+    private long createProduct(String adminToken, String sku, int price) throws Exception {
+        String body = mockMvc.perform(post("/api/products")
+                        .header("Authorization", "Bearer " + adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(String.format("{\"name\":\"상품_%s\",\"sku\":\"%s\",\"price\":%d}", sku, sku, price)))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        return objectMapper.readTree(body).path("data").path("id").asLong();
+    }
+
+    @Test
+    @DisplayName("재입고 알림 신청 → 201, productId 확인")
+    void subscribe_success() throws Exception {
+        String adminToken = createAdminAndLogin("admin", "adminpass1", "admin@test.com");
+        long productId = createProduct(adminToken, "SKU-RN1", 15000);
+
+        String userToken = signupAndLogin("user1", "Password1!", "u1@test.com");
+        mockMvc.perform(post("/api/products/" + productId + "/restock-notify")
+                        .header("Authorization", "Bearer " + userToken))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.productId").value(productId))
+                .andExpect(jsonPath("$.data.productName").exists());
+    }
+
+    @Test
+    @DisplayName("중복 신청 → 409 RESTOCK_ALREADY_SUBSCRIBED")
+    void subscribe_duplicate() throws Exception {
+        String adminToken = createAdminAndLogin("admin", "adminpass1", "admin@test.com");
+        long productId = createProduct(adminToken, "SKU-RN2", 15000);
+
+        String userToken = signupAndLogin("user2", "Password1!", "u2@test.com");
+        mockMvc.perform(post("/api/products/" + productId + "/restock-notify")
+                        .header("Authorization", "Bearer " + userToken))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(post("/api/products/" + productId + "/restock-notify")
+                        .header("Authorization", "Bearer " + userToken))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    @DisplayName("알림 목록 조회 → 신청한 상품 포함")
+    void getMyNotifications() throws Exception {
+        String adminToken = createAdminAndLogin("admin", "adminpass1", "admin@test.com");
+        long productId = createProduct(adminToken, "SKU-RN3", 20000);
+
+        String userToken = signupAndLogin("user3", "Password1!", "u3@test.com");
+        mockMvc.perform(post("/api/products/" + productId + "/restock-notify")
+                        .header("Authorization", "Bearer " + userToken))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(get("/api/users/me/restock-notifications")
+                        .header("Authorization", "Bearer " + userToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(1))
+                .andExpect(jsonPath("$.data[0].productId").value(productId));
+    }
+
+    @Test
+    @DisplayName("알림 취소 → 204, 이후 목록 비어 있음")
+    void unsubscribe_success() throws Exception {
+        String adminToken = createAdminAndLogin("admin", "adminpass1", "admin@test.com");
+        long productId = createProduct(adminToken, "SKU-RN4", 25000);
+
+        String userToken = signupAndLogin("user4", "Password1!", "u4@test.com");
+        mockMvc.perform(post("/api/products/" + productId + "/restock-notify")
+                        .header("Authorization", "Bearer " + userToken))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(delete("/api/products/" + productId + "/restock-notify")
+                        .header("Authorization", "Bearer " + userToken))
+                .andExpect(status().isNoContent());
+
+        mockMvc.perform(get("/api/users/me/restock-notifications")
+                        .header("Authorization", "Bearer " + userToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(0));
+    }
+
+    @Test
+    @DisplayName("인증 없이 접근 → 401")
+    void unauthenticated() throws Exception {
+        mockMvc.perform(post("/api/products/1/restock-notify"))
+                .andExpect(status().isUnauthorized());
+    }
+}


### PR DESCRIPTION
## Summary
- 품절 상품에 대해 재입고 알림을 신청/취소/조회하는 기능 구현
- 재입고 시(available 0→양수) `RestockEvent` 발행 → 구독자에게 이메일 알림 발송 후 구독 자동 해제
- `V48` migration: `restock_notifications` 테이블 (UNIQUE user_id+product_id)
- `SecurityConfig`: restock-notify POST/DELETE를 ADMIN 패턴보다 앞에 authenticated()로 선언
- `UserService.deactivate()`: 회원 탈퇴 시 재입고 알림 정리

## API
- `POST /api/products/{id}/restock-notify` — 201
- `DELETE /api/products/{id}/restock-notify` — 204
- `GET /api/users/me/restock-notifications` — 200

## Test plan
- [x] RestockNotificationServiceTest — 단위 테스트 5개
- [x] RestockNotificationControllerTest — 컨트롤러 테스트 7개
- [x] RestockNotificationIntegrationTest — 통합 테스트 5개
- [x] 전체 테스트 통과 (BUILD SUCCESSFUL)

Closes #123