### PR TITLE
feat: 배송비 정책 API (#133)

### DIFF
--- a/src/main/java/com/stockmanagement/common/config/SecurityConfig.java
+++ b/src/main/java/com/stockmanagement/common/config/SecurityConfig.java
@@ -100,6 +100,8 @@ public class SecurityConfig {
                         .requestMatchers("/payment-test.html").permitAll()
                         // 홈 화면 집계 — 비로그인 허용
                         .requestMatchers(HttpMethod.GET, "/api/home").permitAll()
+                        // 배송비 정책 조회 — 비로그인 허용
+                        .requestMatchers(HttpMethod.GET, "/api/shipping/policy").permitAll()
                         // 상품 조회 — 비로그인 허용 (쇼핑몰 특성상 누구나 열람 가능)
                         .requestMatchers(HttpMethod.GET, "/api/products/**").permitAll()
                         // 상품 이미지 — Presigned URL 발급·저장·삭제는 ADMIN 전용

--- a/src/main/java/com/stockmanagement/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/stockmanagement/domain/admin/controller/AdminController.java
@@ -6,6 +6,8 @@ import com.stockmanagement.domain.admin.dto.DashboardResponse;
 import com.stockmanagement.domain.admin.dto.LowStockThresholdRequest;
 import com.stockmanagement.domain.admin.dto.LowStockThresholdResponse;
 import com.stockmanagement.domain.admin.dto.RoleUpdateRequest;
+import com.stockmanagement.domain.admin.dto.ShippingPolicyRequest;
+import com.stockmanagement.domain.admin.dto.ShippingPolicyResponse;
 import com.stockmanagement.domain.admin.service.AdminService;
 import com.stockmanagement.domain.admin.setting.service.SystemSettingService;
 import com.stockmanagement.domain.inventory.dto.DailyInventorySnapshotResponse;
@@ -120,5 +122,21 @@ public class AdminController {
             @RequestBody @Valid LowStockThresholdRequest request,
             @AuthenticationPrincipal String username) {
         return ApiResponse.ok(systemSettingService.updateLowStockThreshold(request, username));
+    }
+
+    @Operation(summary = "배송비 정책 조회",
+               description = "현재 기본 배송비와 무료배송 기준 금액을 반환한다.")
+    @GetMapping("/settings/shipping-policy")
+    public ApiResponse<ShippingPolicyResponse> getShippingPolicy() {
+        return ApiResponse.ok(systemSettingService.getShippingPolicyDetails());
+    }
+
+    @Operation(summary = "배송비 정책 변경",
+               description = "기본 배송비와 무료배송 기준 금액을 변경한다. 변경 즉시 주문 미리보기에 반영된다.")
+    @PutMapping("/settings/shipping-policy")
+    public ApiResponse<ShippingPolicyResponse> updateShippingPolicy(
+            @RequestBody @Valid ShippingPolicyRequest request,
+            @AuthenticationPrincipal String username) {
+        return ApiResponse.ok(systemSettingService.updateShippingPolicy(request, username));
     }
 }

--- a/src/main/java/com/stockmanagement/domain/admin/dto/ShippingPolicyRequest.java
+++ b/src/main/java/com/stockmanagement/domain/admin/dto/ShippingPolicyRequest.java
@@ -1,0 +1,18 @@
+package com.stockmanagement.domain.admin.dto;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
+
+import java.math.BigDecimal;
+
+/** 배송비 정책 변경 요청 DTO. */
+public record ShippingPolicyRequest(
+        @NotNull(message = "기본 배송비는 필수입니다.")
+        @DecimalMin(value = "0", message = "배송비는 0 이상이어야 합니다.")
+        BigDecimal defaultFee,
+
+        @NotNull(message = "무료배송 기준 금액은 필수입니다.")
+        @DecimalMin(value = "0", message = "무료배송 기준 금액은 0 이상이어야 합니다.")
+        BigDecimal freeShippingThreshold
+) {
+}

--- a/src/main/java/com/stockmanagement/domain/admin/dto/ShippingPolicyResponse.java
+++ b/src/main/java/com/stockmanagement/domain/admin/dto/ShippingPolicyResponse.java
@@ -1,0 +1,17 @@
+package com.stockmanagement.domain.admin.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/** 배송비 정책 응답 DTO. */
+public record ShippingPolicyResponse(
+        BigDecimal defaultFee,
+        BigDecimal freeShippingThreshold,
+        String updatedBy,
+        LocalDateTime updatedAt
+) {
+    public static ShippingPolicyResponse of(BigDecimal defaultFee, BigDecimal freeShippingThreshold,
+                                            String updatedBy, LocalDateTime updatedAt) {
+        return new ShippingPolicyResponse(defaultFee, freeShippingThreshold, updatedBy, updatedAt);
+    }
+}

--- a/src/main/java/com/stockmanagement/domain/admin/setting/service/SystemSettingService.java
+++ b/src/main/java/com/stockmanagement/domain/admin/setting/service/SystemSettingService.java
@@ -4,13 +4,18 @@ import com.stockmanagement.common.exception.BusinessException;
 import com.stockmanagement.common.exception.ErrorCode;
 import com.stockmanagement.domain.admin.dto.LowStockThresholdRequest;
 import com.stockmanagement.domain.admin.dto.LowStockThresholdResponse;
+import com.stockmanagement.domain.admin.dto.ShippingPolicyRequest;
+import com.stockmanagement.domain.admin.dto.ShippingPolicyResponse;
 import com.stockmanagement.domain.admin.setting.repository.SystemSettingRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
 
 /**
  * 시스템 설정 관리 서비스.
@@ -25,7 +30,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class SystemSettingService {
 
     static final String LOW_STOCK_KEY = "low_stock_threshold";
+    static final String SHIPPING_DEFAULT_FEE_KEY = "shipping_default_fee";
+    static final String SHIPPING_FREE_THRESHOLD_KEY = "shipping_free_threshold";
+
     private static final int DEFAULT_LOW_STOCK_THRESHOLD = 10;
+    private static final BigDecimal DEFAULT_SHIPPING_FEE = new BigDecimal("3000");
+    private static final BigDecimal DEFAULT_FREE_THRESHOLD = new BigDecimal("50000");
 
     private final SystemSettingRepository settingRepository;
 
@@ -70,5 +80,83 @@ public class SystemSettingService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.SETTING_NOT_FOUND));
         setting.update(String.valueOf(request.threshold()), updatedBy);
         return LowStockThresholdResponse.from(setting);
+    }
+
+    // ===== Shipping Policy =====
+
+    /** 기본 배송비를 반환한다. */
+    @Cacheable(value = "settings", key = "'" + SHIPPING_DEFAULT_FEE_KEY + "'")
+    public BigDecimal getShippingDefaultFee() {
+        return settingRepository.findById(SHIPPING_DEFAULT_FEE_KEY)
+                .map(s -> parseBigDecimal(s.getSettingValue(), DEFAULT_SHIPPING_FEE))
+                .orElse(DEFAULT_SHIPPING_FEE);
+    }
+
+    /** 무료배송 기준 금액을 반환한다. 0이면 무료배송 없음 (항상 유료). */
+    @Cacheable(value = "settings", key = "'" + SHIPPING_FREE_THRESHOLD_KEY + "'")
+    public BigDecimal getShippingFreeThreshold() {
+        return settingRepository.findById(SHIPPING_FREE_THRESHOLD_KEY)
+                .map(s -> parseBigDecimal(s.getSettingValue(), DEFAULT_FREE_THRESHOLD))
+                .orElse(DEFAULT_FREE_THRESHOLD);
+    }
+
+    /**
+     * 주문 금액에 따른 배송비를 계산한다.
+     *
+     * @param orderAmount 상품 합계 금액 (쿠폰·포인트 적용 전)
+     * @return 배송비 (무료배송 기준 충족 시 0)
+     */
+    public BigDecimal calculateShippingFee(BigDecimal orderAmount) {
+        BigDecimal freeThreshold = getShippingFreeThreshold();
+        if (freeThreshold.compareTo(BigDecimal.ZERO) > 0
+                && orderAmount.compareTo(freeThreshold) >= 0) {
+            return BigDecimal.ZERO;
+        }
+        return getShippingDefaultFee();
+    }
+
+    /** 배송비 정책 상세 정보를 반환한다. */
+    public ShippingPolicyResponse getShippingPolicyDetails() {
+        var feeSetting = settingRepository.findById(SHIPPING_DEFAULT_FEE_KEY);
+        var thresholdSetting = settingRepository.findById(SHIPPING_FREE_THRESHOLD_KEY);
+
+        BigDecimal fee = feeSetting.map(s -> parseBigDecimal(s.getSettingValue(), DEFAULT_SHIPPING_FEE))
+                .orElse(DEFAULT_SHIPPING_FEE);
+        BigDecimal threshold = thresholdSetting.map(s -> parseBigDecimal(s.getSettingValue(), DEFAULT_FREE_THRESHOLD))
+                .orElse(DEFAULT_FREE_THRESHOLD);
+
+        // 변경 이력은 가장 최근 변경된 설정 기준
+        String updatedBy = feeSetting.map(s -> s.getUpdatedBy()).orElse(null);
+        var updatedAt = feeSetting.map(s -> s.getUpdatedAt()).orElse(null);
+
+        return ShippingPolicyResponse.of(fee, threshold, updatedBy, updatedAt);
+    }
+
+    /** 배송비 정책을 변경한다. */
+    @Transactional
+    @Caching(evict = {
+            @CacheEvict(value = "settings", key = "'" + SHIPPING_DEFAULT_FEE_KEY + "'"),
+            @CacheEvict(value = "settings", key = "'" + SHIPPING_FREE_THRESHOLD_KEY + "'")
+    })
+    public ShippingPolicyResponse updateShippingPolicy(ShippingPolicyRequest request, String updatedBy) {
+        var feeSetting = settingRepository.findById(SHIPPING_DEFAULT_FEE_KEY)
+                .orElseThrow(() -> new BusinessException(ErrorCode.SETTING_NOT_FOUND));
+        var thresholdSetting = settingRepository.findById(SHIPPING_FREE_THRESHOLD_KEY)
+                .orElseThrow(() -> new BusinessException(ErrorCode.SETTING_NOT_FOUND));
+
+        feeSetting.update(request.defaultFee().toPlainString(), updatedBy);
+        thresholdSetting.update(request.freeShippingThreshold().toPlainString(), updatedBy);
+
+        return ShippingPolicyResponse.of(request.defaultFee(), request.freeShippingThreshold(),
+                updatedBy, feeSetting.getUpdatedAt());
+    }
+
+    private BigDecimal parseBigDecimal(String value, BigDecimal defaultValue) {
+        try {
+            return new BigDecimal(value);
+        } catch (NumberFormatException e) {
+            log.warn("[SystemSetting] BigDecimal 파싱 실패, 기본값 사용: value={}", value);
+            return defaultValue;
+        }
     }
 }

--- a/src/main/java/com/stockmanagement/domain/order/service/OrderQueryService.java
+++ b/src/main/java/com/stockmanagement/domain/order/service/OrderQueryService.java
@@ -18,6 +18,7 @@ import com.stockmanagement.domain.order.repository.OrderDeliverySnapshotReposito
 import com.stockmanagement.domain.order.repository.OrderRepository;
 import com.stockmanagement.domain.order.repository.OrderSpecification;
 import com.stockmanagement.domain.order.repository.OrderStatusHistoryRepository;
+import com.stockmanagement.domain.admin.setting.service.SystemSettingService;
 import com.stockmanagement.domain.point.service.PointService;
 import com.stockmanagement.domain.product.entity.Product;
 import com.stockmanagement.domain.product.entity.ProductStatus;
@@ -57,6 +58,7 @@ public class OrderQueryService {
     private final OrderDeliverySnapshotRepository deliverySnapshotRepository;
     private final CouponService couponService;
     private final PointService pointService;
+    private final SystemSettingService systemSettingService;
 
     /**
      * 주문 단건을 조회한다.
@@ -199,7 +201,7 @@ public class OrderQueryService {
         }
         BigDecimal pointDiscount = BigDecimal.valueOf(usePoints);
 
-        BigDecimal shippingFee = BigDecimal.ZERO;
+        BigDecimal shippingFee = systemSettingService.calculateShippingFee(originalAmount);
         BigDecimal finalAmount = originalAmount.subtract(couponDiscount).subtract(pointDiscount).add(shippingFee);
         if (finalAmount.compareTo(BigDecimal.ZERO) < 0) finalAmount = BigDecimal.ZERO;
 

--- a/src/main/java/com/stockmanagement/domain/shipment/controller/ShippingPolicyController.java
+++ b/src/main/java/com/stockmanagement/domain/shipment/controller/ShippingPolicyController.java
@@ -1,0 +1,31 @@
+package com.stockmanagement.domain.shipment.controller;
+
+import com.stockmanagement.common.dto.ApiResponse;
+import com.stockmanagement.domain.admin.dto.ShippingPolicyResponse;
+import com.stockmanagement.domain.admin.setting.service.SystemSettingService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 배송비 정책 공개 API.
+ *
+ * <p>프론트엔드에서 주문 전 배송비 정보를 표시하기 위해 비로그인 사용자도 조회 가능.
+ */
+@Tag(name = "배송", description = "배송비 정책 조회")
+@RestController
+@RequestMapping("/api/shipping")
+@RequiredArgsConstructor
+public class ShippingPolicyController {
+
+    private final SystemSettingService systemSettingService;
+
+    @Operation(summary = "배송비 정책 조회", description = "기본 배송비, 무료배송 기준 금액을 반환한다.")
+    @GetMapping("/policy")
+    public ApiResponse<ShippingPolicyResponse> getShippingPolicy() {
+        return ApiResponse.ok(systemSettingService.getShippingPolicyDetails());
+    }
+}

--- a/src/main/resources/db/migration/V49__insert_shipping_policy_settings.sql
+++ b/src/main/resources/db/migration/V49__insert_shipping_policy_settings.sql
@@ -1,0 +1,6 @@
+-- 배송비 정책 시스템 설정 (기본: 3,000원, 50,000원 이상 무료배송)
+INSERT INTO system_settings (setting_key, setting_value, description, updated_by, updated_at)
+VALUES ('shipping_default_fee', '3000', '기본 배송비 (원)', 'SYSTEM', NOW());
+
+INSERT INTO system_settings (setting_key, setting_value, description, updated_by, updated_at)
+VALUES ('shipping_free_threshold', '50000', '무료배송 기준 금액 (원). 0이면 항상 유료.', 'SYSTEM', NOW());

--- a/src/test/java/com/stockmanagement/domain/admin/controller/AdminControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/admin/controller/AdminControllerTest.java
@@ -5,6 +5,7 @@ import com.stockmanagement.common.security.JwtBlacklist;
 import com.stockmanagement.domain.user.service.UserService;
 import com.stockmanagement.domain.admin.dto.AdminOrderResponse;
 import com.stockmanagement.domain.admin.dto.DashboardResponse;
+import com.stockmanagement.domain.admin.dto.ShippingPolicyResponse;
 import com.stockmanagement.domain.admin.service.AdminService;
 import com.stockmanagement.domain.admin.setting.service.SystemSettingService;
 import com.stockmanagement.domain.inventory.dto.DailyInventorySnapshotResponse;
@@ -25,6 +26,8 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -198,6 +201,65 @@ class AdminControllerTest {
                             .param("date", "2025-01-01"))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true));
+        }
+    }
+
+    // ===== 배송비 정책 =====
+
+    @Nested
+    @DisplayName("GET /api/admin/settings/shipping-policy")
+    class GetShippingPolicy {
+
+        @Test
+        @WithMockUser(roles = "ADMIN")
+        @DisplayName("ADMIN — 배송비 정책 조회 → 200")
+        void adminGetsShippingPolicy() throws Exception {
+            given(systemSettingService.getShippingPolicyDetails())
+                    .willReturn(new ShippingPolicyResponse(
+                            new BigDecimal("3000"), new BigDecimal("50000"), "admin", LocalDateTime.now()));
+
+            mockMvc.perform(get("/api/admin/settings/shipping-policy"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.defaultFee").value(3000));
+        }
+
+        @Test
+        @WithMockUser(roles = "USER")
+        @DisplayName("USER — 배송비 정책 조회 → 403")
+        void userForbidden() throws Exception {
+            mockMvc.perform(get("/api/admin/settings/shipping-policy"))
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /api/admin/settings/shipping-policy")
+    class UpdateShippingPolicy {
+
+        @Test
+        @WithMockUser(roles = "ADMIN")
+        @DisplayName("ADMIN — 배송비 정책 변경 → 200")
+        void adminUpdatesShippingPolicy() throws Exception {
+            given(systemSettingService.updateShippingPolicy(any(), any()))
+                    .willReturn(new ShippingPolicyResponse(
+                            new BigDecimal("2500"), new BigDecimal("30000"), "admin", LocalDateTime.now()));
+
+            mockMvc.perform(put("/api/admin/settings/shipping-policy")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"defaultFee\":2500,\"freeShippingThreshold\":30000}"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.defaultFee").value(2500));
+        }
+
+        @Test
+        @WithMockUser(roles = "USER")
+        @DisplayName("USER — 배송비 정책 변경 → 403")
+        void userForbidden() throws Exception {
+            mockMvc.perform(put("/api/admin/settings/shipping-policy")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"defaultFee\":2500,\"freeShippingThreshold\":30000}"))
+                    .andExpect(status().isForbidden());
         }
     }
 }

--- a/src/test/java/com/stockmanagement/domain/admin/setting/service/SystemSettingServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/admin/setting/service/SystemSettingServiceTest.java
@@ -1,0 +1,140 @@
+package com.stockmanagement.domain.admin.setting.service;
+
+import com.stockmanagement.common.exception.BusinessException;
+import com.stockmanagement.domain.admin.dto.ShippingPolicyRequest;
+import com.stockmanagement.domain.admin.dto.ShippingPolicyResponse;
+import com.stockmanagement.domain.admin.setting.repository.SystemSettingRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SystemSettingService 단위 테스트")
+class SystemSettingServiceTest {
+
+    @Mock
+    private SystemSettingRepository settingRepository;
+
+    @InjectMocks
+    private SystemSettingService systemSettingService;
+
+    private com.stockmanagement.domain.admin.setting.entity.SystemSetting createSetting(String key, String value) {
+        try {
+            var clazz = com.stockmanagement.domain.admin.setting.entity.SystemSetting.class;
+            var ctor = clazz.getDeclaredConstructor();
+            ctor.setAccessible(true);
+            var setting = ctor.newInstance();
+            var keyField = clazz.getDeclaredField("settingKey");
+            keyField.setAccessible(true);
+            keyField.set(setting, key);
+            var valField = clazz.getDeclaredField("settingValue");
+            valField.setAccessible(true);
+            valField.set(setting, value);
+            var byField = clazz.getDeclaredField("updatedBy");
+            byField.setAccessible(true);
+            byField.set(setting, "admin");
+            var atField = clazz.getDeclaredField("updatedAt");
+            atField.setAccessible(true);
+            atField.set(setting, LocalDateTime.now());
+            return setting;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Nested
+    @DisplayName("getShippingDefaultFee()")
+    class GetShippingDefaultFee {
+
+        @Test
+        @DisplayName("DB 값이 있으면 해당 값을 반환한다")
+        void returnsDbValue() {
+            given(settingRepository.findById("shipping_default_fee"))
+                    .willReturn(Optional.of(createSetting("shipping_default_fee", "5000")));
+
+            BigDecimal fee = systemSettingService.getShippingDefaultFee();
+
+            assertThat(fee).isEqualByComparingTo("5000");
+        }
+
+        @Test
+        @DisplayName("DB 값이 없으면 기본값 3000을 반환한다")
+        void returnsDefault() {
+            given(settingRepository.findById("shipping_default_fee"))
+                    .willReturn(Optional.empty());
+
+            BigDecimal fee = systemSettingService.getShippingDefaultFee();
+
+            assertThat(fee).isEqualByComparingTo("3000");
+        }
+    }
+
+    @Nested
+    @DisplayName("calculateShippingFee()")
+    class CalculateShippingFee {
+
+        @Test
+        @DisplayName("주문 금액이 무료배송 기준 이상이면 0을 반환한다")
+        void freeShippingWhenAboveThreshold() {
+            given(settingRepository.findById("shipping_free_threshold"))
+                    .willReturn(Optional.of(createSetting("shipping_free_threshold", "50000")));
+
+            BigDecimal fee = systemSettingService.calculateShippingFee(new BigDecimal("50000"));
+
+            assertThat(fee).isEqualByComparingTo("0");
+        }
+
+        @Test
+        @DisplayName("주문 금액이 무료배송 기준 미만이면 기본 배송비를 반환한다")
+        void chargesWhenBelowThreshold() {
+            given(settingRepository.findById("shipping_free_threshold"))
+                    .willReturn(Optional.of(createSetting("shipping_free_threshold", "50000")));
+            given(settingRepository.findById("shipping_default_fee"))
+                    .willReturn(Optional.of(createSetting("shipping_default_fee", "3000")));
+
+            BigDecimal fee = systemSettingService.calculateShippingFee(new BigDecimal("30000"));
+
+            assertThat(fee).isEqualByComparingTo("3000");
+        }
+    }
+
+    @Nested
+    @DisplayName("updateShippingPolicy()")
+    class UpdateShippingPolicy {
+
+        @Test
+        @DisplayName("배송비 정책을 변경한다")
+        void updatesPolicy() {
+            var feeSetting = createSetting("shipping_default_fee", "3000");
+            var thresholdSetting = createSetting("shipping_free_threshold", "50000");
+            given(settingRepository.findById("shipping_default_fee")).willReturn(Optional.of(feeSetting));
+            given(settingRepository.findById("shipping_free_threshold")).willReturn(Optional.of(thresholdSetting));
+
+            ShippingPolicyResponse response = systemSettingService.updateShippingPolicy(
+                    new ShippingPolicyRequest(new BigDecimal("2500"), new BigDecimal("30000")), "admin");
+
+            assertThat(response.defaultFee()).isEqualByComparingTo("2500");
+            assertThat(response.freeShippingThreshold()).isEqualByComparingTo("30000");
+        }
+
+        @Test
+        @DisplayName("설정이 없으면 SETTING_NOT_FOUND 예외를 발생시킨다")
+        void throwsWhenNotFound() {
+            given(settingRepository.findById("shipping_default_fee")).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> systemSettingService.updateShippingPolicy(
+                    new ShippingPolicyRequest(new BigDecimal("2500"), new BigDecimal("30000")), "admin"))
+                    .isInstanceOf(BusinessException.class);
+        }
+    }
+}

--- a/src/test/java/com/stockmanagement/domain/order/service/OrderQueryServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/order/service/OrderQueryServiceTest.java
@@ -2,6 +2,7 @@ package com.stockmanagement.domain.order.service;
 
 import com.stockmanagement.common.exception.BusinessException;
 import com.stockmanagement.common.exception.ErrorCode;
+import com.stockmanagement.domain.admin.setting.service.SystemSettingService;
 import com.stockmanagement.domain.coupon.service.CouponService;
 import com.stockmanagement.domain.order.dto.OrderResponse;
 import com.stockmanagement.domain.order.dto.OrderSearchRequest;
@@ -62,6 +63,9 @@ class OrderQueryServiceTest {
 
     @Mock
     private PointService pointService;
+
+    @Mock
+    private SystemSettingService systemSettingService;
 
     @InjectMocks
     private OrderQueryService orderQueryService;

--- a/src/test/java/com/stockmanagement/domain/shipment/controller/ShippingPolicyControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/shipment/controller/ShippingPolicyControllerTest.java
@@ -1,0 +1,50 @@
+package com.stockmanagement.domain.shipment.controller;
+
+import com.stockmanagement.common.config.SecurityConfig;
+import com.stockmanagement.common.security.JwtBlacklist;
+import com.stockmanagement.common.security.JwtTokenProvider;
+import com.stockmanagement.domain.admin.dto.ShippingPolicyResponse;
+import com.stockmanagement.domain.admin.setting.service.SystemSettingService;
+import com.stockmanagement.domain.user.service.UserService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(ShippingPolicyController.class)
+@Import(SecurityConfig.class)
+@DisplayName("ShippingPolicyController 단위 테스트")
+class ShippingPolicyControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean private SystemSettingService systemSettingService;
+    @MockBean private JwtTokenProvider jwtTokenProvider;
+    @MockBean private JwtBlacklist jwtBlacklist;
+    @MockBean private UserService userService;
+
+    @Test
+    @DisplayName("비로그인 — 배송비 정책 조회 → 200")
+    void publicAccessReturnsPolicy() throws Exception {
+        given(systemSettingService.getShippingPolicyDetails())
+                .willReturn(new ShippingPolicyResponse(
+                        new BigDecimal("3000"), new BigDecimal("50000"), "SYSTEM", LocalDateTime.now()));
+
+        mockMvc.perform(get("/api/shipping/policy"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.defaultFee").value(3000))
+                .andExpect(jsonPath("$.data.freeShippingThreshold").value(50000));
+    }
+}


### PR DESCRIPTION
## Summary
- `GET /api/shipping/policy` (공개): 기본 배송비, 무료배송 기준 금액 조회
- `GET/PUT /api/admin/settings/shipping-policy` (ADMIN): 배송비 정책 관리
- `OrderQueryService.preview()`에서 실제 배송비 반영 (기존 하드코딩 0 → 정책 기반)
- V49 마이그레이션: 초기 설정 (기본 3,000원, 50,000원 이상 무료배송)

## Test plan
- [x] SystemSettingServiceTest — 배송비 조회/계산/변경 단위 테스트 (5개)
- [x] AdminControllerTest — ADMIN 배송비 정책 조회/변경 + 권한 검증 (4개)
- [x] ShippingPolicyControllerTest — 공개 API 비로그인 접근 테스트 (1개)
- [x] 전체 699개 테스트 통과

Closes #133