### PR TITLE
feat: 재고 수량 노출 정책 - StockStatus enum 도입 (#135)

### DIFF
--- a/src/main/java/com/stockmanagement/domain/inventory/entity/StockStatus.java
+++ b/src/main/java/com/stockmanagement/domain/inventory/entity/StockStatus.java
@@ -1,0 +1,28 @@
+package com.stockmanagement.domain.inventory.entity;
+
+/**
+ * 재고 수량 노출 정책용 enum.
+ *
+ * <p>경쟁사에 정확한 재고 수량을 노출하지 않기 위해
+ * 단계별 상태로 변환하여 공개 API에서 사용한다.
+ */
+public enum StockStatus {
+    /** 충분한 재고 (임계값 초과) */
+    IN_STOCK,
+    /** 저재고 (1 이상 ~ 임계값 이하) */
+    LOW_STOCK,
+    /** 품절 (0 이하) */
+    OUT_OF_STOCK;
+
+    /**
+     * 가용 재고 수량과 저재고 임계값으로 StockStatus를 결정한다.
+     *
+     * @param available          가용 재고 수량
+     * @param lowStockThreshold  저재고 임계값 (SystemSetting에서 조회)
+     */
+    public static StockStatus of(int available, int lowStockThreshold) {
+        if (available <= 0) return OUT_OF_STOCK;
+        if (available <= lowStockThreshold) return LOW_STOCK;
+        return IN_STOCK;
+    }
+}

--- a/src/main/java/com/stockmanagement/domain/order/cart/dto/CartItemResponse.java
+++ b/src/main/java/com/stockmanagement/domain/order/cart/dto/CartItemResponse.java
@@ -1,5 +1,6 @@
 package com.stockmanagement.domain.order.cart.dto;
 
+import com.stockmanagement.domain.inventory.entity.StockStatus;
 import com.stockmanagement.domain.order.cart.entity.CartItem;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,8 +20,8 @@ public class CartItemResponse {
 
     /** 상품 대표 이미지 URL — null이면 이미지 없음 */
     private String thumbnailUrl;
-    /** 현재 가용 재고 수량 — null이면 재고 정보 미포함 */
-    private Integer availableQuantity;
+    /** 재고 상태 (IN_STOCK / LOW_STOCK / OUT_OF_STOCK) — null이면 재고 정보 미포함 */
+    private StockStatus stockStatus;
     /** 담은 수량만큼 구매 가능한지 여부 — null이면 재고 정보 미포함 */
     private Boolean isAvailable;
     /** 장바구니 담은 시점의 단가 — null이면 기록 없음 (이전 데이터) */
@@ -29,10 +30,10 @@ public class CartItemResponse {
     private Boolean priceChanged;
 
     public static CartItemResponse from(CartItem item) {
-        return from(item, null);
+        return from(item, null, null);
     }
 
-    public static CartItemResponse from(CartItem item, Integer availableQuantity) {
+    public static CartItemResponse from(CartItem item, Integer availableQuantity, StockStatus stockStatus) {
         BigDecimal unitPrice = item.getProduct().getPrice();
         BigDecimal savedPrice = item.getSavedPrice();
         Boolean priceChanged = savedPrice != null ? savedPrice.compareTo(unitPrice) != 0 : null;
@@ -43,7 +44,7 @@ public class CartItemResponse {
                 .unitPrice(unitPrice)
                 .quantity(item.getQuantity())
                 .subtotal(unitPrice.multiply(BigDecimal.valueOf(item.getQuantity())))
-                .availableQuantity(availableQuantity)
+                .stockStatus(stockStatus)
                 .isAvailable(availableQuantity != null ? availableQuantity >= item.getQuantity() : null)
                 .savedPrice(savedPrice)
                 .priceChanged(priceChanged)

--- a/src/main/java/com/stockmanagement/domain/order/cart/dto/CartResponse.java
+++ b/src/main/java/com/stockmanagement/domain/order/cart/dto/CartResponse.java
@@ -1,5 +1,6 @@
 package com.stockmanagement.domain.order.cart.dto;
 
+import com.stockmanagement.domain.inventory.entity.StockStatus;
 import com.stockmanagement.domain.order.cart.entity.CartItem;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,14 +19,19 @@ public class CartResponse {
     private BigDecimal totalAmount;
 
     public static CartResponse from(Long userId, List<CartItem> cartItems) {
-        return from(userId, cartItems, null);
+        return from(userId, cartItems, null, null);
     }
 
     public static CartResponse from(Long userId, List<CartItem> cartItems,
-                                    Map<Long, Integer> availabilityMap) {
+                                    Map<Long, Integer> availabilityMap,
+                                    Map<Long, StockStatus> stockStatusMap) {
         List<CartItemResponse> itemResponses = cartItems.stream()
-                .map(i -> CartItemResponse.from(i,
-                        availabilityMap != null ? availabilityMap.get(i.getProduct().getId()) : null))
+                .map(i -> {
+                    Long productId = i.getProduct().getId();
+                    return CartItemResponse.from(i,
+                            availabilityMap != null ? availabilityMap.get(productId) : null,
+                            stockStatusMap != null ? stockStatusMap.get(productId) : null);
+                })
                 .toList();
         BigDecimal total = itemResponses.stream()
                 .map(CartItemResponse::getSubtotal)

--- a/src/main/java/com/stockmanagement/domain/order/cart/service/CartService.java
+++ b/src/main/java/com/stockmanagement/domain/order/cart/service/CartService.java
@@ -2,6 +2,7 @@ package com.stockmanagement.domain.order.cart.service;
 
 import com.stockmanagement.common.exception.BusinessException;
 import com.stockmanagement.common.exception.ErrorCode;
+import com.stockmanagement.domain.admin.setting.service.SystemSettingService;
 import com.stockmanagement.domain.order.cart.dto.CartCheckoutRequest;
 import com.stockmanagement.domain.order.cart.dto.CartItemRequest;
 import com.stockmanagement.domain.order.cart.dto.CartItemResponse;
@@ -13,6 +14,7 @@ import com.stockmanagement.domain.order.dto.OrderItemRequest;
 import com.stockmanagement.domain.order.dto.OrderResponse;
 import com.stockmanagement.domain.order.service.OrderCommandService;
 import com.stockmanagement.domain.inventory.entity.Inventory;
+import com.stockmanagement.domain.inventory.entity.StockStatus;
 import com.stockmanagement.domain.inventory.repository.InventoryRepository;
 import com.stockmanagement.domain.product.entity.Product;
 import com.stockmanagement.domain.product.entity.ProductStatus;
@@ -49,17 +51,21 @@ public class CartService {
     private final ProductRepository productRepository;
     private final InventoryRepository inventoryRepository;
     private final OrderCommandService orderCommandService;
+    private final SystemSettingService systemSettingService;
 
     /** 사용자의 장바구니 전체를 재고 상태 포함하여 조회한다. */
     public CartResponse getCart(Long userId) {
         List<CartItem> items = cartRepository.findByUserId(userId);
         if (items.isEmpty()) {
-            return CartResponse.from(userId, items, null);
+            return CartResponse.from(userId, items);
         }
+        int threshold = systemSettingService.getLowStockThreshold();
         List<Long> productIds = items.stream().map(i -> i.getProduct().getId()).toList();
         Map<Long, Integer> availabilityMap = inventoryRepository.findAllByProductIdIn(productIds).stream()
                 .collect(Collectors.toMap(inv -> inv.getProduct().getId(), Inventory::getAvailable));
-        return CartResponse.from(userId, items, availabilityMap);
+        Map<Long, StockStatus> stockStatusMap = availabilityMap.entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> StockStatus.of(e.getValue(), threshold)));
+        return CartResponse.from(userId, items, availabilityMap, stockStatusMap);
     }
 
     /**
@@ -106,7 +112,9 @@ public class CartService {
         Integer available = inventoryRepository.findByProductId(product.getId())
                 .map(Inventory::getAvailable)
                 .orElse(null);
-        return CartItemResponse.from(cartItem, available);
+        StockStatus stockStatus = available != null
+                ? StockStatus.of(available, systemSettingService.getLowStockThreshold()) : null;
+        return CartItemResponse.from(cartItem, available, stockStatus);
     }
 
     /**

--- a/src/main/java/com/stockmanagement/domain/product/dto/ProductResponse.java
+++ b/src/main/java/com/stockmanagement/domain/product/dto/ProductResponse.java
@@ -1,5 +1,6 @@
 package com.stockmanagement.domain.product.dto;
 
+import com.stockmanagement.domain.inventory.entity.StockStatus;
 import com.stockmanagement.domain.product.entity.Product;
 import com.stockmanagement.domain.product.entity.ProductStatus;
 import com.stockmanagement.domain.product.image.dto.ProductImageResponse;
@@ -40,8 +41,10 @@ public class ProductResponse {
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
 
-    /** 현재 가용 재고 수량 — null이면 재고 정보 미포함 */
+    /** 현재 가용 재고 수량 — 공개 목록에서는 null (관리자·상세 전용) */
     private final Integer availableQuantity;
+    /** 재고 상태 (IN_STOCK / LOW_STOCK / OUT_OF_STOCK) — null이면 재고 정보 미포함 */
+    private final StockStatus stockStatus;
     /** 상품 평균 별점 (0.0~5.0) — null이면 리뷰 없음 */
     private final Double avgRating;
     /** 총 리뷰 수 — null이면 리뷰 정보 미포함 */
@@ -62,31 +65,31 @@ public class ProductResponse {
 
     /** Product 엔티티만으로 변환 (재고·리뷰 통계 미포함). */
     public static ProductResponse from(Product product) {
-        return from(product, null, null, null, null, null, null);
+        return from(product, null, null, null, null, null, null, null);
     }
 
     /** Product 엔티티 + 재고·리뷰 통계를 포함한 전체 응답으로 변환 (이미지 미포함). */
-    public static ProductResponse from(Product product, Integer availableQuantity,
+    public static ProductResponse from(Product product, Integer availableQuantity, StockStatus stockStatus,
                                        Double avgRating, Long reviewCount) {
-        return from(product, availableQuantity, avgRating, reviewCount, null, null, null);
+        return from(product, availableQuantity, stockStatus, avgRating, reviewCount, null, null, null);
     }
 
     /** Product 엔티티 + 재고·리뷰 통계 + 이미지 목록을 포함한 전체 응답으로 변환. */
-    public static ProductResponse from(Product product, Integer availableQuantity,
+    public static ProductResponse from(Product product, Integer availableQuantity, StockStatus stockStatus,
                                        Double avgRating, Long reviewCount,
                                        List<ProductImageResponse> images) {
-        return from(product, availableQuantity, avgRating, reviewCount, images, null, null);
+        return from(product, availableQuantity, stockStatus, avgRating, reviewCount, images, null, null);
     }
 
     /** Product 엔티티 + 재고·리뷰 통계 + 이미지 + canReview를 포함한 전체 응답으로 변환. */
-    public static ProductResponse from(Product product, Integer availableQuantity,
+    public static ProductResponse from(Product product, Integer availableQuantity, StockStatus stockStatus,
                                        Double avgRating, Long reviewCount,
                                        List<ProductImageResponse> images, Boolean canReview) {
-        return from(product, availableQuantity, avgRating, reviewCount, images, canReview, null);
+        return from(product, availableQuantity, stockStatus, avgRating, reviewCount, images, canReview, null);
     }
 
     /** Product 엔티티 + 전체 필드(재고·리뷰·이미지·canReview·wishlisted)를 포함한 응답으로 변환. */
-    public static ProductResponse from(Product product, Integer availableQuantity,
+    public static ProductResponse from(Product product, Integer availableQuantity, StockStatus stockStatus,
                                        Double avgRating, Long reviewCount,
                                        List<ProductImageResponse> images, Boolean canReview,
                                        Boolean wishlisted) {
@@ -103,6 +106,7 @@ public class ProductResponse {
                 .createdAt(product.getCreatedAt())
                 .updatedAt(product.getUpdatedAt())
                 .availableQuantity(availableQuantity)
+                .stockStatus(stockStatus)
                 .avgRating(avgRating != null ? Math.round(avgRating * 10.0) / 10.0 : null)
                 .reviewCount(reviewCount)
                 .images(images)

--- a/src/main/java/com/stockmanagement/domain/product/service/HomeService.java
+++ b/src/main/java/com/stockmanagement/domain/product/service/HomeService.java
@@ -1,6 +1,8 @@
 package com.stockmanagement.domain.product.service;
 
+import com.stockmanagement.domain.admin.setting.service.SystemSettingService;
 import com.stockmanagement.domain.inventory.entity.Inventory;
+import com.stockmanagement.domain.inventory.entity.StockStatus;
 import com.stockmanagement.domain.inventory.repository.InventoryRepository;
 import com.stockmanagement.domain.product.category.dto.CategoryResponse;
 import com.stockmanagement.domain.product.category.service.CategoryService;
@@ -41,6 +43,7 @@ public class HomeService {
     private final InventoryRepository inventoryRepository;
     private final ReviewRepository reviewRepository;
     private final CategoryService categoryService;
+    private final SystemSettingService systemSettingService;
 
     @Cacheable(cacheNames = "home", key = "'screen'")
     public HomeResponse getHomeScreen() {
@@ -94,12 +97,14 @@ public class HomeService {
             List<Product> products,
             Map<Long, ReviewStatsProjection> reviewStatsMap,
             Map<Long, Integer> inventoryMap) {
+        int threshold = systemSettingService.getLowStockThreshold();
         return products.stream().map(p -> {
             ReviewStatsProjection stats = reviewStatsMap.get(p.getId());
             Double avgRating = stats != null ? stats.getAvgRating() : null;
             Long reviewCount = stats != null ? stats.getReviewCount() : null;
-            Integer available = inventoryMap.get(p.getId());
-            return ProductResponse.from(p, available, avgRating, reviewCount);
+            int available = inventoryMap.getOrDefault(p.getId(), 0);
+            StockStatus stockStatus = StockStatus.of(available, threshold);
+            return ProductResponse.from(p, null, stockStatus, avgRating, reviewCount);
         }).collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/stockmanagement/domain/product/service/ProductService.java
+++ b/src/main/java/com/stockmanagement/domain/product/service/ProductService.java
@@ -2,7 +2,9 @@ package com.stockmanagement.domain.product.service;
 
 import com.stockmanagement.common.exception.BusinessException;
 import com.stockmanagement.common.exception.ErrorCode;
+import com.stockmanagement.domain.admin.setting.service.SystemSettingService;
 import com.stockmanagement.domain.inventory.entity.Inventory;
+import com.stockmanagement.domain.inventory.entity.StockStatus;
 import com.stockmanagement.domain.inventory.repository.InventoryRepository;
 import com.stockmanagement.domain.order.repository.OrderRepository;
 import com.stockmanagement.domain.product.category.entity.Category;
@@ -64,6 +66,7 @@ public class ProductService {
     private final ApplicationEventPublisher eventPublisher;
     private final OrderRepository orderRepository;
     private final WishlistRepository wishlistRepository;
+    private final SystemSettingService systemSettingService;
 
     /**
      * 상품을 등록한다.
@@ -104,13 +107,14 @@ public class ProductService {
         Product product = findById(id);
         Integer available = inventoryRepository.findByProductId(id)
                 .map(Inventory::getAvailable).orElse(0);
+        StockStatus stockStatus = StockStatus.of(available, systemSettingService.getLowStockThreshold());
         ReviewStatsProjection stats = reviewRepository.findReviewStatsByProductId(id).orElse(null);
         List<ProductImageResponse> images = productImageRepository
                 .findByProductIdOrderByDisplayOrderAsc(id).stream()
                 .map(ProductImageResponse::from).toList();
         boolean purchased = orderRepository.existsPurchaseByUserIdAndProductId(userId, id);
         boolean reviewed = reviewRepository.existsByProductIdAndUserId(id, userId);
-        return ProductResponse.from(product, available,
+        return ProductResponse.from(product, null, stockStatus,
                 stats != null ? stats.getAvgRating() : null,
                 stats != null ? stats.getReviewCount() : 0L,
                 images, purchased && !reviewed);
@@ -244,9 +248,10 @@ public class ProductService {
         Integer available = inventoryRepository.findByProductId(product.getId())
                 .map(Inventory::getAvailable)
                 .orElse(0);
+        StockStatus stockStatus = StockStatus.of(available, systemSettingService.getLowStockThreshold());
         ReviewStatsProjection stats = reviewRepository
                 .findReviewStatsByProductId(product.getId()).orElse(null);
-        return ProductResponse.from(product, available,
+        return ProductResponse.from(product, available, stockStatus,
                 stats != null ? stats.getAvgRating() : null,
                 stats != null ? stats.getReviewCount() : 0L);
     }
@@ -260,13 +265,14 @@ public class ProductService {
         Integer available = inventoryRepository.findByProductId(product.getId())
                 .map(Inventory::getAvailable)
                 .orElse(0);
+        StockStatus stockStatus = StockStatus.of(available, systemSettingService.getLowStockThreshold());
         ReviewStatsProjection stats = reviewRepository
                 .findReviewStatsByProductId(product.getId()).orElse(null);
         List<ProductImageResponse> images = productImageRepository
                 .findByProductIdOrderByDisplayOrderAsc(product.getId()).stream()
                 .map(ProductImageResponse::from)
                 .toList();
-        return ProductResponse.from(product, available,
+        return ProductResponse.from(product, available, stockStatus,
                 stats != null ? stats.getAvgRating() : null,
                 stats != null ? stats.getReviewCount() : 0L,
                 images);
@@ -280,6 +286,7 @@ public class ProductService {
         if (products.isEmpty()) return products.map(ProductResponse::from);
 
         List<Long> ids = products.stream().map(Product::getId).toList();
+        int threshold = systemSettingService.getLowStockThreshold();
 
         Map<Long, Integer> availableMap = inventoryRepository.findAllByProductIdIn(ids).stream()
                 .collect(Collectors.toMap(i -> i.getProduct().getId(), Inventory::getAvailable));
@@ -293,10 +300,12 @@ public class ProductService {
                 : Set.of();
 
         return products.map(p -> {
+            int available = availableMap.getOrDefault(p.getId(), 0);
+            StockStatus stockStatus = StockStatus.of(available, threshold);
             ReviewStatsProjection stats = statsMap.get(p.getId());
             return ProductResponse.from(
                     p,
-                    availableMap.getOrDefault(p.getId(), 0),
+                    null, stockStatus,
                     stats != null ? stats.getAvgRating() : null,
                     stats != null ? stats.getReviewCount() : 0L,
                     null,
@@ -313,6 +322,7 @@ public class ProductService {
         if (esPage.isEmpty()) return esPage;
 
         List<Long> ids = esPage.getContent().stream().map(ProductResponse::getId).toList();
+        int threshold = systemSettingService.getLowStockThreshold();
 
         Map<Long, Integer> availableMap = inventoryRepository.findAllByProductIdIn(ids).stream()
                 .collect(Collectors.toMap(i -> i.getProduct().getId(), Inventory::getAvailable));
@@ -326,6 +336,7 @@ public class ProductService {
                 : Set.of();
 
         List<ProductResponse> enriched = esPage.getContent().stream().map(r -> {
+            int available = availableMap.getOrDefault(r.getId(), 0);
             ReviewStatsProjection stats = statsMap.get(r.getId());
             return ProductResponse.builder()
                     .id(r.getId())
@@ -339,7 +350,7 @@ public class ProductService {
                     .status(r.getStatus())
                     .createdAt(r.getCreatedAt())
                     .updatedAt(r.getUpdatedAt())
-                    .availableQuantity(availableMap.getOrDefault(r.getId(), 0))
+                    .stockStatus(StockStatus.of(available, threshold))
                     .avgRating(stats != null && stats.getAvgRating() != null
                             ? Math.round(stats.getAvgRating() * 10.0) / 10.0 : null)
                     .reviewCount(stats != null ? stats.getReviewCount() : 0L)

--- a/src/main/java/com/stockmanagement/domain/product/wishlist/dto/WishlistResponse.java
+++ b/src/main/java/com/stockmanagement/domain/product/wishlist/dto/WishlistResponse.java
@@ -1,5 +1,6 @@
 package com.stockmanagement.domain.product.wishlist.dto;
 
+import com.stockmanagement.domain.inventory.entity.StockStatus;
 import com.stockmanagement.domain.product.entity.Product;
 import com.stockmanagement.domain.product.entity.ProductStatus;
 import com.stockmanagement.domain.product.wishlist.entity.WishlistItem;
@@ -20,13 +21,13 @@ public class WishlistResponse {
     private String thumbnailUrl;
     private LocalDateTime addedAt;
 
-    /** 현재 가용 재고 수량 — null이면 재고 정보 미포함 */
-    private Integer availableQuantity;
+    /** 재고 상태 (IN_STOCK / LOW_STOCK / OUT_OF_STOCK) — null이면 재고 정보 미포함 */
+    private StockStatus stockStatus;
 
     /** 상품 판매 상태 */
     private ProductStatus productStatus;
 
-    public static WishlistResponse of(WishlistItem item, Product product, Integer availableQuantity) {
+    public static WishlistResponse of(WishlistItem item, Product product, StockStatus stockStatus) {
         return WishlistResponse.builder()
                 .id(item.getId())
                 .productId(item.getProductId())
@@ -34,7 +35,7 @@ public class WishlistResponse {
                 .productPrice(product.getPrice())
                 .thumbnailUrl(product.getThumbnailUrl())
                 .addedAt(item.getCreatedAt())
-                .availableQuantity(availableQuantity)
+                .stockStatus(stockStatus)
                 .productStatus(product.getStatus())
                 .build();
     }

--- a/src/main/java/com/stockmanagement/domain/product/wishlist/service/WishlistService.java
+++ b/src/main/java/com/stockmanagement/domain/product/wishlist/service/WishlistService.java
@@ -2,7 +2,9 @@ package com.stockmanagement.domain.product.wishlist.service;
 
 import com.stockmanagement.common.exception.BusinessException;
 import com.stockmanagement.common.exception.ErrorCode;
+import com.stockmanagement.domain.admin.setting.service.SystemSettingService;
 import com.stockmanagement.domain.inventory.entity.Inventory;
+import com.stockmanagement.domain.inventory.entity.StockStatus;
 import com.stockmanagement.domain.inventory.repository.InventoryRepository;
 import com.stockmanagement.domain.product.entity.Product;
 import com.stockmanagement.domain.product.repository.ProductRepository;
@@ -28,6 +30,7 @@ public class WishlistService {
     private final WishlistRepository wishlistRepository;
     private final ProductRepository productRepository;
     private final InventoryRepository inventoryRepository;
+    private final SystemSettingService systemSettingService;
 
     /**
      * 위시리스트에 상품을 추가한다.
@@ -48,10 +51,11 @@ public class WishlistService {
                 .productId(productId)
                 .build();
 
-        Integer available = inventoryRepository.findByProductId(productId)
+        int available = inventoryRepository.findByProductId(productId)
                 .map(Inventory::getAvailable)
-                .orElse(null);
-        return WishlistResponse.of(wishlistRepository.save(item), product, available);
+                .orElse(0);
+        StockStatus stockStatus = StockStatus.of(available, systemSettingService.getLowStockThreshold());
+        return WishlistResponse.of(wishlistRepository.save(item), product, stockStatus);
     }
 
     /**
@@ -89,14 +93,18 @@ public class WishlistService {
 
         // N+1 방지: 상품 + 재고를 한 번에 배치 조회
         List<Long> productIds = page.map(WishlistItem::getProductId).toList();
+        int threshold = systemSettingService.getLowStockThreshold();
         Map<Long, Product> productMap = productRepository.findAllById(productIds).stream()
                 .collect(Collectors.toMap(Product::getId, Function.identity()));
         Map<Long, Integer> availableMap = inventoryRepository.findAllByProductIdIn(productIds).stream()
                 .collect(Collectors.toMap(i -> i.getProduct().getId(), Inventory::getAvailable));
 
-        return page.map(item -> WishlistResponse.of(
-                item,
-                productMap.get(item.getProductId()),
-                availableMap.get(item.getProductId())));
+        return page.map(item -> {
+            int avail = availableMap.getOrDefault(item.getProductId(), 0);
+            return WishlistResponse.of(
+                    item,
+                    productMap.get(item.getProductId()),
+                    StockStatus.of(avail, threshold));
+        });
     }
 }

--- a/src/test/java/com/stockmanagement/domain/order/cart/service/CartServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/order/cart/service/CartServiceTest.java
@@ -2,6 +2,7 @@ package com.stockmanagement.domain.order.cart.service;
 
 import com.stockmanagement.common.exception.BusinessException;
 import com.stockmanagement.common.exception.ErrorCode;
+import com.stockmanagement.domain.admin.setting.service.SystemSettingService;
 import com.stockmanagement.domain.order.cart.dto.CartCheckoutRequest;
 import com.stockmanagement.domain.order.cart.dto.CartItemRequest;
 import com.stockmanagement.domain.order.cart.dto.CartResponse;
@@ -40,6 +41,7 @@ class CartServiceTest {
     @Mock ProductRepository productRepository;
     @Mock InventoryRepository inventoryRepository;
     @Mock OrderCommandService orderCommandService;
+    @Mock SystemSettingService systemSettingService;
 
     @InjectMocks CartService cartService;
 

--- a/src/test/java/com/stockmanagement/domain/product/service/HomeServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/product/service/HomeServiceTest.java
@@ -1,5 +1,6 @@
 package com.stockmanagement.domain.product.service;
 
+import com.stockmanagement.domain.admin.setting.service.SystemSettingService;
 import com.stockmanagement.domain.inventory.entity.Inventory;
 import com.stockmanagement.domain.inventory.repository.InventoryRepository;
 import com.stockmanagement.domain.product.category.dto.CategoryResponse;
@@ -43,6 +44,9 @@ class HomeServiceTest {
 
     @Mock
     private CategoryService categoryService;
+
+    @Mock
+    private SystemSettingService systemSettingService;
 
     @InjectMocks
     private HomeService homeService;

--- a/src/test/java/com/stockmanagement/domain/product/service/ProductServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/product/service/ProductServiceTest.java
@@ -2,6 +2,7 @@ package com.stockmanagement.domain.product.service;
 
 import com.stockmanagement.common.exception.BusinessException;
 import com.stockmanagement.common.exception.ErrorCode;
+import com.stockmanagement.domain.admin.setting.service.SystemSettingService;
 import com.stockmanagement.domain.inventory.repository.InventoryRepository;
 import com.stockmanagement.domain.product.category.repository.CategoryRepository;
 import com.stockmanagement.domain.product.dto.ProductCreateRequest;
@@ -60,6 +61,9 @@ class ProductServiceTest {
 
     @Mock
     private ApplicationEventPublisher eventPublisher;
+
+    @Mock
+    private SystemSettingService systemSettingService;
 
     @InjectMocks
     private ProductService productService;

--- a/src/test/java/com/stockmanagement/domain/product/wishlist/service/WishlistServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/product/wishlist/service/WishlistServiceTest.java
@@ -2,6 +2,7 @@ package com.stockmanagement.domain.product.wishlist.service;
 
 import com.stockmanagement.common.exception.BusinessException;
 import com.stockmanagement.common.exception.ErrorCode;
+import com.stockmanagement.domain.admin.setting.service.SystemSettingService;
 import com.stockmanagement.domain.inventory.repository.InventoryRepository;
 import com.stockmanagement.domain.product.entity.Product;
 import com.stockmanagement.domain.product.repository.ProductRepository;
@@ -38,6 +39,7 @@ class WishlistServiceTest {
     @Mock private WishlistRepository wishlistRepository;
     @Mock private ProductRepository productRepository;
     @Mock private InventoryRepository inventoryRepository;
+    @Mock private SystemSettingService systemSettingService;
 
     @InjectMocks private WishlistService wishlistService;
 


### PR DESCRIPTION
## Summary
- `StockStatus` enum (IN_STOCK / LOW_STOCK / OUT_OF_STOCK) 도입
- 공개 API(상품 목록, 홈 화면, 위시리스트)에서 정확한 재고 수량 대신 `stockStatus`만 노출
- 장바구니: `isAvailable` 판단용 `availableQuantity` 유지 + `stockStatus` 추가
- 상품 상세/관리자 API: `availableQuantity` 유지 + `stockStatus` 추가
- 저재고 임계값은 `SystemSettingService.getLowStockThreshold()`에서 동적 조회

## Test plan
- [x] 전체 715개 테스트 통과
- [x] ProductServiceTest, CartServiceTest, HomeServiceTest, WishlistServiceTest에 SystemSettingService mock 추가

Closes #135