### PR TITLE
feat: 포인트 적립 예정(PENDING) 상태 도입 (#122)

### DIFF
--- a/src/main/java/com/stockmanagement/common/outbox/OutboxEventProcessor.java
+++ b/src/main/java/com/stockmanagement/common/outbox/OutboxEventProcessor.java
@@ -106,6 +106,13 @@ class OutboxEventProcessor {
                 pointService.earn(userId, paidAmount, orderId);
                 log.info("[Outbox] 포인트 적립 완료: userId={}, paidAmount={}, orderId={}", userId, paidAmount, orderId);
             }
+            case SHIPMENT_DELIVERED -> {
+                Long orderId = toLong(p.get("orderId"));
+                // 배송 완료 시 PENDING 적립 포인트를 확정 (CONFIRMED + 잔액 반영)
+                pointService.confirmPending(orderId);
+                eventPublisher.publishEvent(new ShipmentDeliveredEvent(orderId));
+                log.info("[Outbox] 배송 완료 처리 + 포인트 확정: orderId={}", orderId);
+            }
             default -> eventPublisher.publishEvent(buildEvent(outbox, p));
         }
     }
@@ -120,7 +127,6 @@ class OutboxEventProcessor {
                     toLong(p.get("paymentId")), toLong(p.get("orderId")), toBigDecimal(p.get("amount")));
             case SHIPMENT_SHIPPED -> new ShipmentShippedEvent(
                     toLong(p.get("orderId")), (String) p.get("carrier"), (String) p.get("trackingNumber"));
-            case SHIPMENT_DELIVERED -> new ShipmentDeliveredEvent(toLong(p.get("orderId")));
             case SHIPMENT_RETURNED -> new ShipmentReturnedEvent(toLong(p.get("orderId")));
             default -> throw new IllegalStateException("buildEvent에서 처리되지 않은 타입: " + outbox.getEventType());
         };

--- a/src/main/java/com/stockmanagement/domain/point/controller/PointController.java
+++ b/src/main/java/com/stockmanagement/domain/point/controller/PointController.java
@@ -37,4 +37,12 @@ public class PointController {
             @PageableDefault(size = 20) Pageable pageable) {
         return ApiResponse.ok(pointService.getHistory(username, pageable));
     }
+
+    @Operation(summary = "적립 예정 포인트 조회 (배송 완료 전)")
+    @GetMapping("/pending")
+    public ApiResponse<Page<PointTransactionResponse>> getPending(
+            @AuthenticationPrincipal String username,
+            @PageableDefault(size = 20) Pageable pageable) {
+        return ApiResponse.ok(pointService.getPendingHistory(username, pageable));
+    }
 }

--- a/src/main/java/com/stockmanagement/domain/point/dto/PointTransactionResponse.java
+++ b/src/main/java/com/stockmanagement/domain/point/dto/PointTransactionResponse.java
@@ -1,6 +1,7 @@
 package com.stockmanagement.domain.point.dto;
 
 import com.stockmanagement.domain.point.entity.PointTransaction;
+import com.stockmanagement.domain.point.entity.PointTransactionStatus;
 import com.stockmanagement.domain.point.entity.PointTransactionType;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,6 +15,7 @@ public class PointTransactionResponse {
     private Long id;
     private long amount;
     private PointTransactionType type;
+    private PointTransactionStatus status;
     private String description;
     private Long orderId;
     private LocalDateTime createdAt;
@@ -23,6 +25,7 @@ public class PointTransactionResponse {
                 .id(tx.getId())
                 .amount(tx.getAmount())
                 .type(tx.getType())
+                .status(tx.getStatus())
                 .description(tx.getDescription())
                 .orderId(tx.getOrderId())
                 .createdAt(tx.getCreatedAt())

--- a/src/main/java/com/stockmanagement/domain/point/entity/PointTransaction.java
+++ b/src/main/java/com/stockmanagement/domain/point/entity/PointTransaction.java
@@ -37,17 +37,39 @@ public class PointTransaction {
     @Column(name = "order_id")
     private Long orderId;
 
+    /** 트랜잭션 확정 상태 — EARN 타입의 적립 예정/확정/만료 관리 */
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private PointTransactionStatus status;
+
     @CreationTimestamp
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
     @Builder
     private PointTransaction(Long userId, long amount, PointTransactionType type,
-                             String description, Long orderId) {
+                             String description, Long orderId, PointTransactionStatus status) {
         this.userId = userId;
         this.amount = amount;
         this.type = type;
         this.description = description;
         this.orderId = orderId;
+        this.status = status != null ? status : PointTransactionStatus.CONFIRMED;
+    }
+
+    /** PENDING → CONFIRMED 전환 */
+    public void confirm() {
+        if (this.status != PointTransactionStatus.PENDING) {
+            throw new IllegalStateException("PENDING 상태만 확정 가능: current=" + this.status);
+        }
+        this.status = PointTransactionStatus.CONFIRMED;
+    }
+
+    /** PENDING → EXPIRED 전환 (주문 취소 시) */
+    public void expire() {
+        if (this.status != PointTransactionStatus.PENDING) {
+            throw new IllegalStateException("PENDING 상태만 만료 가능: current=" + this.status);
+        }
+        this.status = PointTransactionStatus.EXPIRED;
     }
 }

--- a/src/main/java/com/stockmanagement/domain/point/entity/PointTransactionStatus.java
+++ b/src/main/java/com/stockmanagement/domain/point/entity/PointTransactionStatus.java
@@ -1,0 +1,11 @@
+package com.stockmanagement.domain.point.entity;
+
+/** 포인트 트랜잭션 확정 상태 */
+public enum PointTransactionStatus {
+    /** 적립 예정 (배송 완료 전) */
+    PENDING,
+    /** 확정 (잔액에 반영됨) */
+    CONFIRMED,
+    /** 만료/취소 (주문 취소 등) */
+    EXPIRED
+}

--- a/src/main/java/com/stockmanagement/domain/point/repository/PointTransactionRepository.java
+++ b/src/main/java/com/stockmanagement/domain/point/repository/PointTransactionRepository.java
@@ -1,12 +1,14 @@
 package com.stockmanagement.domain.point.repository;
 
 import com.stockmanagement.domain.point.entity.PointTransaction;
+import com.stockmanagement.domain.point.entity.PointTransactionStatus;
 import com.stockmanagement.domain.point.entity.PointTransactionType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface PointTransactionRepository extends JpaRepository<PointTransaction, Long> {
 
@@ -16,4 +18,12 @@ public interface PointTransactionRepository extends JpaRepository<PointTransacti
 
     /** Outbox 재처리 시 포인트 이중 적립 방지용 멱등성 체크 */
     boolean existsByOrderIdAndType(Long orderId, PointTransactionType type);
+
+    /** 특정 주문의 PENDING 적립 트랜잭션 조회 */
+    Optional<PointTransaction> findByOrderIdAndTypeAndStatus(
+            Long orderId, PointTransactionType type, PointTransactionStatus status);
+
+    /** 사용자의 적립 예정 (PENDING) 트랜잭션 페이징 조회 */
+    Page<PointTransaction> findByUserIdAndStatusOrderByCreatedAtDesc(
+            Long userId, PointTransactionStatus status, Pageable pageable);
 }

--- a/src/main/java/com/stockmanagement/domain/point/service/PointService.java
+++ b/src/main/java/com/stockmanagement/domain/point/service/PointService.java
@@ -5,6 +5,7 @@ import com.stockmanagement.common.exception.ErrorCode;
 import com.stockmanagement.domain.point.dto.PointBalanceResponse;
 import com.stockmanagement.domain.point.dto.PointTransactionResponse;
 import com.stockmanagement.domain.point.entity.PointTransaction;
+import com.stockmanagement.domain.point.entity.PointTransactionStatus;
 import com.stockmanagement.domain.point.entity.PointTransactionType;
 import com.stockmanagement.domain.point.entity.UserPoint;
 import com.stockmanagement.domain.point.repository.PointTransactionRepository;
@@ -29,10 +30,17 @@ import org.springframework.transaction.annotation.Transactional;
 /**
  * 포인트 적립/사용/환불을 처리하는 서비스.
  *
+ * <p>적립 흐름:
+ * <ol>
+ *   <li>결제 확정 → {@code earn()} — PENDING 상태로 트랜잭션 생성 (잔액 미반영)
+ *   <li>배송 완료 → {@code confirmPending()} — CONFIRMED 전환 + 잔액 반영
+ *   <li>주문 취소 → {@code expirePending()} — EXPIRED 전환 (잔액 변동 없음)
+ * </ol>
+ *
  * <p>트랜잭션 전략:
  * <ul>
- *   <li>{@code earn} — {@code REQUIRES_NEW}: 결제 확정 트랜잭션과 독립 커밋 (실패해도 결제 롤백 방지)
- *   <li>{@code use}, {@code refundByOrder} — {@code REQUIRED}: 주문 생성/취소 트랜잭션에 참여 (원자성 보장)
+ *   <li>{@code earn}, {@code confirmPending} — {@code REQUIRES_NEW}: 독립 커밋
+ *   <li>{@code use}, {@code refundByOrder} — {@code REQUIRED}: 주문 트랜잭션에 참여
  * </ul>
  */
 @Slf4j
@@ -77,6 +85,14 @@ public class PointService {
                 .map(PointTransactionResponse::from);
     }
 
+    /** 적립 예정 (PENDING) 포인트 이력을 최신순 페이징 조회한다. */
+    public Page<PointTransactionResponse> getPendingHistory(String username, Pageable pageable) {
+        User user = findUser(username);
+        return pointTransactionRepository.findByUserIdAndStatusOrderByCreatedAtDesc(
+                        user.getId(), PointTransactionStatus.PENDING, pageable)
+                .map(PointTransactionResponse::from);
+    }
+
     // ===== 변경 =====
 
     /**
@@ -99,10 +115,12 @@ public class PointService {
     }
 
     /**
-     * 결제 완료 시 포인트를 적립한다 (결제금액의 1%).
+     * 결제 완료 시 포인트 적립 예정 트랜잭션을 생성한다 (PENDING, 잔액 미반영).
+     *
+     * <p>배송 완료 시 {@link #confirmPending(Long)}으로 CONFIRMED 전환 후 잔액에 반영된다.
+     * 주문 취소 시 {@link #expirePending(Long)}으로 EXPIRED 전환된다.
      *
      * <p>{@code REQUIRES_NEW}: 결제 확정 트랜잭션과 독립적으로 커밋/롤백된다.
-     * 포인트 적립 실패가 결제 확정 트랜잭션을 rollback-only로 오염시키지 않도록 하기 위함.
      *
      * @param userId     수혜 사용자 ID
      * @param paidAmount 실 결제 금액 (포인트/쿠폰 차감 후)
@@ -110,24 +128,55 @@ public class PointService {
      */
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void earn(Long userId, long paidAmount, Long orderId) {
-        if (paidAmount <= 0) return; // 쿠폰/포인트 전액 할인 시 적립 없음
+        if (paidAmount <= 0) return;
         // 멱등성 보장 — Outbox 재처리 시 이중 적립 방지 (앱 레벨 1차, DB UNIQUE 2차)
         if (pointTransactionRepository.existsByOrderIdAndType(orderId, PointTransactionType.EARN)) {
             return;
         }
         long earnAmount = Math.max(1L, Math.round(paidAmount * EARN_RATE));
-        UserPoint userPoint = getOrCreate(userId);
-        userPoint.earn(earnAmount);
 
         pointTransactionRepository.save(PointTransaction.builder()
                 .userId(userId)
                 .amount(earnAmount)
                 .type(PointTransactionType.EARN)
-                .description("주문 구매 적립 (주문 #" + orderId + ")")
+                .status(PointTransactionStatus.PENDING)
+                .description("주문 구매 적립 예정 (주문 #" + orderId + ")")
                 .orderId(orderId)
                 .build());
-        // UK(order_id, type) 충돌 시 DataIntegrityViolationException 발생 → REQUIRES_NEW 트랜잭션 롤백
-        // (앱 레벨 existsBy 체크로 정상 흐름에서는 미발생)
+    }
+
+    /**
+     * 배송 완료 시 PENDING 적립 포인트를 확정한다 (CONFIRMED + 잔액 반영).
+     *
+     * <p>PENDING 트랜잭션이 없으면 skip (이미 확정되었거나 적립 없음).
+     *
+     * @param orderId 배송 완료된 주문 ID
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void confirmPending(Long orderId) {
+        pointTransactionRepository.findByOrderIdAndTypeAndStatus(
+                orderId, PointTransactionType.EARN, PointTransactionStatus.PENDING
+        ).ifPresent(tx -> {
+            tx.confirm();
+            UserPoint userPoint = getOrCreate(tx.getUserId());
+            userPoint.earn(tx.getAmount());
+            log.info("[Point] 적립 확정: userId={}, orderId={}, amount={}", tx.getUserId(), orderId, tx.getAmount());
+        });
+    }
+
+    /**
+     * 주문 취소 시 PENDING 적립 포인트를 만료시킨다 (잔액 변동 없음).
+     *
+     * @param orderId 취소된 주문 ID
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void expirePending(Long orderId) {
+        pointTransactionRepository.findByOrderIdAndTypeAndStatus(
+                orderId, PointTransactionType.EARN, PointTransactionStatus.PENDING
+        ).ifPresent(tx -> {
+            tx.expire();
+            log.info("[Point] 적립 만료: userId={}, orderId={}, amount={}", tx.getUserId(), orderId, tx.getAmount());
+        });
     }
 
     /**
@@ -143,7 +192,6 @@ public class PointService {
         if (usePoints <= 0) {
             throw new BusinessException(ErrorCode.INVALID_POINT_AMOUNT);
         }
-        // 포인트 계정이 없으면 잔액 0으로 생성 → 이후 use()에서 INSUFFICIENT_POINTS 발생
         UserPoint userPoint = getOrCreate(userId);
         userPoint.use(usePoints);
 
@@ -159,9 +207,8 @@ public class PointService {
     /**
      * 주문 취소/환불 시 포인트를 원상복구한다.
      *
-     * <p>사용된 포인트 반환 + 결제 완료로 적립된 포인트 회수를 모두 처리한다.
-     * 포인트 트랜잭션이 없는 주문(포인트 미사용·미적립)은 early return하여
-     * 불필요한 {@code SELECT FOR UPDATE}(getOrCreate) 호출을 방지한다.
+     * <p>PENDING 적립 포인트는 만료 처리하고, CONFIRMED 적립 포인트는 회수한다.
+     * 사용된 포인트는 반환한다.
      *
      * @param userId  사용자 ID
      * @param orderId 취소된 주문 ID
@@ -172,7 +219,6 @@ public class PointService {
         if (pointTransactionRepository.existsByOrderIdAndType(orderId, PointTransactionType.REFUND)) {
             return;
         }
-        // 포인트 트랜잭션이 없으면 early return — getOrCreate(SELECT FOR UPDATE + 잠재적 INSERT) 불필요
         List<PointTransaction> orderTxns = pointTransactionRepository.findByOrderId(orderId);
         if (orderTxns.isEmpty()) return;
 
@@ -192,29 +238,32 @@ public class PointService {
                         .orderId(orderId)
                         .build());
             } else if (tx.getType() == PointTransactionType.EARN) {
-                // 적립 포인트 회수 (취소 시 소급 적용)
-                // 잔액 부족 시 회수 가능한 만큼만 차감하고, 트랜잭션 기록도 실제 차감량으로 남긴다
-                long reclaimAmount = tx.getAmount();
-                long actualReclaim = Math.min(reclaimAmount, userPoint.getBalance());
-                if (actualReclaim > 0) {
-                    userPoint.use(actualReclaim);
-                    newTxns.add(PointTransaction.builder()
-                            .userId(userId)
-                            .amount(-actualReclaim)
-                            .type(PointTransactionType.EXPIRE)
-                            .description("주문 취소 적립금 회수 (주문 #" + orderId + ")")
-                            .orderId(orderId)
-                            .build());
-                }
-                if (actualReclaim < reclaimAmount) {
-                    log.warn("[Point] 적립금 전액 회수 불가: userId={}, orderId={}, 요청={}, 실제={}",
-                            userId, orderId, reclaimAmount, actualReclaim);
-                    pointPartialReclaimCounter.increment();
+                if (tx.getStatus() == PointTransactionStatus.PENDING) {
+                    // PENDING 적립 → EXPIRED (잔액 변동 없음)
+                    tx.expire();
+                } else if (tx.getStatus() == PointTransactionStatus.CONFIRMED) {
+                    // CONFIRMED 적립 → 회수 (잔액에서 차감)
+                    long reclaimAmount = tx.getAmount();
+                    long actualReclaim = Math.min(reclaimAmount, userPoint.getBalance());
+                    if (actualReclaim > 0) {
+                        userPoint.use(actualReclaim);
+                        newTxns.add(PointTransaction.builder()
+                                .userId(userId)
+                                .amount(-actualReclaim)
+                                .type(PointTransactionType.EXPIRE)
+                                .description("주문 취소 적립금 회수 (주문 #" + orderId + ")")
+                                .orderId(orderId)
+                                .build());
+                    }
+                    if (actualReclaim < reclaimAmount) {
+                        log.warn("[Point] 적립금 전액 회수 불가: userId={}, orderId={}, 요청={}, 실제={}",
+                                userId, orderId, reclaimAmount, actualReclaim);
+                        pointPartialReclaimCounter.increment();
+                    }
                 }
             }
         });
 
-        // 신규 트랜잭션 기록을 단일 배치 INSERT로 처리
         if (!newTxns.isEmpty()) {
             pointTransactionRepository.saveAll(newTxns);
         }
@@ -227,7 +276,6 @@ public class PointService {
                         return userPointRepository.save(
                                 UserPoint.builder().userId(userId).build());
                     } catch (DataIntegrityViolationException e) {
-                        // 동시 생성 충돌 — 재조회하여 이미 생성된 레코드 반환
                         return userPointRepository.findByUserIdWithLock(userId)
                                 .orElseThrow(() -> e);
                     }

--- a/src/main/resources/db/migration/V51__add_point_transaction_status.sql
+++ b/src/main/resources/db/migration/V51__add_point_transaction_status.sql
@@ -1,0 +1,7 @@
+-- 포인트 트랜잭션 확정 상태 컬럼 추가
+-- 기존 데이터는 모두 CONFIRMED (이미 잔액에 반영된 트랜잭션)
+ALTER TABLE point_transactions
+    ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'CONFIRMED';
+
+-- 적립 예정 내역 조회용 인덱스
+CREATE INDEX idx_point_txn_user_status ON point_transactions (user_id, status);

--- a/src/test/java/com/stockmanagement/domain/point/service/PointServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/point/service/PointServiceTest.java
@@ -4,6 +4,7 @@ import com.stockmanagement.common.exception.BusinessException;
 import com.stockmanagement.common.exception.ErrorCode;
 import com.stockmanagement.domain.point.dto.PointBalanceResponse;
 import com.stockmanagement.domain.point.entity.PointTransaction;
+import com.stockmanagement.domain.point.entity.PointTransactionStatus;
 import com.stockmanagement.domain.point.entity.PointTransactionType;
 import com.stockmanagement.domain.point.entity.UserPoint;
 import com.stockmanagement.domain.point.repository.PointTransactionRepository;
@@ -88,20 +89,85 @@ class PointServiceTest {
     }
 
     @Nested
-    @DisplayName("earn() — 포인트 적립")
+    @DisplayName("earn() — 포인트 적립 예정")
     class Earn {
 
         @Test
-        @DisplayName("적립 성공 → balance 증가 + 이력 저장")
+        @DisplayName("적립 성공 → PENDING 이력 저장, balance 미변경")
         void success() {
-            UserPoint up = mockUserPoint(1L, 0);
-            given(userPointRepository.findByUserIdWithLock(1L)).willReturn(Optional.of(up));
+            given(pointTransactionRepository.existsByOrderIdAndType(100L, PointTransactionType.EARN))
+                    .willReturn(false);
             given(pointTransactionRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
 
             pointService.earn(1L, 10000L, 100L);
 
-            assertThat(up.getBalance()).isEqualTo(100L); // 10000 * 0.01 = 100
             verify(pointTransactionRepository).save(any());
+        }
+
+        @Test
+        @DisplayName("이미 적립 이력 있으면 중복 적립 방지")
+        void idempotent() {
+            given(pointTransactionRepository.existsByOrderIdAndType(100L, PointTransactionType.EARN))
+                    .willReturn(true);
+
+            pointService.earn(1L, 10000L, 100L);
+
+            verify(pointTransactionRepository, org.mockito.Mockito.never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("confirmPending() — 적립 확정")
+    class ConfirmPending {
+
+        @Test
+        @DisplayName("PENDING 트랜잭션 확정 → balance 반영")
+        void success() {
+            UserPoint up = mockUserPoint(1L, 0);
+            PointTransaction tx = PointTransaction.builder()
+                    .userId(1L).amount(100L).type(PointTransactionType.EARN)
+                    .status(PointTransactionStatus.PENDING)
+                    .description("적립 예정").orderId(100L).build();
+            given(pointTransactionRepository.findByOrderIdAndTypeAndStatus(
+                    100L, PointTransactionType.EARN, PointTransactionStatus.PENDING))
+                    .willReturn(Optional.of(tx));
+            given(userPointRepository.findByUserIdWithLock(1L)).willReturn(Optional.of(up));
+
+            pointService.confirmPending(100L);
+
+            assertThat(up.getBalance()).isEqualTo(100L);
+            assertThat(tx.getStatus()).isEqualTo(PointTransactionStatus.CONFIRMED);
+        }
+
+        @Test
+        @DisplayName("PENDING 없으면 no-op")
+        void noPending() {
+            given(pointTransactionRepository.findByOrderIdAndTypeAndStatus(
+                    100L, PointTransactionType.EARN, PointTransactionStatus.PENDING))
+                    .willReturn(Optional.empty());
+
+            pointService.confirmPending(100L);
+        }
+    }
+
+    @Nested
+    @DisplayName("expirePending() — 적립 만료")
+    class ExpirePending {
+
+        @Test
+        @DisplayName("PENDING 트랜잭션 만료 → EXPIRED, balance 미변경")
+        void success() {
+            PointTransaction tx = PointTransaction.builder()
+                    .userId(1L).amount(100L).type(PointTransactionType.EARN)
+                    .status(PointTransactionStatus.PENDING)
+                    .description("적립 예정").orderId(100L).build();
+            given(pointTransactionRepository.findByOrderIdAndTypeAndStatus(
+                    100L, PointTransactionType.EARN, PointTransactionStatus.PENDING))
+                    .willReturn(Optional.of(tx));
+
+            pointService.expirePending(100L);
+
+            assertThat(tx.getStatus()).isEqualTo(PointTransactionStatus.EXPIRED);
         }
     }
 
@@ -157,8 +223,10 @@ class PointServiceTest {
     class RefundByOrder {
 
         @Test
-        @DisplayName("USE + EARN 이력 있음 → 반환 + 회수 처리")
+        @DisplayName("USE + EARN(CONFIRMED) 이력 있음 → 반환 + 회수 처리")
         void refundsBothUseAndEarn() {
+            given(pointTransactionRepository.existsByOrderIdAndType(100L, PointTransactionType.REFUND))
+                    .willReturn(false);
             UserPoint up = mockUserPoint(1L, 200); // earn된 상태
             given(userPointRepository.findByUserIdWithLock(1L)).willReturn(Optional.of(up));
 
@@ -178,6 +246,27 @@ class PointServiceTest {
 
             // USE → REFUND: +2000, EARN → EXPIRE: -200 (잔액에서 회수)
             assertThat(up.getBalance()).isEqualTo(200 + 2000 - 200);
+        }
+
+        @Test
+        @DisplayName("PENDING 적립만 있음 → EXPIRED 전환, balance 미변경")
+        void refundsPendingEarn() {
+            PointTransaction pendingEarnTx = PointTransaction.builder()
+                    .userId(1L).amount(100L)
+                    .type(PointTransactionType.EARN)
+                    .status(PointTransactionStatus.PENDING)
+                    .description("적립 예정").orderId(100L).build();
+
+            given(pointTransactionRepository.existsByOrderIdAndType(100L, PointTransactionType.REFUND))
+                    .willReturn(false);
+            given(pointTransactionRepository.findByOrderId(100L)).willReturn(List.of(pendingEarnTx));
+            UserPoint up = mockUserPoint(1L, 0);
+            given(userPointRepository.findByUserIdWithLock(1L)).willReturn(Optional.of(up));
+
+            pointService.refundByOrder(1L, 100L);
+
+            assertThat(pendingEarnTx.getStatus()).isEqualTo(PointTransactionStatus.EXPIRED);
+            assertThat(up.getBalance()).isEqualTo(0);
         }
 
         @Test


### PR DESCRIPTION
## Summary
- 포인트 적립 시 PENDING 상태로 생성, 배송 완료 시 CONFIRMED 전환 후 잔액 반영
- 주문 취소 시 PENDING 적립은 EXPIRED 처리 (잔액 변동 없음)
- `GET /api/points/pending` 적립 예정 내역 조회 API 추가
- `PointTransactionStatus` enum (PENDING/CONFIRMED/EXPIRED) + V51 마이그레이션
- OutboxEventProcessor의 SHIPMENT_DELIVERED 케이스에서 `confirmPending()` 호출

## Changes
- **신규**: `PointTransactionStatus` enum, V51 migration
- **수정**: PointTransaction (status 필드 + confirm/expire), PointService (earn→PENDING, confirmPending, expirePending, getPendingHistory), PointController (pending 엔드포인트), PointTransactionResponse (status 필드), OutboxEventProcessor (SHIPMENT_DELIVERED 확정), PointTransactionRepository (status 조회 메서드)
- **테스트**: PointServiceTest 업데이트 (earn→PENDING, confirmPending, expirePending, refundPending 케이스 추가)

## Test plan
- [x] 719개 테스트 전체 통과
- [ ] 적립 예정 포인트가 배송 완료 전까지 잔액에 미반영되는지 확인
- [ ] 주문 취소 시 PENDING 적립이 EXPIRED 처리되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)