### PR TITLE
feat: 상품 Q&A (#134)

### DIFF
--- a/src/main/java/com/stockmanagement/common/config/SecurityConfig.java
+++ b/src/main/java/com/stockmanagement/common/config/SecurityConfig.java
@@ -112,6 +112,12 @@ public class SecurityConfig {
                         // 리뷰 작성/삭제 — 일반 사용자 인증 필요 (ADMIN 패턴보다 먼저 선언)
                         .requestMatchers(HttpMethod.POST, "/api/products/*/reviews").authenticated()
                         .requestMatchers(HttpMethod.DELETE, "/api/products/*/reviews/**").authenticated()
+                        // Q&A 질문 작성 — 인증 필요 (ADMIN 패턴보다 먼저 선언)
+                        .requestMatchers(HttpMethod.POST, "/api/products/*/qna").authenticated()
+                        // Q&A 답변 작성 — ADMIN 전용
+                        .requestMatchers(HttpMethod.POST, "/api/products/*/qna/*/answer").hasRole("ADMIN")
+                        // Q&A 삭제 — 인증 필요 (작성자 또는 ADMIN, 서비스에서 분기)
+                        .requestMatchers(HttpMethod.DELETE, "/api/products/*/qna/*").authenticated()
                         // 재입고 알림 신청/취소 — 일반 사용자 인증 필요 (ADMIN 패턴보다 먼저 선언)
                         .requestMatchers(HttpMethod.POST, "/api/products/*/restock-notify").authenticated()
                         .requestMatchers(HttpMethod.DELETE, "/api/products/*/restock-notify").authenticated()

--- a/src/main/java/com/stockmanagement/common/exception/ErrorCode.java
+++ b/src/main/java/com/stockmanagement/common/exception/ErrorCode.java
@@ -84,6 +84,10 @@ public enum ErrorCode {
     REVIEW_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 리뷰를 작성한 상품입니다."),
     REVIEW_ACCESS_DENIED(HttpStatus.FORBIDDEN, "본인의 리뷰만 삭제할 수 있습니다."),
 
+    // ===== Product Q&A =====
+    QNA_NOT_FOUND(HttpStatus.NOT_FOUND, "Q&A를 찾을 수 없습니다."),
+    QNA_ACCESS_DENIED(HttpStatus.FORBIDDEN, "본인의 Q&A만 삭제할 수 있습니다."),
+
     // ===== Wishlist =====
     WISHLIST_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 위시리스트에 추가된 상품입니다."),
     WISHLIST_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "위시리스트에서 해당 상품을 찾을 수 없습니다."),

--- a/src/main/java/com/stockmanagement/domain/product/qna/controller/ProductQnaController.java
+++ b/src/main/java/com/stockmanagement/domain/product/qna/controller/ProductQnaController.java
@@ -1,0 +1,82 @@
+package com.stockmanagement.domain.product.qna.controller;
+
+import com.stockmanagement.common.dto.ApiResponse;
+import com.stockmanagement.common.security.CurrentUserId;
+import com.stockmanagement.common.security.SecurityUtils;
+import com.stockmanagement.domain.product.qna.dto.QnaAnswerRequest;
+import com.stockmanagement.domain.product.qna.dto.QnaCreateRequest;
+import com.stockmanagement.domain.product.qna.dto.QnaResponse;
+import com.stockmanagement.domain.product.qna.service.ProductQnaService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 상품 Q&A REST API 컨트롤러.
+ *
+ * <pre>
+ * GET    /api/products/{productId}/qna              Q&A 목록 (공개)         → 200
+ * POST   /api/products/{productId}/qna              질문 작성 (인증 필요)    → 201
+ * POST   /api/products/{productId}/qna/{qnaId}/answer  답변 작성 (ADMIN)   → 200
+ * DELETE /api/products/{productId}/qna/{qnaId}      삭제 (작성자 or ADMIN)  → 204
+ * </pre>
+ */
+@Tag(name = "상품 Q&A", description = "상품 질문·답변 관리")
+@RestController
+@RequestMapping("/api/products/{productId}/qna")
+@RequiredArgsConstructor
+public class ProductQnaController {
+
+    private final ProductQnaService qnaService;
+
+    @Operation(summary = "Q&A 목록 조회", description = "비밀글은 작성자 본인과 ADMIN에게만 원문 노출.")
+    @GetMapping
+    public ApiResponse<Page<QnaResponse>> getList(
+            @PathVariable Long productId,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+            @CurrentUserId(required = false) Long userId,
+            Authentication authentication) {
+        boolean isAdmin = SecurityUtils.isAdmin(authentication);
+        return ApiResponse.ok(qnaService.getList(productId, pageable, userId, isAdmin));
+    }
+
+    @Operation(summary = "질문 작성", description = "구매 여부 무관, 인증된 사용자만 작성 가능.")
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public ApiResponse<QnaResponse> create(
+            @PathVariable Long productId,
+            @CurrentUserId Long userId,
+            @RequestBody @Valid QnaCreateRequest request) {
+        return ApiResponse.ok(qnaService.create(productId, userId, request));
+    }
+
+    @Operation(summary = "답변 작성", description = "ADMIN 전용. 기존 답변이 있으면 덮어쓴다.")
+    @PostMapping("/{qnaId}/answer")
+    public ApiResponse<QnaResponse> answer(
+            @PathVariable Long productId,
+            @PathVariable Long qnaId,
+            @CurrentUserId Long userId,
+            @RequestBody @Valid QnaAnswerRequest request) {
+        return ApiResponse.ok(qnaService.answer(productId, qnaId, userId, request));
+    }
+
+    @Operation(summary = "Q&A 삭제", description = "작성자 본인 또는 ADMIN만 삭제 가능.")
+    @DeleteMapping("/{qnaId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(
+            @PathVariable Long productId,
+            @PathVariable Long qnaId,
+            @CurrentUserId Long userId,
+            Authentication authentication) {
+        boolean isAdmin = SecurityUtils.isAdmin(authentication);
+        qnaService.delete(productId, qnaId, userId, isAdmin);
+    }
+}

--- a/src/main/java/com/stockmanagement/domain/product/qna/dto/QnaAnswerRequest.java
+++ b/src/main/java/com/stockmanagement/domain/product/qna/dto/QnaAnswerRequest.java
@@ -1,0 +1,15 @@
+package com.stockmanagement.domain.product.qna.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class QnaAnswerRequest {
+
+    @NotBlank
+    @Size(max = 5000)
+    private String answer;
+}

--- a/src/main/java/com/stockmanagement/domain/product/qna/dto/QnaCreateRequest.java
+++ b/src/main/java/com/stockmanagement/domain/product/qna/dto/QnaCreateRequest.java
@@ -1,0 +1,17 @@
+package com.stockmanagement.domain.product.qna.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class QnaCreateRequest {
+
+    @NotBlank
+    @Size(max = 5000)
+    private String content;
+
+    private boolean secret;
+}

--- a/src/main/java/com/stockmanagement/domain/product/qna/dto/QnaResponse.java
+++ b/src/main/java/com/stockmanagement/domain/product/qna/dto/QnaResponse.java
@@ -1,0 +1,52 @@
+package com.stockmanagement.domain.product.qna.dto;
+
+import com.stockmanagement.domain.product.qna.entity.ProductQna;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class QnaResponse {
+
+    private Long id;
+    private Long productId;
+    private String username;
+    private String content;
+    private boolean secret;
+    private boolean answered;
+    private String answer;
+    private LocalDateTime answeredAt;
+    private LocalDateTime createdAt;
+
+    /**
+     * 비밀글 가시성 처리.
+     * <ul>
+     *   <li>공개글 또는 작성자 본인 또는 ADMIN → 원문 노출</li>
+     *   <li>타인의 비밀글 → content="비밀글입니다", answer=null</li>
+     * </ul>
+     */
+    public static QnaResponse from(ProductQna qna, String username, Long currentUserId, boolean isAdmin) {
+        boolean canView = !qna.isSecret() || isAdmin
+                || (currentUserId != null && currentUserId.equals(qna.getUserId()));
+
+        return QnaResponse.builder()
+                .id(qna.getId())
+                .productId(qna.getProductId())
+                .username(maskUsername(username))
+                .content(canView ? qna.getContent() : "비밀글입니다")
+                .secret(qna.isSecret())
+                .answered(qna.getAnswer() != null)
+                .answer(canView ? qna.getAnswer() : null)
+                .answeredAt(canView ? qna.getAnsweredAt() : null)
+                .createdAt(qna.getCreatedAt())
+                .build();
+    }
+
+    private static String maskUsername(String raw) {
+        if (raw == null || raw.isBlank()) return "[탈퇴사용자]";
+        if (raw.length() <= 2) return raw.charAt(0) + "***";
+        return raw.substring(0, 2) + "***";
+    }
+}

--- a/src/main/java/com/stockmanagement/domain/product/qna/entity/ProductQna.java
+++ b/src/main/java/com/stockmanagement/domain/product/qna/entity/ProductQna.java
@@ -1,0 +1,66 @@
+package com.stockmanagement.domain.product.qna.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "product_qna")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductQna {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "product_id", nullable = false, updatable = false)
+    private Long productId;
+
+    @Column(name = "user_id", nullable = false, updatable = false)
+    private Long userId;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(nullable = false)
+    private boolean secret;
+
+    @Column(columnDefinition = "TEXT")
+    private String answer;
+
+    @Column(name = "answered_by")
+    private Long answeredBy;
+
+    @Column(name = "answered_at")
+    private LocalDateTime answeredAt;
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Builder
+    private ProductQna(Long productId, Long userId, String content, boolean secret) {
+        this.productId = productId;
+        this.userId = userId;
+        this.content = content;
+        this.secret = secret;
+    }
+
+    /** ADMIN이 답변을 작성(또는 수정)한다. */
+    public void answer(String answer, Long adminId) {
+        this.answer = answer;
+        this.answeredBy = adminId;
+        this.answeredAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/stockmanagement/domain/product/qna/repository/ProductQnaRepository.java
+++ b/src/main/java/com/stockmanagement/domain/product/qna/repository/ProductQnaRepository.java
@@ -1,0 +1,11 @@
+package com.stockmanagement.domain.product.qna.repository;
+
+import com.stockmanagement.domain.product.qna.entity.ProductQna;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductQnaRepository extends JpaRepository<ProductQna, Long> {
+
+    Page<ProductQna> findByProductId(Long productId, Pageable pageable);
+}

--- a/src/main/java/com/stockmanagement/domain/product/qna/service/ProductQnaService.java
+++ b/src/main/java/com/stockmanagement/domain/product/qna/service/ProductQnaService.java
@@ -1,0 +1,111 @@
+package com.stockmanagement.domain.product.qna.service;
+
+import com.stockmanagement.common.exception.BusinessException;
+import com.stockmanagement.common.exception.ErrorCode;
+import com.stockmanagement.domain.product.qna.dto.QnaAnswerRequest;
+import com.stockmanagement.domain.product.qna.dto.QnaCreateRequest;
+import com.stockmanagement.domain.product.qna.dto.QnaResponse;
+import com.stockmanagement.domain.product.qna.entity.ProductQna;
+import com.stockmanagement.domain.product.qna.repository.ProductQnaRepository;
+import com.stockmanagement.domain.product.repository.ProductRepository;
+import com.stockmanagement.domain.user.entity.User;
+import com.stockmanagement.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ProductQnaService {
+
+    private final ProductQnaRepository qnaRepository;
+    private final ProductRepository productRepository;
+    private final UserRepository userRepository;
+
+    /** Q&A 목록 조회 (비밀글 마스킹 포함) */
+    public Page<QnaResponse> getList(Long productId, Pageable pageable, Long currentUserId, boolean isAdmin) {
+        validateProductExists(productId);
+        Page<ProductQna> qnas = qnaRepository.findByProductId(productId, pageable);
+
+        List<Long> userIds = qnas.getContent().stream()
+                .map(ProductQna::getUserId)
+                .distinct()
+                .toList();
+        Map<Long, String> usernameMap = buildUsernameMap(userIds);
+
+        return qnas.map(q -> QnaResponse.from(
+                q,
+                usernameMap.get(q.getUserId()),
+                currentUserId,
+                isAdmin));
+    }
+
+    /** 질문 작성 */
+    @Transactional
+    public QnaResponse create(Long productId, Long userId, QnaCreateRequest request) {
+        validateProductExists(productId);
+        ProductQna qna = ProductQna.builder()
+                .productId(productId)
+                .userId(userId)
+                .content(request.getContent())
+                .secret(request.isSecret())
+                .build();
+        qnaRepository.save(qna);
+
+        String username = userRepository.findById(userId)
+                .map(User::getUsername).orElse(null);
+        return QnaResponse.from(qna, username, userId, false);
+    }
+
+    /** 답변 작성/수정 (ADMIN only) */
+    @Transactional
+    public QnaResponse answer(Long productId, Long qnaId, Long adminId, QnaAnswerRequest request) {
+        ProductQna qna = findByIdAndValidateProduct(qnaId, productId);
+        qna.answer(request.getAnswer(), adminId);
+
+        String username = userRepository.findById(qna.getUserId())
+                .map(User::getUsername).orElse(null);
+        return QnaResponse.from(qna, username, adminId, true);
+    }
+
+    /** 삭제 (작성자 또는 ADMIN) */
+    @Transactional
+    public void delete(Long productId, Long qnaId, Long userId, boolean isAdmin) {
+        ProductQna qna = findByIdAndValidateProduct(qnaId, productId);
+        if (!isAdmin && !qna.getUserId().equals(userId)) {
+            throw new BusinessException(ErrorCode.QNA_ACCESS_DENIED);
+        }
+        qnaRepository.delete(qna);
+    }
+
+    // ===== 내부 헬퍼 =====
+
+    private void validateProductExists(Long productId) {
+        if (!productRepository.existsById(productId)) {
+            throw new BusinessException(ErrorCode.PRODUCT_NOT_FOUND);
+        }
+    }
+
+    private ProductQna findByIdAndValidateProduct(Long qnaId, Long productId) {
+        ProductQna qna = qnaRepository.findById(qnaId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.QNA_NOT_FOUND));
+        if (!qna.getProductId().equals(productId)) {
+            throw new BusinessException(ErrorCode.QNA_NOT_FOUND);
+        }
+        return qna;
+    }
+
+    private Map<Long, String> buildUsernameMap(List<Long> userIds) {
+        if (userIds.isEmpty()) return Map.of();
+        return StreamSupport.stream(userRepository.findAllById(userIds).spliterator(), false)
+                .collect(Collectors.toMap(User::getId, User::getUsername));
+    }
+}

--- a/src/main/resources/db/migration/V54__create_product_qna_table.sql
+++ b/src/main/resources/db/migration/V54__create_product_qna_table.sql
@@ -1,0 +1,20 @@
+CREATE TABLE product_qna
+(
+    id          BIGINT       NOT NULL AUTO_INCREMENT,
+    product_id  BIGINT       NOT NULL COMMENT '대상 상품 ID',
+    user_id     BIGINT       NOT NULL COMMENT '질문 작성자 ID',
+    content     TEXT         NOT NULL COMMENT '질문 내용',
+    secret      BOOLEAN      NOT NULL DEFAULT FALSE COMMENT '비밀글 여부',
+    answer      TEXT         NULL     COMMENT '답변 내용 (ADMIN 작성)',
+    answered_by BIGINT       NULL     COMMENT '답변 작성 ADMIN ID',
+    answered_at DATETIME(6)  NULL     COMMENT '답변 일시',
+    created_at  DATETIME(6)  NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at  DATETIME(6)  NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id),
+    KEY idx_product_qna_product_id (product_id),
+    KEY idx_product_qna_user_id (user_id),
+    CONSTRAINT fk_product_qna_product FOREIGN KEY (product_id) REFERENCES products (id) ON DELETE CASCADE,
+    CONSTRAINT fk_product_qna_user FOREIGN KEY (user_id) REFERENCES users (id)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;

--- a/src/test/java/com/stockmanagement/domain/product/qna/controller/ProductQnaControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/product/qna/controller/ProductQnaControllerTest.java
@@ -1,0 +1,181 @@
+package com.stockmanagement.domain.product.qna.controller;
+
+import com.stockmanagement.common.config.SecurityConfig;
+import com.stockmanagement.common.security.EmailVerificationTokenStore;
+import com.stockmanagement.common.security.JwtBlacklist;
+import com.stockmanagement.common.security.JwtTokenProvider;
+import com.stockmanagement.domain.product.qna.dto.QnaResponse;
+import com.stockmanagement.domain.product.qna.service.ProductQnaService;
+import com.stockmanagement.domain.user.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(ProductQnaController.class)
+@Import(SecurityConfig.class)
+@DisplayName("ProductQnaController 단위 테스트")
+class ProductQnaControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+
+    @MockBean private ProductQnaService qnaService;
+    @MockBean private UserService userService;
+    @MockBean private JwtTokenProvider jwtTokenProvider;
+    @MockBean private JwtBlacklist jwtBlacklist;
+    @MockBean private EmailVerificationTokenStore emailVerificationTokenStore;
+
+    private static final UsernamePasswordAuthenticationToken USER_AUTH =
+            new UsernamePasswordAuthenticationToken("user1", null,
+                    List.of(new SimpleGrantedAuthority("ROLE_USER")));
+
+    private static final UsernamePasswordAuthenticationToken ADMIN_AUTH =
+            new UsernamePasswordAuthenticationToken("admin1", null,
+                    List.of(new SimpleGrantedAuthority("ROLE_ADMIN")));
+
+    @BeforeEach
+    void setUp() {
+        given(userService.resolveUserId(anyString())).willReturn(1L);
+    }
+
+    private QnaResponse sampleResponse() {
+        return QnaResponse.builder()
+                .id(1L)
+                .productId(1L)
+                .username("bu***")
+                .content("배송 문의")
+                .secret(false)
+                .answered(false)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    // ===== GET /api/products/{productId}/qna =====
+
+    @Nested
+    @DisplayName("GET /api/products/{productId}/qna")
+    class GetList {
+
+        @Test
+        @DisplayName("비로그인 조회 → 200")
+        void getListWithoutAuth() throws Exception {
+            given(qnaService.getList(anyLong(), any(Pageable.class), isNull(), eq(false)))
+                    .willReturn(new PageImpl<>(List.of(sampleResponse())));
+
+            mockMvc.perform(get("/api/products/1/qna"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.content[0].content").value("배송 문의"));
+        }
+    }
+
+    // ===== POST /api/products/{productId}/qna =====
+
+    @Nested
+    @DisplayName("POST /api/products/{productId}/qna")
+    class Create {
+
+        @Test
+        @DisplayName("인증된 사용자 → 201")
+        void createSuccess() throws Exception {
+            given(qnaService.create(anyLong(), anyLong(), any())).willReturn(sampleResponse());
+
+            mockMvc.perform(post("/api/products/1/qna")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"content\":\"배송 문의\",\"secret\":false}")
+                            .with(authentication(USER_AUTH)))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.success").value(true));
+        }
+
+        @Test
+        @DisplayName("미인증 → 401")
+        void createUnauthorized() throws Exception {
+            mockMvc.perform(post("/api/products/1/qna")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"content\":\"배송 문의\"}"))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+
+    // ===== POST /api/products/{productId}/qna/{qnaId}/answer =====
+
+    @Nested
+    @DisplayName("POST /api/products/{productId}/qna/{qnaId}/answer")
+    class Answer {
+
+        @Test
+        @DisplayName("ADMIN → 200")
+        void answerByAdmin() throws Exception {
+            QnaResponse response = QnaResponse.builder()
+                    .id(1L).productId(1L).username("bu***")
+                    .content("문의").secret(false).answered(true)
+                    .answer("답변 드립니다").answeredAt(LocalDateTime.now())
+                    .createdAt(LocalDateTime.now()).build();
+
+            given(userService.resolveUserId("admin1")).willReturn(100L);
+            given(qnaService.answer(anyLong(), anyLong(), anyLong(), any())).willReturn(response);
+
+            mockMvc.perform(post("/api/products/1/qna/1/answer")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"answer\":\"답변 드립니다\"}")
+                            .with(authentication(ADMIN_AUTH)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.answered").value(true));
+        }
+
+        @Test
+        @DisplayName("일반 사용자 → 403")
+        void answerByUserForbidden() throws Exception {
+            mockMvc.perform(post("/api/products/1/qna/1/answer")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"answer\":\"답변 시도\"}")
+                            .with(authentication(USER_AUTH)))
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    // ===== DELETE /api/products/{productId}/qna/{qnaId} =====
+
+    @Nested
+    @DisplayName("DELETE /api/products/{productId}/qna/{qnaId}")
+    class Delete {
+
+        @Test
+        @DisplayName("인증된 사용자 → 204")
+        void deleteSuccess() throws Exception {
+            mockMvc.perform(delete("/api/products/1/qna/1")
+                            .with(authentication(USER_AUTH)))
+                    .andExpect(status().isNoContent());
+
+            verify(qnaService).delete(eq(1L), eq(1L), anyLong(), eq(false));
+        }
+
+        @Test
+        @DisplayName("미인증 → 401")
+        void deleteUnauthorized() throws Exception {
+            mockMvc.perform(delete("/api/products/1/qna/1"))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+}

--- a/src/test/java/com/stockmanagement/domain/product/qna/service/ProductQnaServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/product/qna/service/ProductQnaServiceTest.java
@@ -1,0 +1,261 @@
+package com.stockmanagement.domain.product.qna.service;
+
+import com.stockmanagement.common.exception.BusinessException;
+import com.stockmanagement.common.exception.ErrorCode;
+import com.stockmanagement.domain.product.qna.dto.QnaAnswerRequest;
+import com.stockmanagement.domain.product.qna.dto.QnaCreateRequest;
+import com.stockmanagement.domain.product.qna.dto.QnaResponse;
+import com.stockmanagement.domain.product.qna.entity.ProductQna;
+import com.stockmanagement.domain.product.qna.repository.ProductQnaRepository;
+import com.stockmanagement.domain.product.repository.ProductRepository;
+import com.stockmanagement.domain.user.entity.User;
+import com.stockmanagement.domain.user.entity.UserRole;
+import com.stockmanagement.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ProductQnaService 단위 테스트")
+class ProductQnaServiceTest {
+
+    @Mock private ProductQnaRepository qnaRepository;
+    @Mock private ProductRepository productRepository;
+    @Mock private UserRepository userRepository;
+
+    @InjectMocks private ProductQnaService qnaService;
+
+    private ProductQna createQna(Long id, Long productId, Long userId, String content, boolean secret) {
+        ProductQna qna = ProductQna.builder()
+                .productId(productId)
+                .userId(userId)
+                .content(content)
+                .secret(secret)
+                .build();
+        ReflectionTestUtils.setField(qna, "id", id);
+        return qna;
+    }
+
+    private User createUser(Long id, String username) {
+        User user = User.builder()
+                .username(username)
+                .password("encoded")
+                .email(username + "@test.com")
+                .role(UserRole.USER)
+                .build();
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+
+    // ===== create() =====
+
+    @Nested
+    @DisplayName("create()")
+    class Create {
+
+        @Test
+        @DisplayName("정상 작성 — Q&A 저장 후 응답 반환")
+        void createsQna() {
+            QnaCreateRequest request = new QnaCreateRequest();
+            ReflectionTestUtils.setField(request, "content", "배송 기간 문의");
+            ReflectionTestUtils.setField(request, "secret", false);
+
+            given(productRepository.existsById(1L)).willReturn(true);
+            given(qnaRepository.save(any(ProductQna.class))).willAnswer(inv -> {
+                ProductQna qna = inv.getArgument(0);
+                ReflectionTestUtils.setField(qna, "id", 10L);
+                return qna;
+            });
+            given(userRepository.findById(1L)).willReturn(Optional.of(createUser(1L, "buyer")));
+
+            QnaResponse response = qnaService.create(1L, 1L, request);
+
+            assertThat(response.getId()).isEqualTo(10L);
+            assertThat(response.getContent()).isEqualTo("배송 기간 문의");
+            assertThat(response.isSecret()).isFalse();
+            verify(qnaRepository).save(any(ProductQna.class));
+        }
+
+        @Test
+        @DisplayName("상품 미존재 — PRODUCT_NOT_FOUND")
+        void throwsWhenProductNotFound() {
+            QnaCreateRequest request = new QnaCreateRequest();
+            ReflectionTestUtils.setField(request, "content", "문의");
+
+            given(productRepository.existsById(999L)).willReturn(false);
+
+            assertThatThrownBy(() -> qnaService.create(999L, 1L, request))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.PRODUCT_NOT_FOUND));
+        }
+    }
+
+    // ===== getList() =====
+
+    @Nested
+    @DisplayName("getList()")
+    class GetList {
+
+        @Test
+        @DisplayName("정상 조회 — 페이지 반환")
+        void returnsPaged() {
+            Pageable pageable = PageRequest.of(0, 20);
+            ProductQna qna = createQna(1L, 1L, 10L, "문의합니다", false);
+            given(productRepository.existsById(1L)).willReturn(true);
+            given(qnaRepository.findByProductId(1L, pageable))
+                    .willReturn(new PageImpl<>(List.of(qna), pageable, 1));
+            given(userRepository.findAllById(List.of(10L)))
+                    .willReturn(List.of(createUser(10L, "buyer")));
+
+            Page<QnaResponse> result = qnaService.getList(1L, pageable, null, false);
+
+            assertThat(result.getTotalElements()).isEqualTo(1);
+            assertThat(result.getContent().get(0).getContent()).isEqualTo("문의합니다");
+        }
+
+        @Test
+        @DisplayName("비밀글 — 타인이면 마스킹 처리")
+        void masksSecretForOthers() {
+            Pageable pageable = PageRequest.of(0, 20);
+            ProductQna qna = createQna(1L, 1L, 10L, "비밀 내용", true);
+            given(productRepository.existsById(1L)).willReturn(true);
+            given(qnaRepository.findByProductId(1L, pageable))
+                    .willReturn(new PageImpl<>(List.of(qna), pageable, 1));
+            given(userRepository.findAllById(List.of(10L)))
+                    .willReturn(List.of(createUser(10L, "buyer")));
+
+            Page<QnaResponse> result = qnaService.getList(1L, pageable, 99L, false);
+
+            assertThat(result.getContent().get(0).getContent()).isEqualTo("비밀글입니다");
+        }
+
+        @Test
+        @DisplayName("비밀글 — 작성자 본인이면 원문 노출")
+        void showsSecretToAuthor() {
+            Pageable pageable = PageRequest.of(0, 20);
+            ProductQna qna = createQna(1L, 1L, 10L, "비밀 내용", true);
+            given(productRepository.existsById(1L)).willReturn(true);
+            given(qnaRepository.findByProductId(1L, pageable))
+                    .willReturn(new PageImpl<>(List.of(qna), pageable, 1));
+            given(userRepository.findAllById(List.of(10L)))
+                    .willReturn(List.of(createUser(10L, "buyer")));
+
+            Page<QnaResponse> result = qnaService.getList(1L, pageable, 10L, false);
+
+            assertThat(result.getContent().get(0).getContent()).isEqualTo("비밀 내용");
+        }
+
+        @Test
+        @DisplayName("비밀글 — ADMIN이면 원문 노출")
+        void showsSecretToAdmin() {
+            Pageable pageable = PageRequest.of(0, 20);
+            ProductQna qna = createQna(1L, 1L, 10L, "비밀 내용", true);
+            given(productRepository.existsById(1L)).willReturn(true);
+            given(qnaRepository.findByProductId(1L, pageable))
+                    .willReturn(new PageImpl<>(List.of(qna), pageable, 1));
+            given(userRepository.findAllById(List.of(10L)))
+                    .willReturn(List.of(createUser(10L, "buyer")));
+
+            Page<QnaResponse> result = qnaService.getList(1L, pageable, 99L, true);
+
+            assertThat(result.getContent().get(0).getContent()).isEqualTo("비밀 내용");
+        }
+    }
+
+    // ===== answer() =====
+
+    @Nested
+    @DisplayName("answer()")
+    class Answer {
+
+        @Test
+        @DisplayName("정상 답변 — answer/answeredBy 설정")
+        void answersQna() {
+            ProductQna qna = createQna(1L, 1L, 10L, "문의", false);
+            QnaAnswerRequest request = new QnaAnswerRequest();
+            ReflectionTestUtils.setField(request, "answer", "답변 드립니다");
+
+            given(qnaRepository.findById(1L)).willReturn(Optional.of(qna));
+            given(userRepository.findById(10L)).willReturn(Optional.of(createUser(10L, "buyer")));
+
+            QnaResponse response = qnaService.answer(1L, 1L, 100L, request);
+
+            assertThat(response.isAnswered()).isTrue();
+            assertThat(response.getAnswer()).isEqualTo("답변 드립니다");
+            assertThat(qna.getAnsweredBy()).isEqualTo(100L);
+        }
+
+        @Test
+        @DisplayName("Q&A 미존재 — QNA_NOT_FOUND")
+        void throwsWhenNotFound() {
+            QnaAnswerRequest request = new QnaAnswerRequest();
+            ReflectionTestUtils.setField(request, "answer", "답변");
+
+            given(qnaRepository.findById(999L)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> qnaService.answer(1L, 999L, 100L, request))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.QNA_NOT_FOUND));
+        }
+    }
+
+    // ===== delete() =====
+
+    @Nested
+    @DisplayName("delete()")
+    class Delete {
+
+        @Test
+        @DisplayName("작성자 삭제 — 정상 처리")
+        void deletesOwnQna() {
+            ProductQna qna = createQna(1L, 1L, 10L, "문의", false);
+            given(qnaRepository.findById(1L)).willReturn(Optional.of(qna));
+
+            qnaService.delete(1L, 1L, 10L, false);
+
+            verify(qnaRepository).delete(qna);
+        }
+
+        @Test
+        @DisplayName("ADMIN 삭제 — 타인 Q&A 삭제 가능")
+        void adminDeletesOthersQna() {
+            ProductQna qna = createQna(1L, 1L, 10L, "문의", false);
+            given(qnaRepository.findById(1L)).willReturn(Optional.of(qna));
+
+            qnaService.delete(1L, 1L, 100L, true);
+
+            verify(qnaRepository).delete(qna);
+        }
+
+        @Test
+        @DisplayName("타인 삭제 — QNA_ACCESS_DENIED")
+        void throwsWhenNotOwner() {
+            ProductQna qna = createQna(1L, 1L, 10L, "문의", false);
+            given(qnaRepository.findById(1L)).willReturn(Optional.of(qna));
+
+            assertThatThrownBy(() -> qnaService.delete(1L, 1L, 99L, false))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.QNA_ACCESS_DENIED));
+        }
+    }
+}

--- a/src/test/java/com/stockmanagement/integration/AbstractIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/AbstractIntegrationTest.java
@@ -132,6 +132,7 @@ abstract class AbstractIntegrationTest {
             // order_status_history → orders (ON DELETE CASCADE로 자동 삭제되지만 명시적으로 먼저 삭제)
             stmt.execute("DELETE FROM cart_items");
             stmt.execute("DELETE FROM shipments");
+            stmt.execute("DELETE FROM product_qna");
             stmt.execute("DELETE FROM reviews");
             stmt.execute("DELETE FROM wishlist_items");
             stmt.execute("DELETE FROM notifications");

--- a/src/test/java/com/stockmanagement/integration/ProductQnaIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/ProductQnaIntegrationTest.java
@@ -1,0 +1,168 @@
+package com.stockmanagement.integration;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@DisplayName("Product Q&A 통합 테스트")
+class ProductQnaIntegrationTest extends AbstractIntegrationTest {
+
+    // ===== 공통 헬퍼 =====
+
+    private long createProduct(String adminToken, String sku) throws Exception {
+        String body = mockMvc.perform(post("/api/products")
+                        .header("Authorization", "Bearer " + adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(String.format("{\"name\":\"상품_%s\",\"sku\":\"%s\",\"price\":10000}", sku, sku)))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        return objectMapper.readTree(body).path("data").path("id").asLong();
+    }
+
+    private long createQna(String userToken, long productId, String content, boolean secret) throws Exception {
+        String json = String.format("{\"content\":\"%s\",\"secret\":%s}", content, secret);
+        String body = mockMvc.perform(post("/api/products/" + productId + "/qna")
+                        .header("Authorization", "Bearer " + userToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        return objectMapper.readTree(body).path("data").path("id").asLong();
+    }
+
+    // ===== 테스트 =====
+
+    @Test
+    @DisplayName("질문 작성 → 201, 내용 확인")
+    void createQna_success() throws Exception {
+        String adminToken = createAdminAndLogin("admin", "Password1!", "admin@test.com");
+        long productId = createProduct(adminToken, "QNA-1");
+        String userToken = signupAndLogin("user1", "Password1!", "user1@test.com");
+
+        mockMvc.perform(post("/api/products/" + productId + "/qna")
+                        .header("Authorization", "Bearer " + userToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"content\":\"배송 기간이 얼마나 걸리나요?\",\"secret\":false}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.content").value("배송 기간이 얼마나 걸리나요?"))
+                .andExpect(jsonPath("$.data.secret").value(false))
+                .andExpect(jsonPath("$.data.answered").value(false));
+    }
+
+    @Test
+    @DisplayName("비밀글 작성 → 타인 조회 시 마스킹")
+    void secretQna_maskedForOthers() throws Exception {
+        String adminToken = createAdminAndLogin("admin", "Password1!", "admin@test.com");
+        long productId = createProduct(adminToken, "QNA-2");
+        String user1Token = signupAndLogin("user1", "Password1!", "user1@test.com");
+        String user2Token = signupAndLogin("user2", "Password1!", "user2@test.com");
+
+        createQna(user1Token, productId, "비밀 문의입니다", true);
+
+        // user2가 조회 — 마스킹
+        mockMvc.perform(get("/api/products/" + productId + "/qna")
+                        .header("Authorization", "Bearer " + user2Token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content[0].content").value("비밀글입니다"))
+                .andExpect(jsonPath("$.data.content[0].secret").value(true));
+    }
+
+    @Test
+    @DisplayName("비밀글 작성 → 본인 조회 시 원문 노출")
+    void secretQna_visibleToAuthor() throws Exception {
+        String adminToken = createAdminAndLogin("admin", "Password1!", "admin@test.com");
+        long productId = createProduct(adminToken, "QNA-3");
+        String userToken = signupAndLogin("user1", "Password1!", "user1@test.com");
+
+        createQna(userToken, productId, "비밀 문의입니다", true);
+
+        // 작성자 본인 조회 — 원문
+        mockMvc.perform(get("/api/products/" + productId + "/qna")
+                        .header("Authorization", "Bearer " + userToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content[0].content").value("비밀 문의입니다"));
+    }
+
+    @Test
+    @DisplayName("ADMIN 답변 작성 → answer 필드 확인")
+    void adminAnswer_success() throws Exception {
+        String adminToken = createAdminAndLogin("admin", "Password1!", "admin@test.com");
+        long productId = createProduct(adminToken, "QNA-4");
+        String userToken = signupAndLogin("user1", "Password1!", "user1@test.com");
+
+        long qnaId = createQna(userToken, productId, "사이즈 문의", false);
+
+        mockMvc.perform(post("/api/products/" + productId + "/qna/" + qnaId + "/answer")
+                        .header("Authorization", "Bearer " + adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"answer\":\"M 사이즈를 추천드립니다.\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.answered").value(true))
+                .andExpect(jsonPath("$.data.answer").value("M 사이즈를 추천드립니다."));
+    }
+
+    @Test
+    @DisplayName("작성자 삭제 → 204")
+    void deleteByAuthor_success() throws Exception {
+        String adminToken = createAdminAndLogin("admin", "Password1!", "admin@test.com");
+        long productId = createProduct(adminToken, "QNA-5");
+        String userToken = signupAndLogin("user1", "Password1!", "user1@test.com");
+
+        long qnaId = createQna(userToken, productId, "삭제할 문의", false);
+
+        mockMvc.perform(delete("/api/products/" + productId + "/qna/" + qnaId)
+                        .header("Authorization", "Bearer " + userToken))
+                .andExpect(status().isNoContent());
+
+        // 삭제 후 조회 — 빈 목록
+        mockMvc.perform(get("/api/products/" + productId + "/qna"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content").isEmpty());
+    }
+
+    @Test
+    @DisplayName("타인 삭제 시도 → 403")
+    void deleteByOther_forbidden() throws Exception {
+        String adminToken = createAdminAndLogin("admin", "Password1!", "admin@test.com");
+        long productId = createProduct(adminToken, "QNA-6");
+        String user1Token = signupAndLogin("user1", "Password1!", "user1@test.com");
+        String user2Token = signupAndLogin("user2", "Password1!", "user2@test.com");
+
+        long qnaId = createQna(user1Token, productId, "문의", false);
+
+        mockMvc.perform(delete("/api/products/" + productId + "/qna/" + qnaId)
+                        .header("Authorization", "Bearer " + user2Token))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("ADMIN 삭제 → 204")
+    void deleteByAdmin_success() throws Exception {
+        String adminToken = createAdminAndLogin("admin", "Password1!", "admin@test.com");
+        long productId = createProduct(adminToken, "QNA-7");
+        String userToken = signupAndLogin("user1", "Password1!", "user1@test.com");
+
+        long qnaId = createQna(userToken, productId, "문의", false);
+
+        mockMvc.perform(delete("/api/products/" + productId + "/qna/" + qnaId)
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("비로그인 목록 조회 → 200")
+    void getListWithoutAuth_success() throws Exception {
+        String adminToken = createAdminAndLogin("admin", "Password1!", "admin@test.com");
+        long productId = createProduct(adminToken, "QNA-8");
+        String userToken = signupAndLogin("user1", "Password1!", "user1@test.com");
+
+        createQna(userToken, productId, "공개 문의", false);
+
+        mockMvc.perform(get("/api/products/" + productId + "/qna"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content[0].content").value("공개 문의"));
+    }
+}


### PR DESCRIPTION
## Summary
- 상품 상세 페이지 Q&A 기능 구현 (질문 작성 + ADMIN 답변 + 비밀글)
- 구매 여부 무관하게 질문 가능, ADMIN만 답변 가능
- 비밀글은 작성자 본인/ADMIN에게만 원문 노출, 타인에게는 "비밀글입니다" 마스킹

## Changes
| 구분 | 파일 | 설명 |
|---|---|---|
| 신규 | `V54__create_product_qna_table.sql` | product_qna 테이블 |
| 신규 | `domain/product/qna/` | Entity, Repository, Service, Controller, DTO |
| 수정 | `ErrorCode.java` | `QNA_NOT_FOUND`, `QNA_ACCESS_DENIED` 추가 |
| 수정 | `SecurityConfig.java` | Q&A POST/DELETE/answer 보안 규칙 |

## API
| Method | Path | Auth | 설명 |
|---|---|---|---|
| GET | `/api/products/{id}/qna` | public | Q&A 목록 (비밀글 마스킹) |
| POST | `/api/products/{id}/qna` | authenticated | 질문 작성 |
| POST | `/api/products/{id}/qna/{qnaId}/answer` | ADMIN | 답변 작성 |
| DELETE | `/api/products/{id}/qna/{qnaId}` | authenticated | 삭제 (작성자 or ADMIN) |

## Test plan
- [x] ProductQnaServiceTest: 단위 테스트 11개 (CRUD + 비밀글 가시성)
- [x] ProductQnaControllerTest: 컨트롤러 테스트 7개 (인증/권한)
- [x] ProductQnaIntegrationTest: 통합 테스트 8개 (E2E 플로우)
- [x] 전체 테스트 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)