### PR TITLE
refactor: 페이지네이션 전략 통일 (#129)

### DIFF
--- a/docs/ToDoFrontRequest.md
+++ b/docs/ToDoFrontRequest.md
@@ -522,21 +522,11 @@ V37 migration. `CartItem.savedPrice` 추가 (담을 당시 가격 스냅샷). `C
 
 ### 🟡 중장기 — API 설계 일관성
 
-**50. 페이지네이션 전략 혼재 (Page vs CursorPage)**
+**50. ~~페이지네이션 전략 혼재 (Page vs CursorPage)~~ → 해결됨**
 
-주문 목록 조회가 두 가지 방식으로 중복 존재한다:
-- `GET /api/orders` → `Page<OrderResponse>` (offset 기반)
-- `GET /api/orders/scroll` → `CursorPage<OrderResponse>` (커서 기반)
-
-재고 이력은 `CursorPage`, 상품/카테고리/쿠폰은 `Page`. 어떤 API가 어떤 방식인지 패턴이 없다.
-프론트에서 API마다 다른 페이지네이션 로직을 작성해야 하고, 무한 스크롤과 페이지 번호 UI를 각각 구현해야 한다.
-
-```
-개선 방향 합의 필요:
-  - 목록 기본: Page (어드민 테이블, 정렬 가능한 목록)
-  - 무한 스크롤: CursorPage (피드형 목록)
-  - GET /api/orders/scroll 제거 또는 GET /api/orders에 통합
-```
+`GET /api/orders/scroll` 제거. 페이지네이션 전략 통일:
+- **목록 기본**: `Page` (어드민 테이블, 정렬·필터 가능)
+- **무한 스크롤**: `CursorPage` (피드형 — 재고 이력 등)
 
 **51. 재고 수량 직접 노출 정책 미비**
 

--- a/src/main/java/com/stockmanagement/domain/order/controller/OrderController.java
+++ b/src/main/java/com/stockmanagement/domain/order/controller/OrderController.java
@@ -2,7 +2,6 @@ package com.stockmanagement.domain.order.controller;
 
 import com.stockmanagement.common.annotation.RequireEmailVerified;
 import com.stockmanagement.common.dto.ApiResponse;
-import com.stockmanagement.common.dto.CursorPage;
 import com.stockmanagement.common.ratelimit.RateLimit;
 import com.stockmanagement.common.security.CurrentUserId;
 import com.stockmanagement.common.security.SecurityUtils;
@@ -14,17 +13,13 @@ import com.stockmanagement.domain.order.dto.OrderPreviewResponse;
 import com.stockmanagement.domain.order.dto.OrderResponse;
 import com.stockmanagement.domain.order.dto.OrderSearchRequest;
 import com.stockmanagement.domain.order.dto.OrderStatusHistoryResponse;
-import com.stockmanagement.domain.order.entity.OrderStatus;
 import com.stockmanagement.domain.order.service.OrderCommandService;
 import com.stockmanagement.domain.order.service.OrderDetailService;
 import com.stockmanagement.domain.order.service.OrderQueryService;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -44,7 +39,6 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/orders")
 @RequiredArgsConstructor
-@Validated
 public class OrderController {
 
     private final OrderQueryService orderQueryService;
@@ -103,28 +97,6 @@ public class OrderController {
         boolean isAdmin = SecurityUtils.isAdmin(authentication);
         Long effectiveUserId = isAdmin ? null : userId;
         return ApiResponse.ok(orderQueryService.getList(effectiveUserId, isAdmin, request, pageable));
-    }
-
-    @Operation(
-        summary = "주문 목록 커서 스크롤 (사용자용)",
-        description = """
-            커서 기반 페이지네이션으로 주문 목록을 최신순 조회한다.
-            - 첫 조회: lastId 없이 호출
-            - 다음 페이지: 이전 응답의 nextCursor를 lastId로 전달
-            - status 필터 지원 (PENDING / CONFIRMED / CANCELLED / REFUNDED)
-            - ADMIN: userId 파라미터로 특정 사용자 주문 스크롤 가능
-            - USER: 본인 주문만 조회 (userId 파라미터 무시)
-            """
-    )
-    @GetMapping("/scroll")
-    public ApiResponse<CursorPage<OrderResponse>> scroll(
-            @CurrentUserId Long userId,
-            Authentication authentication,
-            @RequestParam(required = false) OrderStatus status,
-            @RequestParam(required = false) Long lastId,
-            @Min(1) @Max(100) @RequestParam(defaultValue = "20") int size) {
-        boolean isAdmin = SecurityUtils.isAdmin(authentication);
-        return ApiResponse.ok(orderQueryService.getOrderScroll(userId, isAdmin, status, lastId, size));
     }
 
     @Operation(summary = "주문 취소", description = "PENDING 상태만 취소 가능. 재고 예약 해제(reserved--). ADMIN은 모든 주문 취소 가능.")

--- a/src/main/java/com/stockmanagement/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/stockmanagement/domain/order/repository/OrderRepository.java
@@ -124,41 +124,6 @@ public interface OrderRepository extends JpaRepository<Order, Long>, JpaSpecific
     boolean existsPurchaseByUserIdAndProductId(@Param("userId") Long userId,
                                                @Param("productId") Long productId);
 
-    // ===== 커서 기반 페이지네이션 (사용자 주문 목록 스크롤) =====
-
-    /**
-     * 사용자 주문 목록을 커서 기반으로 최신순 조회한다 (첫 페이지).
-     *
-     * <p>COUNT 쿼리 없이 LIMIT만 사용하여 오프셋 방식 대비 일정한 응답 속도를 보장한다.
-     *
-     * @param userId 조회 대상 사용자 ID
-     * @param status 주문 상태 필터 (null이면 전체)
-     * @param pageable {@code PageRequest.of(0, size+1)} — LIMIT 제어용
-     */
-    @Query("SELECT o FROM Order o WHERE o.userId = :userId " +
-           "AND (:status IS NULL OR o.status = :status) " +
-           "ORDER BY o.id DESC")
-    List<Order> findCursorByUserId(@Param("userId") Long userId,
-                                   @Param("status") OrderStatus status,
-                                   Pageable pageable);
-
-    /**
-     * 사용자 주문 목록을 커서 기반으로 최신순 조회한다 (커서 이후).
-     *
-     * @param userId  조회 대상 사용자 ID
-     * @param status  주문 상태 필터 (null이면 전체)
-     * @param lastId  이전 페이지 마지막 항목의 ID (이 ID 미만부터 조회)
-     * @param pageable {@code PageRequest.of(0, size+1)} — LIMIT 제어용
-     */
-    @Query("SELECT o FROM Order o WHERE o.userId = :userId " +
-           "AND (:status IS NULL OR o.status = :status) " +
-           "AND o.id < :lastId " +
-           "ORDER BY o.id DESC")
-    List<Order> findCursorByUserIdAfter(@Param("userId") Long userId,
-                                        @Param("status") OrderStatus status,
-                                        @Param("lastId") Long lastId,
-                                        Pageable pageable);
-
     // ===== 일별 통계 집계 (DailyOrderStatsScheduler) =====
 
     /** 기간 내 전체 주문 수 (>= start AND < end) */

--- a/src/main/java/com/stockmanagement/domain/order/service/OrderQueryService.java
+++ b/src/main/java/com/stockmanagement/domain/order/service/OrderQueryService.java
@@ -1,6 +1,5 @@
 package com.stockmanagement.domain.order.service;
 
-import com.stockmanagement.common.dto.CursorPage;
 import com.stockmanagement.common.exception.BusinessException;
 import com.stockmanagement.common.exception.ErrorCode;
 import com.stockmanagement.domain.coupon.dto.CouponValidateRequest;
@@ -13,7 +12,6 @@ import com.stockmanagement.domain.order.dto.OrderSearchRequest;
 import com.stockmanagement.domain.order.dto.OrderStatusHistoryResponse;
 import com.stockmanagement.domain.order.entity.Order;
 import com.stockmanagement.domain.order.entity.OrderDeliverySnapshot;
-import com.stockmanagement.domain.order.entity.OrderStatus;
 import com.stockmanagement.domain.order.repository.OrderDeliverySnapshotRepository;
 import com.stockmanagement.domain.order.repository.OrderRepository;
 import com.stockmanagement.domain.order.repository.OrderSpecification;
@@ -28,7 +26,6 @@ import com.stockmanagement.domain.shipment.repository.ShipmentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -113,29 +110,6 @@ public class OrderQueryService {
                 .stream().collect(Collectors.toMap(OrderDeliverySnapshot::getOrderId, s -> s));
 
         return page.map(o -> OrderResponse.from(o, null, statusMap.get(o.getId()), snapshotMap.get(o.getId())));
-    }
-
-    /**
-     * 사용자 주문 목록을 커서 기반으로 최신순 조회한다.
-     *
-     * <p>오프셋 방식과 달리 COUNT 쿼리가 없어 대용량 이력 스크롤에 적합하다.
-     */
-    public CursorPage<OrderResponse> getOrderScroll(Long userId, boolean isAdmin,
-                                                     OrderStatus status, Long lastId, int size) {
-        PageRequest limit = PageRequest.of(0, size + 1);
-        List<Order> items = lastId == null
-                ? orderRepository.findCursorByUserId(userId, status, limit)
-                : orderRepository.findCursorByUserIdAfter(userId, status, lastId, limit);
-        // 배송 상태 + 배송지 스냅샷 배치 조회 (N+1 방지)
-        List<Long> orderIds = items.stream().map(Order::getId).toList();
-        Map<Long, ShipmentStatus> statusMap = shipmentRepository.findStatusMapByOrderIds(orderIds);
-        Map<Long, OrderDeliverySnapshot> snapshotMap = deliverySnapshotRepository.findByOrderIdIn(orderIds)
-                .stream().collect(Collectors.toMap(OrderDeliverySnapshot::getOrderId, s -> s));
-
-        return CursorPage.of(
-                items.stream().map(o -> OrderResponse.from(o, null, statusMap.get(o.getId()), snapshotMap.get(o.getId()))).toList(),
-                size,
-                OrderResponse::getId);
     }
 
     /**


### PR DESCRIPTION
## Summary
- `GET /api/orders/scroll` (커서 기반) 엔드포인트 제거
- 주문 목록 조회는 `GET /api/orders` (offset/Page) 단일 방식으로 통일
- `CursorPage`는 재고 이력 등 무한 스크롤이 필요한 곳에서 계속 사용

## 변경 사항
- `OrderController`: `scroll()` 메서드 + 관련 import 제거
- `OrderQueryService`: `getOrderScroll()` 메서드 + 관련 import 제거
- `OrderRepository`: `findCursorByUserId()`, `findCursorByUserIdAfter()` 제거
- `docs/ToDoFrontRequest.md`: #50 해결됨 표시

## Test plan
- [x] 전체 테스트 통과 (scroll 관련 테스트 없었으므로 삭제할 테스트 없음)
- [x] CursorPage 클래스 유지 (재고 이력에서 사용 중)

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)