### PR TITLE
feat: 상품 정렬 옵션 추가 — 판매량순·리뷰순 (#126)

### DIFF
--- a/src/main/java/com/stockmanagement/domain/order/repository/OrderItemRepository.java
+++ b/src/main/java/com/stockmanagement/domain/order/repository/OrderItemRepository.java
@@ -2,6 +2,8 @@ package com.stockmanagement.domain.order.repository;
 
 import com.stockmanagement.domain.order.entity.OrderItem;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -16,4 +18,11 @@ public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
 
     /** 특정 주문의 모든 항목 조회 */
     List<OrderItem> findByOrderId(Long orderId);
+
+    /** 결제 완료된 주문에서 특정 상품의 누적 판매 수량 */
+    @Query("SELECT COALESCE(SUM(oi.quantity), 0) FROM OrderItem oi " +
+           "WHERE oi.product.id = :productId " +
+           "AND oi.order.status IN (com.stockmanagement.domain.order.entity.OrderStatus.CONFIRMED, " +
+           "com.stockmanagement.domain.order.entity.OrderStatus.CANCEL_IN_PROGRESS)")
+    long sumSalesCountByProductId(@Param("productId") Long productId);
 }

--- a/src/main/java/com/stockmanagement/domain/product/document/ProductDocument.java
+++ b/src/main/java/com/stockmanagement/domain/product/document/ProductDocument.java
@@ -60,8 +60,19 @@ public class ProductDocument {
     @Field(type = FieldType.Date, format = {}, pattern = "uuuu-MM-dd'T'HH:mm:ss.SSSSSS||uuuu-MM-dd'T'HH:mm:ss.SSS||uuuu-MM-dd'T'HH:mm:ss")
     private LocalDateTime createdAt;
 
+    @Field(type = FieldType.Long)
+    private long reviewCount;
+
+    @Field(type = FieldType.Long)
+    private long salesCount;
+
     /** Product JPA 엔티티로부터 ES 문서를 생성한다. */
     public static ProductDocument from(Product product) {
+        return from(product, 0L, 0L);
+    }
+
+    /** Product JPA 엔티티 + 리뷰/판매 통계를 포함한 ES 문서를 생성한다. */
+    public static ProductDocument from(Product product, long reviewCount, long salesCount) {
         return ProductDocument.builder()
                 .id(String.valueOf(product.getId()))
                 .name(product.getName())
@@ -72,6 +83,8 @@ public class ProductDocument {
                 .status(product.getStatus() != null ? product.getStatus().name() : null)
                 .thumbnailUrl(product.getThumbnailUrl())
                 .createdAt(product.getCreatedAt())
+                .reviewCount(reviewCount)
+                .salesCount(salesCount)
                 .build();
     }
 

--- a/src/main/java/com/stockmanagement/domain/product/dto/ProductSearchRequest.java
+++ b/src/main/java/com/stockmanagement/domain/product/dto/ProductSearchRequest.java
@@ -44,6 +44,8 @@ public class ProductSearchRequest {
      *   <li>{@code price_asc} — 가격 오름차순
      *   <li>{@code price_desc} — 가격 내림차순
      *   <li>{@code newest} — 최신 등록순
+     *   <li>{@code popular} — 판매량순 (ES 전용)
+     *   <li>{@code review} — 리뷰순 (ES 전용)
      * </ul>
      */
     private String sort;

--- a/src/main/java/com/stockmanagement/domain/product/service/ProductEventListener.java
+++ b/src/main/java/com/stockmanagement/domain/product/service/ProductEventListener.java
@@ -1,7 +1,9 @@
 package com.stockmanagement.domain.product.service;
 
 import com.stockmanagement.common.event.ProductSyncEvent;
+import com.stockmanagement.domain.order.repository.OrderItemRepository;
 import com.stockmanagement.domain.product.repository.ProductRepository;
+import com.stockmanagement.domain.product.review.repository.ReviewRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -24,6 +26,8 @@ public class ProductEventListener {
 
     private final ProductRepository productRepository;
     private final ProductSearchService productSearchService;
+    private final ReviewRepository reviewRepository;
+    private final OrderItemRepository orderItemRepository;
 
     /**
      * 상품 변경이 DB에 커밋된 후 ES 색인을 동기화한다.
@@ -44,7 +48,9 @@ public class ProductEventListener {
         try {
             productRepository.findById(productId).ifPresentOrElse(
                     product -> {
-                        productSearchService.index(product);
+                        long reviewCount = reviewRepository.countByProductId(productId);
+                        long salesCount = orderItemRepository.sumSalesCountByProductId(productId);
+                        productSearchService.index(product, reviewCount, salesCount);
                         log.debug("[ProductEventListener] ES 색인 완료. productId={}", productId);
                     },
                     () -> log.warn("[ProductEventListener] ES 색인 대상 상품 미존재. productId={}", productId)

--- a/src/main/java/com/stockmanagement/domain/product/service/ProductSearchService.java
+++ b/src/main/java/com/stockmanagement/domain/product/service/ProductSearchService.java
@@ -113,6 +113,12 @@ public class ProductSearchService {
         log.debug("ES 색인 완료. productId={}", product.getId());
     }
 
+    /** 리뷰/판매 통계를 포함한 ES 색인. */
+    public void index(Product product, long reviewCount, long salesCount) {
+        productSearchRepository.save(ProductDocument.from(product, reviewCount, salesCount));
+        log.debug("ES 색인 완료. productId={} reviewCount={} salesCount={}", product.getId(), reviewCount, salesCount);
+    }
+
     /**
      * 상품을 Elasticsearch 색인에서 삭제한다.
      * ProductService의 delete/changeStatus(DISCONTINUED)에서 호출된다.
@@ -135,6 +141,10 @@ public class ProductSearchService {
                 options.add(SortOptions.of(s -> s.field(f -> f.field("price").order(SortOrder.Desc))));
             case "newest" ->
                 options.add(SortOptions.of(s -> s.field(f -> f.field("createdAt").order(SortOrder.Desc))));
+            case "popular" ->
+                options.add(SortOptions.of(s -> s.field(f -> f.field("salesCount").order(SortOrder.Desc))));
+            case "review" ->
+                options.add(SortOptions.of(s -> s.field(f -> f.field("reviewCount").order(SortOrder.Desc))));
             // relevance: 별도 지정 없음 — ES 기본 _score 정렬
             default -> { }
         }


### PR DESCRIPTION
## Summary
- ES 검색에 `popular`(판매량순), `review`(리뷰순) 정렬 옵션 추가
- `ProductDocument`에 `reviewCount`, `salesCount` 필드 추가
- `ProductEventListener`에서 상품 ES 동기화 시 DB에서 리뷰 수·판매량 조회하여 함께 색인
- `OrderItemRepository.sumSalesCountByProductId()` — CONFIRMED 이상 주문의 누적 판매 수량 쿼리 추가
- MySQL fallback에서는 popular/review 정렬 미지원 (ES 전용)

## 사용법
```
GET /api/products?q=노트북&sort=popular   # 판매량순
GET /api/products?q=노트북&sort=review    # 리뷰순
```

## Test plan
- [x] 전체 테스트 통과 (BUILD SUCCESSFUL)
- [ ] ES 인덱스 재색인 후 popular/review 정렬 검증

Closes #126