### PR TITLE
feat: 포인트 적립분 만료 예정일 관리 (#117)

### DIFF
--- a/src/main/java/com/stockmanagement/domain/point/controller/PointController.java
+++ b/src/main/java/com/stockmanagement/domain/point/controller/PointController.java
@@ -13,6 +13,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Point", description = "포인트/적립금 API")
@@ -44,5 +45,14 @@ public class PointController {
             @AuthenticationPrincipal String username,
             @PageableDefault(size = 20) Pageable pageable) {
         return ApiResponse.ok(pointService.getPendingHistory(username, pageable));
+    }
+
+    @Operation(summary = "만료 예정 포인트 조회")
+    @GetMapping("/expiring-soon")
+    public ApiResponse<Page<PointTransactionResponse>> getExpiringSoon(
+            @AuthenticationPrincipal String username,
+            @RequestParam(defaultValue = "30") int withinDays,
+            @PageableDefault(size = 20) Pageable pageable) {
+        return ApiResponse.ok(pointService.getExpiringSoon(username, withinDays, pageable));
     }
 }

--- a/src/main/java/com/stockmanagement/domain/point/dto/PointTransactionResponse.java
+++ b/src/main/java/com/stockmanagement/domain/point/dto/PointTransactionResponse.java
@@ -18,6 +18,7 @@ public class PointTransactionResponse {
     private PointTransactionStatus status;
     private String description;
     private Long orderId;
+    private LocalDateTime expiresAt;
     private LocalDateTime createdAt;
 
     public static PointTransactionResponse from(PointTransaction tx) {
@@ -28,6 +29,7 @@ public class PointTransactionResponse {
                 .status(tx.getStatus())
                 .description(tx.getDescription())
                 .orderId(tx.getOrderId())
+                .expiresAt(tx.getExpiresAt())
                 .createdAt(tx.getCreatedAt())
                 .build();
     }

--- a/src/main/java/com/stockmanagement/domain/point/entity/PointTransaction.java
+++ b/src/main/java/com/stockmanagement/domain/point/entity/PointTransaction.java
@@ -42,19 +42,25 @@ public class PointTransaction {
     @Column(nullable = false, length = 20)
     private PointTransactionStatus status;
 
+    /** 적립 포인트 만료 예정일 — EARN 타입에만 설정 */
+    @Column(name = "expires_at")
+    private LocalDateTime expiresAt;
+
     @CreationTimestamp
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
     @Builder
     private PointTransaction(Long userId, long amount, PointTransactionType type,
-                             String description, Long orderId, PointTransactionStatus status) {
+                             String description, Long orderId, PointTransactionStatus status,
+                             LocalDateTime expiresAt) {
         this.userId = userId;
         this.amount = amount;
         this.type = type;
         this.description = description;
         this.orderId = orderId;
         this.status = status != null ? status : PointTransactionStatus.CONFIRMED;
+        this.expiresAt = expiresAt;
     }
 
     /** PENDING → CONFIRMED 전환 */
@@ -69,6 +75,14 @@ public class PointTransaction {
     public void expire() {
         if (this.status != PointTransactionStatus.PENDING) {
             throw new IllegalStateException("PENDING 상태만 만료 가능: current=" + this.status);
+        }
+        this.status = PointTransactionStatus.EXPIRED;
+    }
+
+    /** CONFIRMED → EXPIRED 전환 (기간 만료 시) */
+    public void expireConfirmed() {
+        if (this.status != PointTransactionStatus.CONFIRMED) {
+            throw new IllegalStateException("CONFIRMED 상태만 기간 만료 가능: current=" + this.status);
         }
         this.status = PointTransactionStatus.EXPIRED;
     }

--- a/src/main/java/com/stockmanagement/domain/point/repository/PointTransactionRepository.java
+++ b/src/main/java/com/stockmanagement/domain/point/repository/PointTransactionRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -26,4 +27,12 @@ public interface PointTransactionRepository extends JpaRepository<PointTransacti
     /** 사용자의 적립 예정 (PENDING) 트랜잭션 페이징 조회 */
     Page<PointTransaction> findByUserIdAndStatusOrderByCreatedAtDesc(
             Long userId, PointTransactionStatus status, Pageable pageable);
+
+    /** 만료 대상 조회: CONFIRMED + expiresAt 경과 */
+    List<PointTransaction> findByStatusAndExpiresAtBefore(
+            PointTransactionStatus status, LocalDateTime now);
+
+    /** 사용자의 만료 예정 CONFIRMED 포인트 조회 (만료일 가까운 순) */
+    Page<PointTransaction> findByUserIdAndStatusAndExpiresAtBeforeOrderByExpiresAtAsc(
+            Long userId, PointTransactionStatus status, LocalDateTime deadline, Pageable pageable);
 }

--- a/src/main/java/com/stockmanagement/domain/point/scheduler/PointExpiryScheduler.java
+++ b/src/main/java/com/stockmanagement/domain/point/scheduler/PointExpiryScheduler.java
@@ -1,0 +1,29 @@
+package com.stockmanagement.domain.point.scheduler;
+
+import com.stockmanagement.domain.point.service.PointService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * 만료일 경과 포인트 자동 소멸 스케줄러.
+ *
+ * <p>매일 새벽 0시 30분에 CONFIRMED 상태이면서 {@code expiresAt < now}인
+ * 적립 포인트를 EXPIRED로 전환하고 잔액에서 차감한다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "point.expiry.enabled", havingValue = "true", matchIfMissing = true)
+public class PointExpiryScheduler {
+
+    private final PointService pointService;
+
+    @Scheduled(cron = "${point.expiry.cron:0 30 0 * * *}")
+    public void expirePoints() {
+        int count = pointService.expireBySchedule();
+        log.info("[PointExpiryScheduler] 만료 포인트 처리 완료 — {}건", count);
+    }
+}

--- a/src/main/java/com/stockmanagement/domain/point/service/PointService.java
+++ b/src/main/java/com/stockmanagement/domain/point/service/PointService.java
@@ -17,11 +17,15 @@ import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -51,6 +55,9 @@ public class PointService {
 
     /** 결제 완료 시 적립 비율 (1%) */
     private static final double EARN_RATE = 0.01;
+
+    @Value("${point.expiry.retention-days:365}")
+    private int retentionDays;
 
     private final UserPointRepository userPointRepository;
     private final PointTransactionRepository pointTransactionRepository;
@@ -90,6 +97,15 @@ public class PointService {
         User user = findUser(username);
         return pointTransactionRepository.findByUserIdAndStatusOrderByCreatedAtDesc(
                         user.getId(), PointTransactionStatus.PENDING, pageable)
+                .map(PointTransactionResponse::from);
+    }
+
+    /** 만료 예정 CONFIRMED 포인트를 만료일 가까운 순으로 페이징 조회한다. */
+    public Page<PointTransactionResponse> getExpiringSoon(String username, int withinDays, Pageable pageable) {
+        User user = findUser(username);
+        LocalDateTime deadline = LocalDateTime.now().plusDays(withinDays);
+        return pointTransactionRepository.findByUserIdAndStatusAndExpiresAtBeforeOrderByExpiresAtAsc(
+                        user.getId(), PointTransactionStatus.CONFIRMED, deadline, pageable)
                 .map(PointTransactionResponse::from);
     }
 
@@ -142,6 +158,7 @@ public class PointService {
                 .status(PointTransactionStatus.PENDING)
                 .description("주문 구매 적립 예정 (주문 #" + orderId + ")")
                 .orderId(orderId)
+                .expiresAt(LocalDateTime.now().plusDays(retentionDays))
                 .build());
     }
 
@@ -267,6 +284,40 @@ public class PointService {
         if (!newTxns.isEmpty()) {
             pointTransactionRepository.saveAll(newTxns);
         }
+    }
+
+    /**
+     * 만료일이 경과한 CONFIRMED 포인트를 일괄 만료 처리한다.
+     * 사용자별로 잔액 차감 후 EXPIRED 전환.
+     *
+     * @return 만료 처리된 트랜잭션 수
+     */
+    @Transactional
+    public int expireBySchedule() {
+        LocalDateTime now = LocalDateTime.now();
+        List<PointTransaction> expired = pointTransactionRepository
+                .findByStatusAndExpiresAtBefore(PointTransactionStatus.CONFIRMED, now);
+        if (expired.isEmpty()) return 0;
+
+        // 사용자별 그룹핑하여 잔액 차감
+        Map<Long, List<PointTransaction>> byUser = expired.stream()
+                .collect(Collectors.groupingBy(PointTransaction::getUserId));
+
+        byUser.forEach((userId, txns) -> {
+            UserPoint userPoint = getOrCreate(userId);
+            long totalExpire = 0;
+            for (PointTransaction tx : txns) {
+                long actualExpire = Math.min(tx.getAmount(), userPoint.getBalance());
+                if (actualExpire > 0) {
+                    userPoint.use(actualExpire);
+                }
+                tx.expireConfirmed();
+                totalExpire += tx.getAmount();
+            }
+            log.info("[Point] 기간 만료: userId={}, 건수={}, 총액={}", userId, txns.size(), totalExpire);
+        });
+
+        return expired.size();
     }
 
     private UserPoint getOrCreate(Long userId) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -118,6 +118,11 @@ order.expiry.enabled=true
 coupon.expiry.enabled=true
 coupon.expiry.cron=0 0 1 * * *
 
+# ===== 포인트 만료 자동 처리 (매일 새벽 0시 30분) =====
+point.expiry.enabled=true
+point.expiry.cron=0 30 0 * * *
+point.expiry.retention-days=365
+
 # ===== 일별 재고 스냅샷 (매일 자정 5분) =====
 inventory.snapshot.enabled=true
 inventory.snapshot.cron=0 5 0 * * *

--- a/src/main/resources/db/migration/V52__add_point_expires_at.sql
+++ b/src/main/resources/db/migration/V52__add_point_expires_at.sql
@@ -1,0 +1,4 @@
+ALTER TABLE point_transactions
+    ADD COLUMN expires_at DATETIME NULL;
+
+CREATE INDEX idx_point_txn_status_expires ON point_transactions (status, expires_at);

--- a/src/test/java/com/stockmanagement/domain/point/service/PointServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/point/service/PointServiceTest.java
@@ -279,4 +279,42 @@ class PointServiceTest {
             // early return — userPointRepository 호출 없음
         }
     }
+
+    @Nested
+    @DisplayName("expireBySchedule() — 기간 만료 처리")
+    class ExpireBySchedule {
+
+        @Test
+        @DisplayName("CONFIRMED + 만료일 경과 → EXPIRED 전환 + 잔액 차감")
+        void expiresConfirmed() {
+            UserPoint up = mockUserPoint(1L, 500);
+            PointTransaction tx = PointTransaction.builder()
+                    .userId(1L).amount(200L).type(PointTransactionType.EARN)
+                    .status(PointTransactionStatus.CONFIRMED)
+                    .description("적립").orderId(100L).build();
+
+            given(pointTransactionRepository.findByStatusAndExpiresAtBefore(
+                    any(PointTransactionStatus.class), any()))
+                    .willReturn(List.of(tx));
+            given(userPointRepository.findByUserIdWithLock(1L)).willReturn(Optional.of(up));
+
+            int count = pointService.expireBySchedule();
+
+            assertThat(count).isEqualTo(1);
+            assertThat(tx.getStatus()).isEqualTo(PointTransactionStatus.EXPIRED);
+            assertThat(up.getBalance()).isEqualTo(300L);
+        }
+
+        @Test
+        @DisplayName("만료 대상 없음 → 0 반환")
+        void noExpired() {
+            given(pointTransactionRepository.findByStatusAndExpiresAtBefore(
+                    any(PointTransactionStatus.class), any()))
+                    .willReturn(List.of());
+
+            int count = pointService.expireBySchedule();
+
+            assertThat(count).isEqualTo(0);
+        }
+    }
 }

--- a/src/test/resources/application-integration.properties
+++ b/src/test/resources/application-integration.properties
@@ -33,6 +33,7 @@ spring.boot.admin.client.enabled=false
 # 스케줄러: 통합 테스트 중 간섭 방지를 위해 비활성화
 order.expiry.enabled=false
 coupon.expiry.enabled=false
+point.expiry.enabled=false
 inventory.snapshot.enabled=false
 order.stats.enabled=false
 


### PR DESCRIPTION
## Summary
- `PointTransaction.expiresAt` 필드 추가 (V52 마이그레이션)
- EARN 시 만료 예정일 자동 설정 (`point.expiry.retention-days=365`)
- `PointExpiryScheduler`: CONFIRMED + 만료일 경과 포인트 자동 EXPIRED 전환 + 잔액 차감
- `GET /api/points/expiring-soon?withinDays=30` 만료 예정 포인트 조회 API
- `PointTransaction.expireConfirmed()`: CONFIRMED → EXPIRED 상태 전환 메서드

## Changes
- **신규**: `V52__add_point_expires_at.sql`, `PointExpiryScheduler`
- **수정**: `PointTransaction` (expiresAt 필드 + expireConfirmed), `PointService` (earn에 expiresAt 설정 + expireBySchedule + getExpiringSoon), `PointTransactionResponse` (expiresAt), `PointTransactionRepository` (만료 조회 메서드 2개), `PointController` (expiring-soon 엔드포인트)
- **테스트**: `PointServiceTest` — expireBySchedule 2개 케이스 추가

## Test plan
- [x] 전체 테스트 통과
- [ ] 적립 시 expiresAt이 now+365일로 설정되는지 확인
- [ ] 만료 스케줄러가 CONFIRMED + 만료일 경과 포인트를 EXPIRED로 전환하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)