### PR TITLE
feat: 사용자 반품 신청 플로우 (#116)

### DIFF
--- a/src/main/java/com/stockmanagement/common/config/SecurityConfig.java
+++ b/src/main/java/com/stockmanagement/common/config/SecurityConfig.java
@@ -130,7 +130,9 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/api/inventory/**").hasRole("ADMIN")
                         // 내 배송 목록 조회 — 인증된 사용자 전용 (ADMIN PATCH 패턴보다 앞에 선언)
                         .requestMatchers(HttpMethod.GET, "/api/shipments/my").authenticated()
-                        // 배송 상태 변경 (출고/완료/반품)은 ADMIN 전용
+                        // 반품 신청 — 인증된 사용자 (ADMIN PATCH 패턴보다 앞에 선언)
+                        .requestMatchers(HttpMethod.POST, "/api/shipments/orders/*/return-request").authenticated()
+                        // 배송 상태 변경 (출고/완료/반품/반품승인/반품거부)은 ADMIN 전용
                         .requestMatchers(HttpMethod.PATCH, "/api/shipments/**").hasRole("ADMIN")
                         // 카테고리 조회 공개, 관리 (생성/수정/삭제)는 ADMIN 전용
                         .requestMatchers(HttpMethod.GET, "/api/categories/**").permitAll()

--- a/src/main/java/com/stockmanagement/common/exception/ErrorCode.java
+++ b/src/main/java/com/stockmanagement/common/exception/ErrorCode.java
@@ -56,6 +56,7 @@ public enum ErrorCode {
     SHIPMENT_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 배송이 생성된 주문입니다."),
     INVALID_SHIPMENT_STATUS(HttpStatus.CONFLICT, "현재 배송 상태에서 허용되지 않는 작업입니다."),
     SHIPMENT_ACCESS_DENIED(HttpStatus.FORBIDDEN, "본인의 배송 정보만 접근할 수 있습니다."),
+    RETURN_ALREADY_REQUESTED(HttpStatus.CONFLICT, "이미 반품이 신청된 배송입니다."),
 
     // ===== Category =====
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "카테고리를 찾을 수 없습니다."),

--- a/src/main/java/com/stockmanagement/domain/shipment/controller/ShipmentController.java
+++ b/src/main/java/com/stockmanagement/domain/shipment/controller/ShipmentController.java
@@ -3,6 +3,7 @@ package com.stockmanagement.domain.shipment.controller;
 import com.stockmanagement.common.dto.ApiResponse;
 import com.stockmanagement.common.security.CurrentUserId;
 import com.stockmanagement.common.security.SecurityUtils;
+import com.stockmanagement.domain.shipment.dto.ReturnRequestDto;
 import com.stockmanagement.domain.shipment.dto.ShipmentResponse;
 import com.stockmanagement.domain.shipment.dto.ShipmentUpdateRequest;
 import com.stockmanagement.domain.shipment.service.ShipmentService;
@@ -22,10 +23,13 @@ import org.springframework.web.bind.annotation.*;
  * 배송 REST API 컨트롤러.
  *
  * <pre>
- * GET   /api/shipments/orders/{orderId}          주문별 배송 조회              → 200 OK (인증)
- * PATCH /api/shipments/orders/{orderId}/ship      배송 출고 처리               → 200 OK (ADMIN)
- * PATCH /api/shipments/orders/{orderId}/deliver   배송 완료 처리               → 200 OK (ADMIN)
- * PATCH /api/shipments/orders/{orderId}/return    반품 처리                    → 200 OK (ADMIN)
+ * GET   /api/shipments/orders/{orderId}                 주문별 배송 조회        → 200 OK (인증)
+ * PATCH /api/shipments/orders/{orderId}/ship            배송 출고 처리         → 200 OK (ADMIN)
+ * PATCH /api/shipments/orders/{orderId}/deliver         배송 완료 처리         → 200 OK (ADMIN)
+ * PATCH /api/shipments/orders/{orderId}/return          반품 처리              → 200 OK (ADMIN)
+ * POST  /api/shipments/orders/{orderId}/return-request  반품 신청              → 200 OK (인증)
+ * PATCH /api/shipments/orders/{orderId}/return-approve   반품 승인             → 200 OK (ADMIN)
+ * PATCH /api/shipments/orders/{orderId}/return-reject    반품 거부             → 200 OK (ADMIN)
  * </pre>
  *
  * <p>배송 생성은 결제 확정({@code PaymentService.confirm()}) 시 자동으로 수행되므로
@@ -76,5 +80,26 @@ public class ShipmentController {
     @PatchMapping("/orders/{orderId}/return")
     public ApiResponse<ShipmentResponse> processReturn(@PathVariable Long orderId) {
         return ApiResponse.ok(shipmentService.processReturn(orderId));
+    }
+
+    @Operation(summary = "반품 신청", description = "DELIVERED → RETURN_REQUESTED. 사용자가 직접 반품을 신청한다.")
+    @PostMapping("/orders/{orderId}/return-request")
+    public ApiResponse<ShipmentResponse> requestReturn(
+            @PathVariable Long orderId,
+            @CurrentUserId Long userId,
+            @RequestBody @Valid ReturnRequestDto request) {
+        return ApiResponse.ok(shipmentService.requestReturn(orderId, userId, request.getReason()));
+    }
+
+    @Operation(summary = "반품 승인 (ADMIN)", description = "RETURN_REQUESTED → RETURNED.")
+    @PatchMapping("/orders/{orderId}/return-approve")
+    public ApiResponse<ShipmentResponse> approveReturn(@PathVariable Long orderId) {
+        return ApiResponse.ok(shipmentService.approveReturn(orderId));
+    }
+
+    @Operation(summary = "반품 거부 (ADMIN)", description = "RETURN_REQUESTED → DELIVERED.")
+    @PatchMapping("/orders/{orderId}/return-reject")
+    public ApiResponse<ShipmentResponse> rejectReturn(@PathVariable Long orderId) {
+        return ApiResponse.ok(shipmentService.rejectReturn(orderId));
     }
 }

--- a/src/main/java/com/stockmanagement/domain/shipment/dto/ReturnRequestDto.java
+++ b/src/main/java/com/stockmanagement/domain/shipment/dto/ReturnRequestDto.java
@@ -1,0 +1,15 @@
+package com.stockmanagement.domain.shipment.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ReturnRequestDto {
+
+    @NotBlank
+    @Size(max = 500)
+    private String reason;
+}

--- a/src/main/java/com/stockmanagement/domain/shipment/dto/ShipmentResponse.java
+++ b/src/main/java/com/stockmanagement/domain/shipment/dto/ShipmentResponse.java
@@ -23,6 +23,8 @@ public class ShipmentResponse {
     private LocalDate estimatedDeliveryAt;
     private LocalDateTime shippedAt;
     private LocalDateTime deliveredAt;
+    private String returnReason;
+    private LocalDateTime returnRequestedAt;
     private LocalDateTime createdAt;
 
     public static ShipmentResponse from(Shipment shipment) {
@@ -36,6 +38,8 @@ public class ShipmentResponse {
                 .estimatedDeliveryAt(shipment.getEstimatedDeliveryAt())
                 .shippedAt(shipment.getShippedAt())
                 .deliveredAt(shipment.getDeliveredAt())
+                .returnReason(shipment.getReturnReason())
+                .returnRequestedAt(shipment.getReturnRequestedAt())
                 .createdAt(shipment.getCreatedAt())
                 .build();
     }

--- a/src/main/java/com/stockmanagement/domain/shipment/entity/Shipment.java
+++ b/src/main/java/com/stockmanagement/domain/shipment/entity/Shipment.java
@@ -17,7 +17,7 @@ import java.time.LocalDateTime;
  * 배송 엔티티.
  *
  * <p>주문 1건당 배송 1건(order_id UNIQUE)으로 관리된다.
- * 상태 전이: PREPARING → SHIPPED → DELIVERED / RETURNED
+ * 상태 전이: PREPARING → SHIPPED → DELIVERED → RETURN_REQUESTED → RETURNED
  *
  * <p>설계 원칙:
  * <ul>
@@ -40,7 +40,7 @@ public class Shipment {
     private Long orderId;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false, length = 20)
+    @Column(nullable = false, length = 30)
     private ShipmentStatus status;
 
     /** 택배사명 (예: CJ대한통운, 한진택배) */
@@ -60,6 +60,14 @@ public class Shipment {
     /** 택배사 예상 도착일 (출고 시 입력, 선택값) */
     @Column(name = "estimated_delivery_at")
     private LocalDate estimatedDeliveryAt;
+
+    /** 반품 사유 (사용자 입력) */
+    @Column(name = "return_reason", length = 500)
+    private String returnReason;
+
+    /** 반품 신청 일시 */
+    @Column(name = "return_requested_at")
+    private LocalDateTime returnRequestedAt;
 
     @CreationTimestamp
     @Column(nullable = false, updatable = false)
@@ -109,12 +117,58 @@ public class Shipment {
     /**
      * 반품 처리한다. (PREPARING|SHIPPED → RETURNED)
      *
-     * @throws BusinessException DELIVERED·RETURNED 상태에서 반품 시도 시
+     * @throws BusinessException DELIVERED·RETURNED·RETURN_REQUESTED 상태에서 반품 시도 시
      */
     public void processReturn() {
-        if (this.status == ShipmentStatus.DELIVERED || this.status == ShipmentStatus.RETURNED) {
+        if (this.status == ShipmentStatus.DELIVERED
+                || this.status == ShipmentStatus.RETURNED
+                || this.status == ShipmentStatus.RETURN_REQUESTED) {
             throw new BusinessException(ErrorCode.INVALID_SHIPMENT_STATUS);
         }
         this.status = ShipmentStatus.RETURNED;
+    }
+
+    /**
+     * 사용자가 반품을 신청한다. (DELIVERED → RETURN_REQUESTED)
+     *
+     * @throws BusinessException DELIVERED 상태가 아닌 경우
+     * @throws BusinessException 이미 반품 신청된 경우 (RETURN_REQUESTED)
+     */
+    public void requestReturn(String reason) {
+        if (this.status == ShipmentStatus.RETURN_REQUESTED) {
+            throw new BusinessException(ErrorCode.RETURN_ALREADY_REQUESTED);
+        }
+        if (this.status != ShipmentStatus.DELIVERED) {
+            throw new BusinessException(ErrorCode.INVALID_SHIPMENT_STATUS);
+        }
+        this.status = ShipmentStatus.RETURN_REQUESTED;
+        this.returnReason = reason;
+        this.returnRequestedAt = LocalDateTime.now();
+    }
+
+    /**
+     * ADMIN이 반품을 승인한다. (RETURN_REQUESTED → RETURNED)
+     *
+     * @throws BusinessException RETURN_REQUESTED 상태가 아닌 경우
+     */
+    public void approveReturn() {
+        if (this.status != ShipmentStatus.RETURN_REQUESTED) {
+            throw new BusinessException(ErrorCode.INVALID_SHIPMENT_STATUS);
+        }
+        this.status = ShipmentStatus.RETURNED;
+    }
+
+    /**
+     * ADMIN이 반품을 거부한다. (RETURN_REQUESTED → DELIVERED)
+     *
+     * @throws BusinessException RETURN_REQUESTED 상태가 아닌 경우
+     */
+    public void rejectReturn() {
+        if (this.status != ShipmentStatus.RETURN_REQUESTED) {
+            throw new BusinessException(ErrorCode.INVALID_SHIPMENT_STATUS);
+        }
+        this.status = ShipmentStatus.DELIVERED;
+        this.returnReason = null;
+        this.returnRequestedAt = null;
     }
 }

--- a/src/main/java/com/stockmanagement/domain/shipment/entity/ShipmentStatus.java
+++ b/src/main/java/com/stockmanagement/domain/shipment/entity/ShipmentStatus.java
@@ -6,10 +6,11 @@ package com.stockmanagement.domain.shipment.entity;
  * <pre>
  * PREPARING  — 배송 준비 중 (주문 CONFIRMED 시 자동 생성)
  * SHIPPED    — 배송 출고 완료 (운송장 등록)
- * DELIVERED  — 배송 완료
- * RETURNED   — 반품 처리
+ * DELIVERED        — 배송 완료
+ * RETURN_REQUESTED — 사용자 반품 신청 (ADMIN 승인/거부 대기)
+ * RETURNED         — 반품 처리 완료
  * </pre>
  */
 public enum ShipmentStatus {
-    PREPARING, SHIPPED, DELIVERED, RETURNED
+    PREPARING, SHIPPED, DELIVERED, RETURN_REQUESTED, RETURNED
 }

--- a/src/main/java/com/stockmanagement/domain/shipment/service/ShipmentService.java
+++ b/src/main/java/com/stockmanagement/domain/shipment/service/ShipmentService.java
@@ -31,7 +31,10 @@ import org.springframework.transaction.annotation.Transactional;
  *   결제 완료(CONFIRMED)  → {@link #createForOrder}    : PREPARING 생성 (PaymentService 호출)
  *   PREPARING            → {@link #startShipping}     : SHIPPED (운송장 등록)
  *   SHIPPED              → {@link #completeDelivery}  : DELIVERED
- *   PREPARING|SHIPPED    → {@link #processReturn}     : RETURNED
+ *   PREPARING|SHIPPED    → {@link #processReturn}     : RETURNED (ADMIN 직접)
+ *   DELIVERED            → {@link #requestReturn}     : RETURN_REQUESTED (사용자 신청)
+ *   RETURN_REQUESTED     → {@link #approveReturn}     : RETURNED (ADMIN 승인)
+ *   RETURN_REQUESTED     → {@link #rejectReturn}      : DELIVERED (ADMIN 거부)
  * </pre>
  */
 @Service
@@ -140,6 +143,50 @@ public class ShipmentService {
         Shipment shipment = findByOrderIdOrThrow(orderId);
         shipment.processReturn();
         outboxEventStore.save(new ShipmentReturnedEvent(orderId));
+        return ShipmentResponse.from(shipment);
+    }
+
+    /**
+     * 사용자가 반품을 신청한다. (DELIVERED → RETURN_REQUESTED)
+     *
+     * @param orderId 주문 ID
+     * @param userId  요청자 ID (소유권 검증)
+     * @param reason  반품 사유
+     */
+    @Transactional
+    public ShipmentResponse requestReturn(Long orderId, Long userId, String reason) {
+        Long orderUserId = orderRepository.findUserIdById(orderId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
+        if (!orderUserId.equals(userId)) {
+            throw new BusinessException(ErrorCode.SHIPMENT_NOT_FOUND);
+        }
+        Shipment shipment = findByOrderIdOrThrow(orderId);
+        shipment.requestReturn(reason);
+        return ShipmentResponse.from(shipment);
+    }
+
+    /**
+     * ADMIN이 반품을 승인한다. (RETURN_REQUESTED → RETURNED)
+     *
+     * @param orderId 주문 ID
+     */
+    @Transactional
+    public ShipmentResponse approveReturn(Long orderId) {
+        Shipment shipment = findByOrderIdOrThrow(orderId);
+        shipment.approveReturn();
+        outboxEventStore.save(new ShipmentReturnedEvent(orderId));
+        return ShipmentResponse.from(shipment);
+    }
+
+    /**
+     * ADMIN이 반품을 거부한다. (RETURN_REQUESTED → DELIVERED)
+     *
+     * @param orderId 주문 ID
+     */
+    @Transactional
+    public ShipmentResponse rejectReturn(Long orderId) {
+        Shipment shipment = findByOrderIdOrThrow(orderId);
+        shipment.rejectReturn();
         return ShipmentResponse.from(shipment);
     }
 

--- a/src/main/resources/db/migration/V55__add_shipment_return_fields.sql
+++ b/src/main/resources/db/migration/V55__add_shipment_return_fields.sql
@@ -1,0 +1,4 @@
+ALTER TABLE shipments
+    MODIFY COLUMN status VARCHAR(30) NOT NULL COMMENT '배송 상태 (RETURN_REQUESTED 수용)',
+    ADD COLUMN return_reason VARCHAR(500) NULL COMMENT '반품 사유',
+    ADD COLUMN return_requested_at DATETIME(6) NULL COMMENT '반품 신청 일시';

--- a/src/test/java/com/stockmanagement/domain/shipment/controller/ShipmentControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/shipment/controller/ShipmentControllerTest.java
@@ -3,8 +3,10 @@ package com.stockmanagement.domain.shipment.controller;
 import com.stockmanagement.common.config.SecurityConfig;
 import com.stockmanagement.common.exception.BusinessException;
 import com.stockmanagement.common.exception.ErrorCode;
+import com.stockmanagement.common.security.EmailVerificationTokenStore;
 import com.stockmanagement.common.security.JwtBlacklist;
 import com.stockmanagement.domain.shipment.dto.ShipmentResponse;
+import com.stockmanagement.domain.shipment.entity.ShipmentStatus;
 import com.stockmanagement.domain.shipment.service.ShipmentService;
 import com.stockmanagement.common.security.JwtTokenProvider;
 import com.stockmanagement.domain.user.service.UserService;
@@ -40,6 +42,7 @@ class ShipmentControllerTest {
     @MockBean private JwtTokenProvider jwtTokenProvider;
     @MockBean private JwtBlacklist jwtBlacklist;
     @MockBean private UserService userService;
+    @MockBean private EmailVerificationTokenStore emailVerificationTokenStore;
 
     // ===== GET /api/shipments/my =====
 
@@ -195,6 +198,106 @@ class ShipmentControllerTest {
         @DisplayName("USER — 반품 처리 → 403")
         void userForbidden() throws Exception {
             mockMvc.perform(patch("/api/shipments/orders/1/return"))
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    // ===== POST /api/shipments/orders/{orderId}/return-request =====
+
+    @Nested
+    @DisplayName("POST /api/shipments/orders/{orderId}/return-request")
+    class ReturnRequest {
+
+        private static final String RETURN_JSON = "{\"reason\":\"단순 변심\"}";
+
+        @Test
+        @WithMockUser
+        @DisplayName("인증된 사용자 — 반품 신청 → 200")
+        void requestsReturn() throws Exception {
+            given(userService.resolveUserId(any())).willReturn(1L);
+            ShipmentResponse response = ShipmentResponse.builder()
+                    .id(1L).orderId(1L).status(ShipmentStatus.RETURN_REQUESTED)
+                    .returnReason("단순 변심").build();
+            given(shipmentService.requestReturn(anyLong(), anyLong(), anyString())).willReturn(response);
+
+            mockMvc.perform(post("/api/shipments/orders/1/return-request")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(RETURN_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.status").value("RETURN_REQUESTED"));
+        }
+
+        @Test
+        @DisplayName("인증 없음 → 401")
+        void unauthenticated() throws Exception {
+            mockMvc.perform(post("/api/shipments/orders/1/return-request")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(RETURN_JSON))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @WithMockUser
+        @DisplayName("사유 누락 → 400")
+        void validationFailure() throws Exception {
+            given(userService.resolveUserId(any())).willReturn(1L);
+
+            mockMvc.perform(post("/api/shipments/orders/1/return-request")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"reason\":\"\"}"))
+                    .andExpect(status().isBadRequest());
+        }
+    }
+
+    // ===== PATCH /api/shipments/orders/{orderId}/return-approve =====
+
+    @Nested
+    @DisplayName("PATCH /api/shipments/orders/{orderId}/return-approve")
+    class ReturnApprove {
+
+        @Test
+        @WithMockUser(roles = "ADMIN")
+        @DisplayName("ADMIN — 반품 승인 → 200")
+        void adminApproves() throws Exception {
+            given(shipmentService.approveReturn(1L)).willReturn(mock(ShipmentResponse.class));
+
+            mockMvc.perform(patch("/api/shipments/orders/1/return-approve"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true));
+        }
+
+        @Test
+        @WithMockUser(roles = "USER")
+        @DisplayName("USER — 반품 승인 → 403")
+        void userForbidden() throws Exception {
+            mockMvc.perform(patch("/api/shipments/orders/1/return-approve"))
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    // ===== PATCH /api/shipments/orders/{orderId}/return-reject =====
+
+    @Nested
+    @DisplayName("PATCH /api/shipments/orders/{orderId}/return-reject")
+    class ReturnReject {
+
+        @Test
+        @WithMockUser(roles = "ADMIN")
+        @DisplayName("ADMIN — 반품 거부 → 200")
+        void adminRejects() throws Exception {
+            given(shipmentService.rejectReturn(1L)).willReturn(mock(ShipmentResponse.class));
+
+            mockMvc.perform(patch("/api/shipments/orders/1/return-reject"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true));
+        }
+
+        @Test
+        @WithMockUser(roles = "USER")
+        @DisplayName("USER — 반품 거부 → 403")
+        void userForbidden() throws Exception {
+            mockMvc.perform(patch("/api/shipments/orders/1/return-reject"))
                     .andExpect(status().isForbidden());
         }
     }

--- a/src/test/java/com/stockmanagement/domain/shipment/service/ShipmentServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/shipment/service/ShipmentServiceTest.java
@@ -1,6 +1,7 @@
 package com.stockmanagement.domain.shipment.service;
 
 import com.stockmanagement.common.event.ShipmentDeliveredEvent;
+import com.stockmanagement.common.event.ShipmentReturnedEvent;
 import com.stockmanagement.common.event.ShipmentShippedEvent;
 import com.stockmanagement.common.exception.BusinessException;
 import com.stockmanagement.common.exception.ErrorCode;
@@ -212,6 +213,137 @@ class ShipmentServiceTest {
             given(shipmentRepository.findByOrderId(2L)).willReturn(Optional.of(shippedShipment));
 
             assertThatThrownBy(() -> shipmentService.processReturn(2L))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ErrorCode.INVALID_SHIPMENT_STATUS.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("반품 신청 (requestReturn)")
+    class RequestReturn {
+
+        @Test
+        @DisplayName("DELIVERED 상태 + 본인 주문 → RETURN_REQUESTED")
+        void requestsReturnSuccessfully() {
+            Shipment delivered = Shipment.builder().orderId(1L).build();
+            delivered.ship("CJ", "111", null);
+            delivered.deliver();
+
+            given(orderRepository.findUserIdById(1L)).willReturn(Optional.of(10L));
+            given(shipmentRepository.findByOrderId(1L)).willReturn(Optional.of(delivered));
+
+            ShipmentResponse response = shipmentService.requestReturn(1L, 10L, "단순 변심");
+
+            assertThat(response.getStatus()).isEqualTo(ShipmentStatus.RETURN_REQUESTED);
+            assertThat(response.getReturnReason()).isEqualTo("단순 변심");
+            assertThat(response.getReturnRequestedAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("타인 주문 → SHIPMENT_NOT_FOUND")
+        void throwsWhenNotOwner() {
+            given(orderRepository.findUserIdById(1L)).willReturn(Optional.of(10L));
+
+            assertThatThrownBy(() -> shipmentService.requestReturn(1L, 99L, "사유"))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ErrorCode.SHIPMENT_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("이미 반품 신청됨 → RETURN_ALREADY_REQUESTED")
+        void throwsWhenAlreadyRequested() {
+            Shipment delivered = Shipment.builder().orderId(1L).build();
+            delivered.ship("CJ", "111", null);
+            delivered.deliver();
+            delivered.requestReturn("첫 번째 사유");
+
+            given(orderRepository.findUserIdById(1L)).willReturn(Optional.of(10L));
+            given(shipmentRepository.findByOrderId(1L)).willReturn(Optional.of(delivered));
+
+            assertThatThrownBy(() -> shipmentService.requestReturn(1L, 10L, "두 번째 사유"))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ErrorCode.RETURN_ALREADY_REQUESTED.getMessage());
+        }
+
+        @Test
+        @DisplayName("PREPARING 상태 → INVALID_SHIPMENT_STATUS")
+        void throwsWhenNotDelivered() {
+            given(orderRepository.findUserIdById(1L)).willReturn(Optional.of(10L));
+            given(shipmentRepository.findByOrderId(1L)).willReturn(Optional.of(preparingShipment));
+
+            assertThatThrownBy(() -> shipmentService.requestReturn(1L, 10L, "사유"))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ErrorCode.INVALID_SHIPMENT_STATUS.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("반품 승인 (approveReturn)")
+    class ApproveReturn {
+
+        @Test
+        @DisplayName("RETURN_REQUESTED → RETURNED + 이벤트 발행")
+        void approvesSuccessfully() {
+            Shipment delivered = Shipment.builder().orderId(1L).build();
+            delivered.ship("CJ", "111", null);
+            delivered.deliver();
+            delivered.requestReturn("변심");
+
+            given(shipmentRepository.findByOrderId(1L)).willReturn(Optional.of(delivered));
+
+            ShipmentResponse response = shipmentService.approveReturn(1L);
+
+            assertThat(response.getStatus()).isEqualTo(ShipmentStatus.RETURNED);
+            verify(outboxEventStore).save(any(ShipmentReturnedEvent.class));
+        }
+
+        @Test
+        @DisplayName("DELIVERED 상태에서 승인 → INVALID_SHIPMENT_STATUS")
+        void throwsWhenNotRequested() {
+            Shipment delivered = Shipment.builder().orderId(1L).build();
+            delivered.ship("CJ", "111", null);
+            delivered.deliver();
+
+            given(shipmentRepository.findByOrderId(1L)).willReturn(Optional.of(delivered));
+
+            assertThatThrownBy(() -> shipmentService.approveReturn(1L))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ErrorCode.INVALID_SHIPMENT_STATUS.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("반품 거부 (rejectReturn)")
+    class RejectReturn {
+
+        @Test
+        @DisplayName("RETURN_REQUESTED → DELIVERED (필드 초기화)")
+        void rejectsSuccessfully() {
+            Shipment delivered = Shipment.builder().orderId(1L).build();
+            delivered.ship("CJ", "111", null);
+            delivered.deliver();
+            delivered.requestReturn("변심");
+
+            given(shipmentRepository.findByOrderId(1L)).willReturn(Optional.of(delivered));
+
+            ShipmentResponse response = shipmentService.rejectReturn(1L);
+
+            assertThat(response.getStatus()).isEqualTo(ShipmentStatus.DELIVERED);
+            assertThat(response.getReturnReason()).isNull();
+            assertThat(response.getReturnRequestedAt()).isNull();
+            verify(outboxEventStore, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("DELIVERED 상태에서 거부 → INVALID_SHIPMENT_STATUS")
+        void throwsWhenNotRequested() {
+            Shipment delivered = Shipment.builder().orderId(1L).build();
+            delivered.ship("CJ", "111", null);
+            delivered.deliver();
+
+            given(shipmentRepository.findByOrderId(1L)).willReturn(Optional.of(delivered));
+
+            assertThatThrownBy(() -> shipmentService.rejectReturn(1L))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage(ErrorCode.INVALID_SHIPMENT_STATUS.getMessage());
         }

--- a/src/test/java/com/stockmanagement/integration/ShipmentIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/ShipmentIntegrationTest.java
@@ -152,4 +152,110 @@ class ShipmentIntegrationTest extends AbstractIntegrationTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.status").value("RETURNED"));
     }
+
+    // ===== 사용자 반품 신청 플로우 =====
+
+    /** DELIVERED 상태의 Shipment를 DB에 직접 준비한다. */
+    private long createDeliveredShipment(long orderId) {
+        Shipment shipment = Shipment.builder().orderId(orderId).build();
+        shipment.ship("CJ대한통운", "999888777", null);
+        shipment.deliver();
+        shipmentRepository.save(shipment);
+        return orderId;
+    }
+
+    @Test
+    @DisplayName("사용자 반품 신청 → RETURN_REQUESTED")
+    void requestReturn_success() throws Exception {
+        String userToken = signupAndLogin("buyer", "Password1!", "buyer@test.com");
+        long userId = userRepository.findByUsername("buyer").orElseThrow().getId();
+        long orderId = createConfirmedOrder(userId);
+        createDeliveredShipment(orderId);
+
+        mockMvc.perform(post("/api/shipments/orders/" + orderId + "/return-request")
+                        .header("Authorization", "Bearer " + userToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"reason\":\"단순 변심\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value("RETURN_REQUESTED"))
+                .andExpect(jsonPath("$.data.returnReason").value("단순 변심"))
+                .andExpect(jsonPath("$.data.returnRequestedAt").isNotEmpty());
+    }
+
+    @Test
+    @DisplayName("타인 주문 반품 신청 → 404")
+    void requestReturn_notOwner() throws Exception {
+        String ownerToken = signupAndLogin("owner", "Password1!", "owner@test.com");
+        long ownerId = userRepository.findByUsername("owner").orElseThrow().getId();
+        long orderId = createConfirmedOrder(ownerId);
+        createDeliveredShipment(orderId);
+
+        String otherToken = signupAndLogin("other", "Password1!", "other@test.com");
+
+        mockMvc.perform(post("/api/shipments/orders/" + orderId + "/return-request")
+                        .header("Authorization", "Bearer " + otherToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"reason\":\"도용 시도\"}"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("ADMIN 반품 승인 → RETURNED")
+    void approveReturn_success() throws Exception {
+        String userToken = signupAndLogin("buyer2", "Password1!", "buyer2@test.com");
+        long userId = userRepository.findByUsername("buyer2").orElseThrow().getId();
+        long orderId = createConfirmedOrder(userId);
+        createDeliveredShipment(orderId);
+
+        // 사용자 반품 신청
+        mockMvc.perform(post("/api/shipments/orders/" + orderId + "/return-request")
+                        .header("Authorization", "Bearer " + userToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"reason\":\"사이즈 불일치\"}"))
+                .andExpect(status().isOk());
+
+        // ADMIN 승인
+        String adminToken = createAdminAndLogin("admin2", "adminpass1", "admin2@test.com");
+        mockMvc.perform(patch("/api/shipments/orders/" + orderId + "/return-approve")
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value("RETURNED"));
+    }
+
+    @Test
+    @DisplayName("ADMIN 반품 거부 → DELIVERED 복원")
+    void rejectReturn_success() throws Exception {
+        String userToken = signupAndLogin("buyer3", "Password1!", "buyer3@test.com");
+        long userId = userRepository.findByUsername("buyer3").orElseThrow().getId();
+        long orderId = createConfirmedOrder(userId);
+        createDeliveredShipment(orderId);
+
+        // 사용자 반품 신청
+        mockMvc.perform(post("/api/shipments/orders/" + orderId + "/return-request")
+                        .header("Authorization", "Bearer " + userToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"reason\":\"마음이 바뀜\"}"))
+                .andExpect(status().isOk());
+
+        // ADMIN 거부
+        String adminToken = createAdminAndLogin("admin3", "adminpass1", "admin3@test.com");
+        mockMvc.perform(patch("/api/shipments/orders/" + orderId + "/return-reject")
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value("DELIVERED"))
+                .andExpect(jsonPath("$.data.returnReason").isEmpty());
+    }
+
+    @Test
+    @DisplayName("USER 권한으로 반품 승인 → 403")
+    void approveReturn_userForbidden() throws Exception {
+        String userToken = signupAndLogin("buyer4", "Password1!", "buyer4@test.com");
+        long userId = userRepository.findByUsername("buyer4").orElseThrow().getId();
+        long orderId = createConfirmedOrder(userId);
+        createDeliveredShipment(orderId);
+
+        mockMvc.perform(patch("/api/shipments/orders/" + orderId + "/return-approve")
+                        .header("Authorization", "Bearer " + userToken))
+                .andExpect(status().isForbidden());
+    }
 }


### PR DESCRIPTION
## Summary
- DELIVERED 상태에서 사용자가 직접 반품 신청 가능 (`POST /api/shipments/orders/{orderId}/return-request`)
- ADMIN이 반품 승인(`PATCH .../return-approve`) 또는 거부(`PATCH .../return-reject`) 처리
- 기존 ADMIN 직접 반품 플로우(PREPARING|SHIPPED → RETURNED) 유지

## 변경 사항
- V55 migration: `return_reason`, `return_requested_at` 컬럼 추가
- `ShipmentStatus.RETURN_REQUESTED` 추가
- `Shipment` 엔티티: `requestReturn()`, `approveReturn()`, `rejectReturn()` 메서드
- `ShipmentService`: 3개 메서드 추가 (소유권 검증 포함)
- `ShipmentController`: 3개 엔드포인트 추가
- `SecurityConfig`: POST return-request → authenticated(), PATCH return-approve/reject → ADMIN
- `ErrorCode.RETURN_ALREADY_REQUESTED` 추가

## 상태 전이
```
DELIVERED → RETURN_REQUESTED (사용자 신청)
RETURN_REQUESTED → RETURNED (ADMIN 승인)
RETURN_REQUESTED → DELIVERED (ADMIN 거부)
```

## Test plan
- [x] ShipmentServiceTest: 8개 신규 (requestReturn/approveReturn/rejectReturn)
- [x] ShipmentControllerTest: 7개 신규 (3 엔드포인트 권한/검증)
- [x] ShipmentIntegrationTest: 5개 신규 (E2E 반품 플로우)
- [x] 전체 테스트 통과

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)