### PR TITLE
feat: 검색 자동완성 API (#118)

### DIFF
--- a/src/main/java/com/stockmanagement/domain/product/controller/ProductController.java
+++ b/src/main/java/com/stockmanagement/domain/product/controller/ProductController.java
@@ -7,11 +7,13 @@ import com.stockmanagement.domain.product.dto.ProductResponse;
 import com.stockmanagement.domain.product.dto.ProductSearchRequest;
 import com.stockmanagement.domain.product.dto.ProductStatusRequest;
 import com.stockmanagement.domain.product.dto.ProductUpdateRequest;
+import com.stockmanagement.domain.product.dto.SuggestResponse;
 import com.stockmanagement.domain.product.service.ProductService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import jakarta.validation.constraints.Size;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -57,6 +59,13 @@ public class ProductController {
             @PageableDefault(size = 20, sort = "id") Pageable pageable,
             @CurrentUserId(required = false) Long userId) {
         return ApiResponse.ok(productService.getList(pageable, request, userId));
+    }
+
+    @Operation(summary = "검색 자동완성", description = "검색어 prefix로 상품명 자동완성 후보를 반환한다. 최대 10건.")
+    @GetMapping("/search/suggestions")
+    public ApiResponse<SuggestResponse> suggest(
+            @RequestParam @Size(min = 1, max = 200, message = "검색어는 1~200자여야 합니다.") String q) {
+        return ApiResponse.ok(new SuggestResponse(productService.suggest(q, 10)));
     }
 
     @Operation(summary = "상품 수정", description = "ADMIN 전용.")

--- a/src/main/java/com/stockmanagement/domain/product/dto/SuggestResponse.java
+++ b/src/main/java/com/stockmanagement/domain/product/dto/SuggestResponse.java
@@ -1,0 +1,7 @@
+package com.stockmanagement.domain.product.dto;
+
+import java.util.List;
+
+/** 검색 자동완성 응답 DTO. */
+public record SuggestResponse(List<String> suggestions) {
+}

--- a/src/main/java/com/stockmanagement/domain/product/service/ProductSearchService.java
+++ b/src/main/java/com/stockmanagement/domain/product/service/ProductSearchService.java
@@ -21,7 +21,9 @@ import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Elasticsearch 기반 상품 검색 서비스.
@@ -126,6 +128,39 @@ public class ProductSearchService {
     public void deleteFromIndex(Long productId) {
         productSearchRepository.deleteById(String.valueOf(productId));
         log.debug("ES 색인 삭제 완료. productId={}", productId);
+    }
+
+    /**
+     * 검색어 prefix로 상품명 자동완성 후보를 반환한다.
+     *
+     * <p>match_phrase_prefix 쿼리를 사용하여 nori_analyzer 기반으로 검색한다.
+     * ACTIVE 상태 상품만 대상이며, 중복 제거 후 최대 size개를 반환한다.
+     *
+     * @param prefix 검색 접두사
+     * @param size   최대 반환 개수
+     * @return 상품명 리스트
+     */
+    public List<String> suggest(String prefix, int size) {
+        BoolQuery.Builder boolQuery = new BoolQuery.Builder();
+        boolQuery.filter(f -> f.term(t -> t.field("status").value("ACTIVE")));
+        boolQuery.must(m -> m.matchPhrasePrefix(mpp -> mpp
+                .field("name")
+                .query(prefix)
+        ));
+
+        NativeQuery query = NativeQuery.builder()
+                .withQuery(q -> q.bool(boolQuery.build()))
+                .withPageable(PageRequest.of(0, size * 2))
+                .build();
+
+        SearchHits<ProductDocument> hits = elasticsearchOperations.search(query, ProductDocument.class);
+
+        Set<String> seen = new LinkedHashSet<>();
+        for (var hit : hits) {
+            seen.add(hit.getContent().getName());
+            if (seen.size() >= size) break;
+        }
+        return new ArrayList<>(seen);
     }
 
     // ===== 내부 헬퍼 =====

--- a/src/main/java/com/stockmanagement/domain/product/service/ProductService.java
+++ b/src/main/java/com/stockmanagement/domain/product/service/ProductService.java
@@ -166,6 +166,19 @@ public class ProductService {
         return PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort);
     }
 
+    /**
+     * 검색어 prefix로 상품명 자동완성 후보를 반환한다.
+     * ES 장애 시 빈 리스트를 반환한다.
+     */
+    public List<String> suggest(String prefix, int size) {
+        try {
+            return productSearchService.suggest(prefix, size);
+        } catch (Exception e) {
+            log.warn("검색 자동완성 실패 (ES 오류). prefix={}", prefix, e);
+            return List.of();
+        }
+    }
+
     /** 전체 상품 페이징 조회 (ACTIVE + DISCONTINUED, 관리자 전용). search가 있으면 상품명/SKU로 필터링 */
     public Page<ProductResponse> getListAll(Pageable pageable, String search) {
         Page<Product> products = (search != null && !search.isBlank())

--- a/src/test/java/com/stockmanagement/domain/product/controller/ProductControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/product/controller/ProductControllerTest.java
@@ -219,4 +219,31 @@ class ProductControllerTest {
                     .andExpect(status().isForbidden());
         }
     }
+
+    // ===== GET /api/products/search/suggestions =====
+
+    @Nested
+    @DisplayName("GET /api/products/search/suggestions")
+    class Suggest {
+
+        @Test
+        @DisplayName("비로그인 — 자동완성 조회 → 200")
+        void suggestWithoutAuth() throws Exception {
+            given(productService.suggest(eq("노트"), eq(10)))
+                    .willReturn(List.of("노트북", "노트북 Pro"));
+
+            mockMvc.perform(get("/api/products/search/suggestions").param("q", "노트"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.suggestions[0]").value("노트북"))
+                    .andExpect(jsonPath("$.data.suggestions[1]").value("노트북 Pro"));
+        }
+
+        @Test
+        @DisplayName("검색어 없음 → 400")
+        void suggestWithoutQuery() throws Exception {
+            mockMvc.perform(get("/api/products/search/suggestions"))
+                    .andExpect(status().isBadRequest());
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- `GET /api/products/search/suggestions?q=노트` → `{ suggestions: ["노트북", "노트북 Pro", ...] }`
- ES `match_phrase_prefix` + nori_analyzer로 한국어 형태소 기반 자동완성
- ACTIVE 상태 상품만 대상, 최대 10건, 중복 제거
- ES 장애 시 빈 리스트 반환 (graceful degradation)

## Test plan
- [x] ProductControllerTest — 비로그인 자동완성 조회 + 검색어 누락 400 (2개)
- [x] 전체 테스트 통과

Closes #118