### PR TITLE
perf: 관리자 대시보드 Redis 캐시 적용 (#62)

### DIFF
--- a/src/main/java/com/stockmanagement/common/config/CacheConfig.java
+++ b/src/main/java/com/stockmanagement/common/config/CacheConfig.java
@@ -77,7 +77,9 @@ public class CacheConfig {
                         // 홈 화면 집계: 5분 TTL — 신상품/인기상품/카테고리 통합
                         "home", base.entryTtl(Duration.ofMinutes(5)),
                         // 시스템 설정: 변경 빈도 매우 낮음 → 1시간 + 명시적 evict
-                        "settings", base.entryTtl(Duration.ofHours(1))
+                        "settings", base.entryTtl(Duration.ofHours(1)),
+                        // 관리자 대시보드: GROUP BY 집계 부하 감소 → 5분 TTL
+                        "dashboard", base.entryTtl(Duration.ofMinutes(5))
                 ))
                 .build();
     }

--- a/src/main/java/com/stockmanagement/domain/admin/service/AdminService.java
+++ b/src/main/java/com/stockmanagement/domain/admin/service/AdminService.java
@@ -23,6 +23,7 @@ import com.stockmanagement.domain.user.entity.User;
 import com.stockmanagement.domain.user.entity.UserRole;
 import com.stockmanagement.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -53,7 +54,9 @@ public class AdminService {
      *
      * <p>기존 6개 쿼리(상태별 count×4 + sum×1 + userCount×1)를 2개로 줄인다.
      * {@code findOrderStats()}의 GROUP BY 결과로 주문 관련 5개 쿼리를 대체한다.
+     * Redis 캐시(5분 TTL)로 반복 조회 부하를 줄인다.
      */
+    @Cacheable("dashboard")
     public DashboardResponse getDashboard() {
         // 쿼리 1: 상태별 주문 수·금액 일괄 집계
         Map<OrderStatus, OrderStatsProjection> statsMap = orderRepository.findOrderStats()


### PR DESCRIPTION
## Summary
- `AdminService.getDashboard()`에 `@Cacheable("dashboard")` 적용 (5분 TTL)
- GROUP BY 집계 쿼리 반복 호출 부하를 Redis 캐시로 감소

## Test plan
- [x] admin 관련 테스트 통과 확인

Closes #62