### PR TITLE
feat: 상품 변형(ProductVariant) 시스템 도입

### DIFF
--- a/src/main/java/com/stockmanagement/common/config/SecurityConfig.java
+++ b/src/main/java/com/stockmanagement/common/config/SecurityConfig.java
@@ -105,6 +105,10 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/shipping/policy").permitAll()
                         // 상품 조회 — 비로그인 허용 (쇼핑몰 특성상 누구나 열람 가능)
                         .requestMatchers(HttpMethod.GET, "/api/products/**").permitAll()
+                        // 상품 변형 — 추가·수정·삭제는 ADMIN 전용 (GET은 상품 조회 공개 규칙에 포함)
+                        .requestMatchers(HttpMethod.POST, "/api/products/*/variants").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.PUT, "/api/products/*/variants/*").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.DELETE, "/api/products/*/variants/*").hasRole("ADMIN")
                         // 상품 이미지 — Presigned URL 발급·저장·삭제는 ADMIN 전용
                         .requestMatchers(HttpMethod.POST, "/api/products/*/images/presigned").hasRole("ADMIN")
                         .requestMatchers(HttpMethod.POST, "/api/products/*/images").hasRole("ADMIN")

--- a/src/main/java/com/stockmanagement/common/event/LowStockEvent.java
+++ b/src/main/java/com/stockmanagement/common/event/LowStockEvent.java
@@ -10,12 +10,17 @@ public class LowStockEvent extends DomainEvent {
 
     private final Long productId;
     private final String productName;
+    private final Long variantId;
+    private final String variantOptionName;
     private final int available;
 
-    public LowStockEvent(Long productId, String productName, int available) {
+    public LowStockEvent(Long productId, String productName,
+                         Long variantId, String variantOptionName, int available) {
         super();
         this.productId = productId;
         this.productName = productName;
+        this.variantId = variantId;
+        this.variantOptionName = variantOptionName;
         this.available = available;
     }
 }

--- a/src/main/java/com/stockmanagement/common/event/RestockEvent.java
+++ b/src/main/java/com/stockmanagement/common/event/RestockEvent.java
@@ -8,12 +8,17 @@ public class RestockEvent extends DomainEvent {
 
     private final Long productId;
     private final String productName;
+    private final Long variantId;
+    private final String variantOptionName;
     private final int available;
 
-    public RestockEvent(Long productId, String productName, int available) {
+    public RestockEvent(Long productId, String productName,
+                        Long variantId, String variantOptionName, int available) {
         super();
         this.productId = productId;
         this.productName = productName;
+        this.variantId = variantId;
+        this.variantOptionName = variantOptionName;
         this.available = available;
     }
 }

--- a/src/main/java/com/stockmanagement/common/exception/ErrorCode.java
+++ b/src/main/java/com/stockmanagement/common/exception/ErrorCode.java
@@ -22,6 +22,10 @@ public enum ErrorCode {
     PRODUCT_NOT_AVAILABLE(HttpStatus.UNPROCESSABLE_ENTITY, "판매 중이 아닌 상품은 주문할 수 없습니다."),
     DUPLICATE_SKU(HttpStatus.CONFLICT, "이미 존재하는 SKU입니다."),
 
+    // ===== ProductVariant =====
+    VARIANT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품 변형을 찾을 수 없습니다."),
+    VARIANT_NOT_AVAILABLE(HttpStatus.UNPROCESSABLE_ENTITY, "판매 중이 아닌 변형은 주문할 수 없습니다."),
+
     // ===== Inventory =====
     INVENTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "재고 정보를 찾을 수 없습니다."),
     INSUFFICIENT_STOCK(HttpStatus.CONFLICT, "재고가 부족합니다."),

--- a/src/main/java/com/stockmanagement/domain/inventory/controller/InventoryController.java
+++ b/src/main/java/com/stockmanagement/domain/inventory/controller/InventoryController.java
@@ -27,11 +27,11 @@ import org.springframework.web.bind.annotation.*;
  * <p>Base URL: {@code /api/inventory}
  *
  * <pre>
- * GET  /api/inventory                            재고 목록 검색   → 200 OK (Page)
- * GET  /api/inventory/{productId}                재고 현황 조회   → 200 OK
- * GET  /api/inventory/{productId}/transactions   재고 이력 조회   → 200 OK
- * POST /api/inventory/{productId}/receive        입고 처리        → 200 OK
- * POST /api/inventory/{productId}/adjust         수동 조정        → 200 OK
+ * GET  /api/inventory                                     재고 목록 검색   → 200 OK (Page)
+ * GET  /api/inventory/variants/{variantId}                재고 현황 조회   → 200 OK
+ * GET  /api/inventory/variants/{variantId}/transactions   재고 이력 조회   → 200 OK
+ * POST /api/inventory/variants/{variantId}/receive        입고 처리        → 200 OK
+ * POST /api/inventory/variants/{variantId}/adjust         수동 조정        → 200 OK
  * </pre>
  *
  * <p>reserve / releaseReservation / confirmAllocation 은 Order·Payment 도메인에서
@@ -65,9 +65,9 @@ public class InventoryController {
     }
 
     @Operation(summary = "재고 현황 조회", description = "onHand / reserved / allocated / available 반환.")
-    @GetMapping("/{productId}")
-    public ApiResponse<InventoryResponse> getByProductId(@PathVariable Long productId) {
-        return ApiResponse.ok(inventoryService.getByProductId(productId));
+    @GetMapping("/variants/{variantId}")
+    public ApiResponse<InventoryResponse> getByVariantId(@PathVariable Long variantId) {
+        return ApiResponse.ok(inventoryService.getByVariantId(variantId));
     }
 
     @Operation(
@@ -79,27 +79,27 @@ public class InventoryController {
             - hasNext=false이면 마지막 페이지
             """
     )
-    @GetMapping("/{productId}/transactions")
+    @GetMapping("/variants/{variantId}/transactions")
     public ApiResponse<CursorPage<InventoryTransactionResponse>> getTransactions(
-            @PathVariable Long productId,
+            @PathVariable Long variantId,
             @RequestParam(required = false) Long lastId,
             @Min(1) @Max(100) @RequestParam(defaultValue = "20") int size) {
-        return ApiResponse.ok(inventoryService.getTransactions(productId, lastId, size));
+        return ApiResponse.ok(inventoryService.getTransactions(variantId, lastId, size));
     }
 
     @Operation(summary = "입고 처리", description = "ADMIN 전용. onHand 증가 → available 증가.")
-    @PostMapping("/{productId}/receive")
+    @PostMapping("/variants/{variantId}/receive")
     public ApiResponse<InventoryResponse> receive(
-            @PathVariable Long productId,
+            @PathVariable Long variantId,
             @RequestBody @Valid InventoryReceiveRequest request) {
-        return ApiResponse.ok(inventoryService.receive(productId, request));
+        return ApiResponse.ok(inventoryService.receive(variantId, request));
     }
 
     @Operation(summary = "재고 수동 조정", description = "ADMIN 전용. quantity 양수=증가, 음수=감소.")
-    @PostMapping("/{productId}/adjust")
+    @PostMapping("/variants/{variantId}/adjust")
     public ApiResponse<InventoryResponse> adjust(
-            @PathVariable Long productId,
+            @PathVariable Long variantId,
             @RequestBody @Valid InventoryAdjustRequest request) {
-        return ApiResponse.ok(inventoryService.adjust(productId, request));
+        return ApiResponse.ok(inventoryService.adjust(variantId, request));
     }
 }

--- a/src/main/java/com/stockmanagement/domain/inventory/dto/InventoryResponse.java
+++ b/src/main/java/com/stockmanagement/domain/inventory/dto/InventoryResponse.java
@@ -1,6 +1,8 @@
 package com.stockmanagement.domain.inventory.dto;
 
 import com.stockmanagement.domain.inventory.entity.Inventory;
+import com.stockmanagement.domain.product.entity.Product;
+import com.stockmanagement.domain.product.entity.ProductVariant;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.extern.jackson.Jacksonized;
@@ -26,6 +28,11 @@ public class InventoryResponse {
     private final String productName;
     private final String category;
 
+    /** variant 식별 정보 */
+    private final Long variantId;
+    private final String variantOptionName;
+    private final String variantSku;
+
     /** 창고 실물 재고 */
     private final int onHand;
 
@@ -42,11 +49,16 @@ public class InventoryResponse {
 
     /** Inventory 엔티티를 응답 DTO로 변환하는 정적 팩토리 메서드 */
     public static InventoryResponse from(Inventory inventory) {
+        ProductVariant variant = inventory.getVariant();
+        Product product = variant.getProduct();
         return InventoryResponse.builder()
                 .id(inventory.getId())
-                .productId(inventory.getProduct().getId())
-                .productName(inventory.getProduct().getName())
-                .category(inventory.getProduct().getCategoryName())
+                .productId(product.getId())
+                .productName(product.getName())
+                .category(product.getCategoryName())
+                .variantId(variant.getId())
+                .variantOptionName(variant.getOptionName())
+                .variantSku(variant.getSku())
                 .onHand(inventory.getOnHand())
                 .reserved(inventory.getReserved())
                 .allocated(inventory.getAllocated())

--- a/src/main/java/com/stockmanagement/domain/inventory/entity/Inventory.java
+++ b/src/main/java/com/stockmanagement/domain/inventory/entity/Inventory.java
@@ -4,6 +4,7 @@ import com.stockmanagement.common.exception.BusinessException;
 import com.stockmanagement.common.exception.ErrorCode;
 import com.stockmanagement.common.exception.InsufficientStockException;
 import com.stockmanagement.domain.product.entity.Product;
+import com.stockmanagement.domain.product.entity.ProductVariant;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -18,7 +19,7 @@ import java.time.LocalDateTime;
 /**
  * 재고 엔티티.
  *
- * <p>상품(Product) 1개당 재고 레코드 1개가 존재한다 (1:1 관계).
+ * <p>상품 변형(ProductVariant) 1개당 재고 레코드 1개가 존재한다 (1:1 관계).
  *
  * <p>재고 수량 모델:
  * <ul>
@@ -45,9 +46,14 @@ public class Inventory {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    /** 연관 상품 — 지연 로딩으로 불필요한 JOIN을 방지한다 */
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "product_id", nullable = false, unique = true)
+    /** 연관 변형 — variant당 재고 레코드 1:1 */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "variant_id", nullable = false, unique = true)
+    private ProductVariant variant;
+
+    /** 연관 상품 — variant.product와 동일. product_id NOT NULL 제약을 위해 INSERT 시 자동 설정. */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
     private Product product;
 
     /** 창고 실물 재고 */
@@ -79,12 +85,13 @@ public class Inventory {
     private LocalDateTime updatedAt;
 
     /**
-     * 상품에 대한 초기 재고 레코드를 생성한다.
+     * 변형에 대한 초기 재고 레코드를 생성한다.
      * 최초 생성 시 모든 수량은 0으로 초기화된다.
      */
     @Builder
-    private Inventory(Product product) {
-        this.product = product;
+    private Inventory(ProductVariant variant) {
+        this.variant = variant;
+        this.product = variant != null ? variant.getProduct() : null;
         this.onHand = 0;
         this.reserved = 0;
         this.allocated = 0;
@@ -163,9 +170,9 @@ public class Inventory {
         }
         if (quantity > this.reserved) {
             throw new BusinessException(ErrorCode.INVENTORY_STATE_INCONSISTENT,
-                    String.format("confirmAllocation 실패: quantity=%d > reserved=%d (productId=%s)",
+                    String.format("confirmAllocation 실패: quantity=%d > reserved=%d (variantId=%s)",
                             quantity, this.reserved,
-                            this.product != null ? this.product.getId() : "unknown"));
+                            this.variant != null ? this.variant.getId() : "unknown"));
         }
         this.reserved -= quantity;
         this.allocated += quantity;

--- a/src/main/java/com/stockmanagement/domain/inventory/repository/InventoryRepository.java
+++ b/src/main/java/com/stockmanagement/domain/inventory/repository/InventoryRepository.java
@@ -22,40 +22,48 @@ import java.util.Optional;
  *
  * <p>동시성 제어를 위해 두 가지 조회 메서드를 제공한다:
  * <ul>
- *   <li>{@link #findByProductId} — 단순 조회 (읽기 전용)
- *   <li>{@link #findByProductIdWithLock} — 비관적 락 조회 (입고 등 쓰기 전용)
+ *   <li>{@link #findByVariantId} — 단순 조회 (읽기 전용)
+ *   <li>{@link #findByVariantIdWithLock} — 비관적 락 조회 (입고 등 쓰기 전용)
  * </ul>
  */
 public interface InventoryRepository extends JpaRepository<Inventory, Long>, JpaSpecificationExecutor<Inventory> {
 
-    /** 상품 ID로 재고를 조회한다 (읽기 전용). product를 JOIN FETCH하여 N+1 방지. */
-    @EntityGraph(attributePaths = {"product"})
-    Optional<Inventory> findByProductId(Long productId);
+    /** variant ID로 재고를 조회한다 (읽기 전용). variant+product를 JOIN FETCH하여 N+1 방지. */
+    @EntityGraph(attributePaths = {"variant", "variant.product"})
+    Optional<Inventory> findByVariantId(Long variantId);
 
     /**
-     * 상품 ID로 재고를 조회하되 비관적 쓰기 락을 건다.
+     * variant ID로 재고를 조회하되 비관적 쓰기 락을 건다.
      *
      * <p>입고(receive) 같이 onHand를 수정하는 고빈도 쓰기 작업에 사용한다.
      * 같은 재고를 동시에 수정하는 트랜잭션이 있으면 한 쪽이 락 해제를 기다린다.
      * {@code @Version} 낙관적 락과 병행 사용해 이중으로 보호한다.
      */
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("SELECT i FROM Inventory i WHERE i.product.id = :productId")
-    Optional<Inventory> findByProductIdWithLock(@Param("productId") Long productId);
+    @Query("SELECT i FROM Inventory i WHERE i.variant.id = :variantId")
+    Optional<Inventory> findByVariantIdWithLock(@Param("variantId") Long variantId);
 
-    /** 여러 상품의 재고를 한 번에 조회한다. product를 JOIN FETCH하여 N+1 방지. */
-    @EntityGraph(attributePaths = {"product"})
-    List<Inventory> findAllByProductIdIn(Collection<Long> productIds);
+    /** 여러 variant의 재고를 한 번에 조회한다. variant+product를 JOIN FETCH하여 N+1 방지. */
+    @EntityGraph(attributePaths = {"variant", "variant.product"})
+    List<Inventory> findAllByVariantIdIn(Collection<Long> variantIds);
+
+    /** 상품의 모든 variant 재고를 조회한다 (상세 조회용). */
+    @Query("SELECT i FROM Inventory i JOIN FETCH i.variant v WHERE v.product.id = :productId")
+    List<Inventory> findAllByProductId(@Param("productId") Long productId);
+
+    /** 여러 상품의 variant 재고를 한 번에 조회한다 (목록 조회용, N+1 방지). */
+    @Query("SELECT i FROM Inventory i JOIN FETCH i.variant v WHERE v.product.id IN :productIds")
+    List<Inventory> findAllByProductIdIn(@Param("productIds") Collection<Long> productIds);
 
     /** available(= onHand - reserved - allocated)이 threshold 미만인 저재고 목록 (대시보드용) */
-    @Query("SELECT i FROM Inventory i JOIN FETCH i.product WHERE (i.onHand - i.reserved - i.allocated) < :threshold")
+    @Query("SELECT i FROM Inventory i JOIN FETCH i.variant v JOIN FETCH v.product WHERE (i.onHand - i.reserved - i.allocated) < :threshold")
     List<Inventory> findLowStock(@Param("threshold") int threshold);
 
     /**
-     * 동적 조건 검색 — product를 EntityGraph로 즉시 로딩해 N+1을 방지한다.
+     * 동적 조건 검색 — variant+product를 EntityGraph로 즉시 로딩해 N+1을 방지한다.
      * {@link InventorySpecification}으로 생성한 Specification을 전달한다.
      */
-    @EntityGraph(attributePaths = {"product"})
+    @EntityGraph(attributePaths = {"variant", "variant.product"})
     @Override
     Page<Inventory> findAll(Specification<Inventory> spec, Pageable pageable);
 

--- a/src/main/java/com/stockmanagement/domain/inventory/repository/InventorySpecification.java
+++ b/src/main/java/com/stockmanagement/domain/inventory/repository/InventorySpecification.java
@@ -4,6 +4,7 @@ import com.stockmanagement.domain.inventory.dto.InventorySearchRequest;
 import com.stockmanagement.domain.inventory.entity.Inventory;
 import com.stockmanagement.domain.inventory.entity.InventoryStatus;
 import com.stockmanagement.domain.product.entity.Product;
+import com.stockmanagement.domain.product.entity.ProductVariant;
 import jakarta.persistence.criteria.*;
 import org.springframework.data.jpa.domain.Specification;
 
@@ -36,8 +37,9 @@ public class InventorySpecification {
         return (root, query, cb) -> {
             List<Predicate> predicates = new ArrayList<>();
 
-            // product JOIN (필터용 — FETCH 아님, EntityGraph에서 별도 로딩)
-            Join<Inventory, Product> product = root.join("product", JoinType.INNER);
+            // variant → product JOIN 체인 (필터용 — FETCH 아님, EntityGraph에서 별도 로딩)
+            Join<Inventory, ProductVariant> variant = root.join("variant", JoinType.INNER);
+            Join<ProductVariant, Product> product = variant.join("product", JoinType.INNER);
 
             // available = onHand - reserved - allocated (Criteria 연산)
             Expression<Integer> available = cb.diff(

--- a/src/main/java/com/stockmanagement/domain/inventory/repository/InventoryTransactionRepository.java
+++ b/src/main/java/com/stockmanagement/domain/inventory/repository/InventoryTransactionRepository.java
@@ -8,10 +8,10 @@ import java.util.List;
 
 public interface InventoryTransactionRepository extends JpaRepository<InventoryTransaction, Long> {
 
-    /** 첫 페이지: 특정 상품 재고 이력을 ID 내림차순으로 최대 size+1건 조회. */
-    List<InventoryTransaction> findByInventoryProductIdOrderByIdDesc(Long productId, Pageable pageable);
+    /** 첫 페이지: 특정 재고의 이력을 ID 내림차순으로 최대 size+1건 조회. */
+    List<InventoryTransaction> findByInventoryIdOrderByIdDesc(Long inventoryId, Pageable pageable);
 
     /** 커서 이후: lastId보다 작은 재고 이력을 ID 내림차순으로 최대 size+1건 조회. */
-    List<InventoryTransaction> findByInventoryProductIdAndIdLessThanOrderByIdDesc(
-            Long productId, Long lastId, Pageable pageable);
+    List<InventoryTransaction> findByInventoryIdAndIdLessThanOrderByIdDesc(
+            Long inventoryId, Long lastId, Pageable pageable);
 }

--- a/src/main/java/com/stockmanagement/domain/inventory/service/InventoryService.java
+++ b/src/main/java/com/stockmanagement/domain/inventory/service/InventoryService.java
@@ -19,18 +19,21 @@ import com.stockmanagement.common.dto.CursorPage;
 import com.stockmanagement.common.event.LowStockEvent;
 import com.stockmanagement.common.event.RestockEvent;
 import com.stockmanagement.domain.product.entity.Product;
-import com.stockmanagement.domain.product.repository.ProductRepository;
+import com.stockmanagement.domain.product.entity.ProductVariant;
+import com.stockmanagement.domain.product.repository.ProductVariantRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
-import org.springframework.cache.annotation.Caching;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
 
 
 /**
@@ -45,7 +48,7 @@ import org.springframework.transaction.annotation.Transactional;
  * <p>동시성 2중 제어:
  * <ul>
  *   <li>분산 락({@link DistributedLock}): 멀티 인스턴스 환경에서 Redis를 통한 외부 락
- *   <li>비관적 락({@code findByProductIdWithLock}): 단일 인스턴스 DB 레벨 보조 락
+ *   <li>비관적 락({@code findByVariantIdWithLock}): 단일 인스턴스 DB 레벨 보조 락
  * </ul>
  */
 @Slf4j
@@ -56,16 +59,14 @@ public class InventoryService {
 
     private final InventoryRepository inventoryRepository;
     private final InventoryTransactionRepository transactionRepository;
-    private final ProductRepository productRepository;
+    private final ProductVariantRepository variantRepository;
     private final ApplicationEventPublisher eventPublisher;
     private final SystemSettingService systemSettingService;
+    private final CacheManager cacheManager;
 
     /**
      * 재고 목록을 조건 필터링 + 페이지네이션으로 조회한다.
      * 모든 필터 조건은 선택적이며, AND로 결합된다.
-     *
-     * @param request  status / minAvailable / maxAvailable / productName / category 필터
-     * @param pageable page / size / sort
      */
     public Page<InventoryResponse> search(InventorySearchRequest request, Pageable pageable) {
         return inventoryRepository.findAll(InventorySpecification.of(request), pageable)
@@ -73,31 +74,32 @@ public class InventoryService {
     }
 
     /**
-     * 상품의 재고 현황을 조회한다.
+     * variant의 재고 현황을 조회한다.
      * 재고 레코드가 없으면 404 예외를 발생시킨다.
      * 결과를 Redis에 캐싱한다 (TTL: 5분, write 시 명시적 evict).
      */
-    @Cacheable(cacheNames = "inventory", key = "#productId")
-    public InventoryResponse getByProductId(Long productId) {
-        return InventoryResponse.from(findByProductId(productId));
+    @Cacheable(cacheNames = "inventory", key = "#variantId")
+    public InventoryResponse getByVariantId(Long variantId) {
+        return InventoryResponse.from(findByVariantId(variantId));
     }
 
     /**
-     * 상품의 재고 변동 이력을 커서 기반으로 최신순 조회한다.
+     * variant의 재고 변동 이력을 커서 기반으로 최신순 조회한다.
      *
      * <p>오프셋 페이지네이션 대신 {@code WHERE id < :lastId} 커서 방식을 사용하여
      * 페이지 번호가 늘어나도 앞 레코드를 스캔하지 않는다.
      *
-     * @param productId 조회 대상 상품 ID
+     * @param variantId 조회 대상 variant ID
      * @param lastId    이전 페이지의 마지막 항목 ID (첫 조회 시 null)
      * @param size      한 페이지 항목 수
      */
-    public CursorPage<InventoryTransactionResponse> getTransactions(Long productId, Long lastId, int size) {
-        findByProductId(productId); // 재고 존재 여부 확인
+    public CursorPage<InventoryTransactionResponse> getTransactions(Long variantId, Long lastId, int size) {
+        Inventory inventory = findByVariantId(variantId);
+        Long inventoryId = inventory.getId();
         PageRequest limit = PageRequest.of(0, size + 1);
         var items = lastId == null
-                ? transactionRepository.findByInventoryProductIdOrderByIdDesc(productId, limit)
-                : transactionRepository.findByInventoryProductIdAndIdLessThanOrderByIdDesc(productId, lastId, limit);
+                ? transactionRepository.findByInventoryIdOrderByIdDesc(inventoryId, limit)
+                : transactionRepository.findByInventoryIdAndIdLessThanOrderByIdDesc(inventoryId, lastId, limit);
         return CursorPage.of(
                 items.stream().map(InventoryTransactionResponse::from).toList(),
                 size,
@@ -105,33 +107,30 @@ public class InventoryService {
     }
 
     /**
-     * 상품에 재고를 입고한다.
+     * variant에 재고를 입고한다.
      *
      * <p>처리 흐름:
      * <ol>
      *   <li>분산 락 획득
-     *   <li>상품 존재 여부 확인
-     *   <li>재고 레코드가 없으면 자동 생성 (상품 등록 후 첫 입고)
+     *   <li>variant 존재 여부 확인
+     *   <li>재고 레코드가 없으면 자동 생성 (variant 등록 후 첫 입고)
      *   <li>비관적 락으로 재고 행을 잠근 뒤 onHand 증가
      *   <li>이력 기록
      * </ol>
      *
-     * @param productId 입고 대상 상품 ID
+     * @param variantId 입고 대상 variant ID
      * @param request   입고 수량 및 메모
      */
-    @DistributedLock(key = "'inventory:' + #productId")
+    @DistributedLock(key = "'inventory:' + #variantId")
     @Transactional
-    @Caching(evict = {
-            @CacheEvict(cacheNames = "inventory", key = "#productId"),
-            @CacheEvict(cacheNames = "products",  key = "#productId")
-    })
-    public InventoryResponse receive(Long productId, InventoryReceiveRequest request) {
-        Product product = productRepository.findById(productId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND));
+    @CacheEvict(cacheNames = "inventory", key = "#variantId")
+    public InventoryResponse receive(Long variantId, InventoryReceiveRequest request) {
+        ProductVariant variant = variantRepository.findByIdWithProduct(variantId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.VARIANT_NOT_FOUND));
 
-        Inventory inventory = inventoryRepository.findByProductIdWithLock(productId)
+        Inventory inventory = inventoryRepository.findByVariantIdWithLock(variantId)
                 .orElseGet(() -> inventoryRepository.save(
-                        Inventory.builder().product(product).build()
+                        Inventory.builder().variant(variant).build()
                 ));
 
         int availableBefore = inventory.getAvailable();
@@ -139,33 +138,35 @@ public class InventoryService {
         recordTransaction(inventory, InventoryTransactionType.RECEIVE, request.getQuantity(), request.getNote());
 
         // 재입고 알림 — 가용 재고가 0에서 양수로 전환될 때 발행
+        Product product = variant.getProduct();
         if (availableBefore <= 0 && inventory.getAvailable() > 0) {
             eventPublisher.publishEvent(new RestockEvent(
-                    productId, product.getName(), inventory.getAvailable()));
+                    product.getId(), product.getName(),
+                    variant.getId(), variant.getOptionName(),
+                    inventory.getAvailable()));
         }
 
+        evictProductCache(product.getId());
         return InventoryResponse.from(inventory);
     }
 
     /**
      * 관리자 수동 재고 조정.
      *
-     * @param productId 조정 대상 상품 ID
+     * @param variantId 조정 대상 variant ID
      * @param request   조정 수량(양수/음수) 및 사유
      */
-    @DistributedLock(key = "'inventory:' + #productId")
+    @DistributedLock(key = "'inventory:' + #variantId")
     @Transactional
-    @Caching(evict = {
-            @CacheEvict(cacheNames = "inventory", key = "#productId"),
-            @CacheEvict(cacheNames = "products",  key = "#productId")
-    })
-    public InventoryResponse adjust(Long productId, InventoryAdjustRequest request) {
+    @CacheEvict(cacheNames = "inventory", key = "#variantId")
+    public InventoryResponse adjust(Long variantId, InventoryAdjustRequest request) {
         if (request.getQuantity() == 0) {
             throw new BusinessException(ErrorCode.INVALID_INPUT);
         }
-        Inventory inventory = findByProductIdWithLock(productId);
+        Inventory inventory = findByVariantIdWithLock(variantId);
         inventory.adjust(request.getQuantity());
         recordTransaction(inventory, InventoryTransactionType.ADJUSTMENT, request.getQuantity(), request.getNote());
+        evictProductCache(inventory.getVariant().getProduct().getId());
         return InventoryResponse.from(inventory);
     }
 
@@ -178,99 +179,98 @@ public class InventoryService {
      * <p>동시성 이중 방어:
      * <ul>
      *   <li>@DistributedLock(Redisson) — 멀티 인스턴스 간 상호 배제 (외부 락)
-     *   <li>findByProductIdWithLock(SELECT FOR UPDATE) — 단일 DB 트랜잭션 내 비관적 락 (내부 락)
+     *   <li>findByVariantIdWithLock(SELECT FOR UPDATE) — 단일 DB 트랜잭션 내 비관적 락 (내부 락)
      * </ul>
      * Redis 장애 시 Redisson 락이 누락되더라도 DB 비관적 락이 최후 방어선으로 동작한다.
-     * releaseReservation(), allocate(), releaseAllocation()도 동일한 이중 락 구조를 따른다.
+     * releaseReservation(), confirmAllocation(), releaseAllocation()도 동일한 이중 락 구조를 따른다.
      */
-    @DistributedLock(key = "'inventory:' + #productId")
+    @DistributedLock(key = "'inventory:' + #variantId")
     @Transactional
-    @Caching(evict = {
-            @CacheEvict(cacheNames = "inventory", key = "#productId"),
-            @CacheEvict(cacheNames = "products",  key = "#productId")
-    })
-    public void reserve(Long productId, int quantity) {
-        Inventory inventory = findByProductIdWithLock(productId);
+    @CacheEvict(cacheNames = "inventory", key = "#variantId")
+    public void reserve(Long variantId, int quantity) {
+        Inventory inventory = findByVariantIdWithLock(variantId);
         int availableBefore = inventory.getAvailable() + quantity; // reserve 전 가용 재고
         inventory.reserve(quantity);
         recordTransaction(inventory, InventoryTransactionType.RESERVE, quantity);
 
         // 저재고 경보 — 임계값을 처음 하향 돌파하는 순간에만 발행 (중복 이메일 방지)
-        // systemSettingService 캐시(1시간 TTL)로 DB 조회 부담 없음
+        ProductVariant variant = inventory.getVariant();
+        Product product = variant.getProduct();
         int threshold = systemSettingService.getLowStockThreshold();
         if (availableBefore >= threshold && inventory.getAvailable() < threshold) {
             eventPublisher.publishEvent(new LowStockEvent(
-                    productId,
-                    inventory.getProduct().getName(),
+                    product.getId(), product.getName(),
+                    variant.getId(), variant.getOptionName(),
                     inventory.getAvailable()));
         }
+        evictProductCache(product.getId());
     }
 
     /** 주문 취소 또는 결제 실패 시 예약을 해제한다. */
-    @DistributedLock(key = "'inventory:' + #productId")
+    @DistributedLock(key = "'inventory:' + #variantId")
     @Transactional
-    @Caching(evict = {
-            @CacheEvict(cacheNames = "inventory", key = "#productId"),
-            @CacheEvict(cacheNames = "products",  key = "#productId")
-    })
-    public void releaseReservation(Long productId, int quantity) {
-        Inventory inventory = findByProductIdWithLock(productId);
+    @CacheEvict(cacheNames = "inventory", key = "#variantId")
+    public void releaseReservation(Long variantId, int quantity) {
+        Inventory inventory = findByVariantIdWithLock(variantId);
         if (inventory.getReserved() < quantity) {
-            // 음수 reserved는 available 계산을 오염시켜 품절 상품이 주문 가능 상태로 노출됨
-            // 경고 후 진행하지 않고 즉시 예외를 던져 데이터 정합성 위반을 빠르게 감지한다
             throw new BusinessException(ErrorCode.INVENTORY_STATE_INCONSISTENT,
-                    String.format("[Inventory] reserved 불일치: productId=%d, reserved=%d, 해제요청=%d",
-                            productId, inventory.getReserved(), quantity));
+                    String.format("[Inventory] reserved 불일치: variantId=%d, reserved=%d, 해제요청=%d",
+                            variantId, inventory.getReserved(), quantity));
         }
         inventory.releaseReservation(quantity);
         recordTransaction(inventory, InventoryTransactionType.RELEASE_RESERVATION, quantity);
+        evictProductCache(inventory.getVariant().getProduct().getId());
     }
 
     /** 결제 완료 시 예약을 확정(allocated)으로 전환한다. */
-    @DistributedLock(key = "'inventory:' + #productId")
+    @DistributedLock(key = "'inventory:' + #variantId")
     @Transactional
-    @Caching(evict = {
-            @CacheEvict(cacheNames = "inventory", key = "#productId"),
-            @CacheEvict(cacheNames = "products",  key = "#productId")
-    })
-    public void confirmAllocation(Long productId, int quantity) {
-        Inventory inventory = findByProductIdWithLock(productId);
+    @CacheEvict(cacheNames = "inventory", key = "#variantId")
+    public void confirmAllocation(Long variantId, int quantity) {
+        Inventory inventory = findByVariantIdWithLock(variantId);
         inventory.confirmAllocation(quantity);
         recordTransaction(inventory, InventoryTransactionType.CONFIRM_ALLOCATION, quantity);
+        evictProductCache(inventory.getVariant().getProduct().getId());
     }
 
     /**
      * 결제 취소(환불) 시 확정 재고를 해제한다.
      * allocated를 감소시켜 available을 복구한다.
      */
-    @DistributedLock(key = "'inventory:' + #productId")
+    @DistributedLock(key = "'inventory:' + #variantId")
     @Transactional
-    @Caching(evict = {
-            @CacheEvict(cacheNames = "inventory", key = "#productId"),
-            @CacheEvict(cacheNames = "products",  key = "#productId")
-    })
-    public void releaseAllocation(Long productId, int quantity) {
-        Inventory inventory = findByProductIdWithLock(productId);
+    @CacheEvict(cacheNames = "inventory", key = "#variantId")
+    public void releaseAllocation(Long variantId, int quantity) {
+        Inventory inventory = findByVariantIdWithLock(variantId);
         if (inventory.getAllocated() < quantity) {
             throw new BusinessException(ErrorCode.INVENTORY_STATE_INCONSISTENT,
-                    String.format("[Inventory] allocated 불일치: productId=%d, allocated=%d, 해제요청=%d",
-                            productId, inventory.getAllocated(), quantity));
+                    String.format("[Inventory] allocated 불일치: variantId=%d, allocated=%d, 해제요청=%d",
+                            variantId, inventory.getAllocated(), quantity));
         }
         inventory.releaseAllocation(quantity);
         recordTransaction(inventory, InventoryTransactionType.RELEASE_ALLOCATION, quantity);
+        evictProductCache(inventory.getVariant().getProduct().getId());
     }
 
     // ===== private 헬퍼 =====
 
-    private Inventory findByProductId(Long productId) {
-        return inventoryRepository.findByProductId(productId)
+    private Inventory findByVariantId(Long variantId) {
+        return inventoryRepository.findByVariantId(variantId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.INVENTORY_NOT_FOUND));
     }
 
     /** 비관적 락으로 재고를 조회한다 — 쓰기 작업 전용 */
-    private Inventory findByProductIdWithLock(Long productId) {
-        return inventoryRepository.findByProductIdWithLock(productId)
+    private Inventory findByVariantIdWithLock(Long variantId) {
+        return inventoryRepository.findByVariantIdWithLock(variantId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.INVENTORY_NOT_FOUND));
+    }
+
+    /** products 캐시를 프로그래밍 방식으로 evict한다. */
+    private void evictProductCache(Long productId) {
+        var cache = cacheManager.getCache("products");
+        if (cache != null) {
+            cache.evict(productId);
+        }
     }
 
     /** 재고 뮤테이션 이후 이력을 기록한다 (note 없음). */

--- a/src/main/java/com/stockmanagement/domain/order/cart/controller/CartController.java
+++ b/src/main/java/com/stockmanagement/domain/order/cart/controller/CartController.java
@@ -53,11 +53,11 @@ public class CartController {
         return ApiResponse.ok(cartService.addOrUpdate(userId, request));
     }
 
-    @Operation(summary = "특정 상품 제거")
-    @DeleteMapping("/items/{productId}")
+    @Operation(summary = "특정 변형 제거")
+    @DeleteMapping("/items/variants/{variantId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void removeItem(@CurrentUserId Long userId, @PathVariable Long productId) {
-        cartService.removeItem(userId, productId);
+    public void removeItem(@CurrentUserId Long userId, @PathVariable Long variantId) {
+        cartService.removeItem(userId, variantId);
     }
 
     @Operation(summary = "장바구니 전체 비우기")

--- a/src/main/java/com/stockmanagement/domain/order/cart/dto/CartCheckoutRequest.java
+++ b/src/main/java/com/stockmanagement/domain/order/cart/dto/CartCheckoutRequest.java
@@ -32,6 +32,6 @@ public class CartCheckoutRequest {
     /** 배송지 ID — 선택 항목. null이면 배송지 미지정 */
     private Long deliveryAddressId;
 
-    /** 선택 결제할 상품 ID 목록 — null이면 장바구니 전체 결제 */
-    private List<Long> selectedProductIds;
+    /** 선택 결제할 variant ID 목록 — null이면 장바구니 전체 결제 */
+    private List<Long> selectedVariantIds;
 }

--- a/src/main/java/com/stockmanagement/domain/order/cart/dto/CartItemRequest.java
+++ b/src/main/java/com/stockmanagement/domain/order/cart/dto/CartItemRequest.java
@@ -13,6 +13,9 @@ public class CartItemRequest {
     @NotNull(message = "상품 ID는 필수입니다.")
     private Long productId;
 
+    @NotNull(message = "상품 변형 ID는 필수입니다.")
+    private Long variantId;
+
     @Min(value = 1, message = "수량은 1 이상이어야 합니다.")
     private int quantity;
 }

--- a/src/main/java/com/stockmanagement/domain/order/cart/dto/CartItemResponse.java
+++ b/src/main/java/com/stockmanagement/domain/order/cart/dto/CartItemResponse.java
@@ -14,6 +14,8 @@ public class CartItemResponse {
 
     private Long productId;
     private String productName;
+    private Long variantId;
+    private String variantOptionName;
     private BigDecimal unitPrice;
     private int quantity;
     private BigDecimal subtotal;
@@ -34,12 +36,14 @@ public class CartItemResponse {
     }
 
     public static CartItemResponse from(CartItem item, Integer availableQuantity, StockStatus stockStatus) {
-        BigDecimal unitPrice = item.getProduct().getPrice();
+        BigDecimal unitPrice = item.getVariant().getPrice();
         BigDecimal savedPrice = item.getSavedPrice();
         Boolean priceChanged = savedPrice != null ? savedPrice.compareTo(unitPrice) != 0 : null;
         return CartItemResponse.builder()
                 .productId(item.getProduct().getId())
                 .productName(item.getProduct().getName())
+                .variantId(item.getVariant().getId())
+                .variantOptionName(item.getVariant().getOptionName())
                 .thumbnailUrl(item.getProduct().getThumbnailUrl())
                 .unitPrice(unitPrice)
                 .quantity(item.getQuantity())

--- a/src/main/java/com/stockmanagement/domain/order/cart/dto/CartResponse.java
+++ b/src/main/java/com/stockmanagement/domain/order/cart/dto/CartResponse.java
@@ -27,10 +27,10 @@ public class CartResponse {
                                     Map<Long, StockStatus> stockStatusMap) {
         List<CartItemResponse> itemResponses = cartItems.stream()
                 .map(i -> {
-                    Long productId = i.getProduct().getId();
+                    Long variantId = i.getVariant().getId();
                     return CartItemResponse.from(i,
-                            availabilityMap != null ? availabilityMap.get(productId) : null,
-                            stockStatusMap != null ? stockStatusMap.get(productId) : null);
+                            availabilityMap != null ? availabilityMap.get(variantId) : null,
+                            stockStatusMap != null ? stockStatusMap.get(variantId) : null);
                 })
                 .toList();
         BigDecimal total = itemResponses.stream()

--- a/src/main/java/com/stockmanagement/domain/order/cart/entity/CartItem.java
+++ b/src/main/java/com/stockmanagement/domain/order/cart/entity/CartItem.java
@@ -1,6 +1,7 @@
 package com.stockmanagement.domain.order.cart.entity;
 
 import com.stockmanagement.domain.product.entity.Product;
+import com.stockmanagement.domain.product.entity.ProductVariant;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -15,8 +16,8 @@ import java.time.LocalDateTime;
 /**
  * 장바구니 아이템 엔티티.
  *
- * <p>사용자({@code userId})별로 상품({@code product})을 담는다.
- * {@code userId + product_id} 조합이 UNIQUE하므로 동일 상품은 수량만 변경된다.
+ * <p>사용자({@code userId})별로 상품 변형({@code variant})을 담는다.
+ * {@code userId + variant_id} 조합이 UNIQUE하므로 동일 변형은 수량만 변경된다.
  */
 @Entity
 @Table(name = "cart_items")
@@ -36,6 +37,11 @@ public class CartItem {
     @JoinColumn(name = "product_id", nullable = false)
     private Product product;
 
+    /** 장바구니에 담은 상품 변형 */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "variant_id", nullable = false)
+    private ProductVariant variant;
+
     /** 담은 수량 — 1 이상이어야 한다 */
     @Column(nullable = false)
     private int quantity;
@@ -53,9 +59,11 @@ public class CartItem {
     private LocalDateTime updatedAt;
 
     @Builder
-    private CartItem(Long userId, Product product, int quantity, BigDecimal savedPrice) {
+    private CartItem(Long userId, Product product, ProductVariant variant,
+                     int quantity, BigDecimal savedPrice) {
         this.userId = userId;
         this.product = product;
+        this.variant = variant;
         this.quantity = quantity;
         this.savedPrice = savedPrice;
     }

--- a/src/main/java/com/stockmanagement/domain/order/cart/repository/CartRepository.java
+++ b/src/main/java/com/stockmanagement/domain/order/cart/repository/CartRepository.java
@@ -15,21 +15,21 @@ import java.util.Optional;
  */
 public interface CartRepository extends JpaRepository<CartItem, Long> {
 
-    /** 사용자의 장바구니 전체 조회 — 상품(product) fetch join으로 N+1 방지 */
-    @EntityGraph(attributePaths = "product")
+    /** 사용자의 장바구니 전체 조회 — product, variant fetch join으로 N+1 방지 */
+    @EntityGraph(attributePaths = {"product", "variant"})
     List<CartItem> findByUserId(Long userId);
 
-    /** 사용자 + 상품 조합으로 단건 조회 */
-    @EntityGraph(attributePaths = "product")
-    Optional<CartItem> findByUserIdAndProductId(Long userId, Long productId);
+    /** 사용자 + variant 조합으로 단건 조회 */
+    @EntityGraph(attributePaths = {"product", "variant"})
+    Optional<CartItem> findByUserIdAndVariantId(Long userId, Long variantId);
 
     /** 사용자의 장바구니 전체 삭제 — 벌크 DELETE (파생 삭제 메서드의 N+1 방지) */
     @Modifying
     @Query("DELETE FROM CartItem c WHERE c.userId = :userId")
     void deleteByUserId(Long userId);
 
-    /** 사용자의 장바구니에서 특정 상품들만 삭제 (선택 결제 후 나머지 유지) */
+    /** 사용자의 장바구니에서 특정 variant들만 삭제 (선택 결제 후 나머지 유지) */
     @Modifying
-    @Query("DELETE FROM CartItem c WHERE c.userId = :userId AND c.product.id IN :productIds")
-    void deleteByUserIdAndProductIdIn(Long userId, Collection<Long> productIds);
+    @Query("DELETE FROM CartItem c WHERE c.userId = :userId AND c.variant.id IN :variantIds")
+    void deleteByUserIdAndVariantIdIn(Long userId, Collection<Long> variantIds);
 }

--- a/src/main/java/com/stockmanagement/domain/order/cart/service/CartService.java
+++ b/src/main/java/com/stockmanagement/domain/order/cart/service/CartService.java
@@ -18,7 +18,8 @@ import com.stockmanagement.domain.inventory.entity.StockStatus;
 import com.stockmanagement.domain.inventory.repository.InventoryRepository;
 import com.stockmanagement.domain.product.entity.Product;
 import com.stockmanagement.domain.product.entity.ProductStatus;
-import com.stockmanagement.domain.product.repository.ProductRepository;
+import com.stockmanagement.domain.product.entity.ProductVariant;
+import com.stockmanagement.domain.product.repository.ProductVariantRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
@@ -48,7 +49,7 @@ import java.util.stream.Collectors;
 public class CartService {
 
     private final CartRepository cartRepository;
-    private final ProductRepository productRepository;
+    private final ProductVariantRepository variantRepository;
     private final InventoryRepository inventoryRepository;
     private final OrderCommandService orderCommandService;
     private final SystemSettingService systemSettingService;
@@ -60,33 +61,37 @@ public class CartService {
             return CartResponse.from(userId, items);
         }
         int threshold = systemSettingService.getLowStockThreshold();
-        List<Long> productIds = items.stream().map(i -> i.getProduct().getId()).toList();
-        Map<Long, Integer> availabilityMap = inventoryRepository.findAllByProductIdIn(productIds).stream()
-                .collect(Collectors.toMap(inv -> inv.getProduct().getId(), Inventory::getAvailable));
+        List<Long> variantIds = items.stream().map(i -> i.getVariant().getId()).toList();
+        Map<Long, Integer> availabilityMap = inventoryRepository.findAllByVariantIdIn(variantIds).stream()
+                .collect(Collectors.toMap(inv -> inv.getVariant().getId(), Inventory::getAvailable));
         Map<Long, StockStatus> stockStatusMap = availabilityMap.entrySet().stream()
                 .collect(Collectors.toMap(Map.Entry::getKey, e -> StockStatus.of(e.getValue(), threshold)));
         return CartResponse.from(userId, items, availabilityMap, stockStatusMap);
     }
 
     /**
-     * 상품을 장바구니에 추가하거나 수량을 변경한다.
+     * 상품 변형을 장바구니에 추가하거나 수량을 변경한다.
      *
-     * <p>동일 상품이 이미 담겨 있으면 요청 수량으로 덮어쓴다(교체).
+     * <p>동일 변형이 이미 담겨 있으면 요청 수량으로 덮어쓴다(교체).
      * 없으면 새 CartItem을 추가한다.
-     * 전체 장바구니 재조회 없이 영향받은 단건만 반환하여 불필요한 쿼리를 최소화한다.
      */
     @Transactional
     public CartItemResponse addOrUpdate(Long userId, CartItemRequest request) {
-        Product product = productRepository.findById(request.getProductId())
-                .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND));
+        ProductVariant variant = variantRepository.findByIdWithProduct(request.getVariantId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.VARIANT_NOT_FOUND));
 
-        // 판매 중인 상품만 장바구니에 담을 수 있다
+        Product product = variant.getProduct();
+
+        // 판매 중인 상품/변형만 장바구니에 담을 수 있다
         if (product.getStatus() != ProductStatus.ACTIVE) {
             throw new BusinessException(ErrorCode.PRODUCT_NOT_AVAILABLE);
         }
+        if (variant.getStatus() != ProductStatus.ACTIVE) {
+            throw new BusinessException(ErrorCode.VARIANT_NOT_AVAILABLE);
+        }
 
         Optional<CartItem> existing =
-                cartRepository.findByUserIdAndProductId(userId, product.getId());
+                cartRepository.findByUserIdAndVariantId(userId, variant.getId());
 
         CartItem cartItem;
         if (existing.isPresent()) {
@@ -97,19 +102,20 @@ public class CartService {
                 cartItem = cartRepository.saveAndFlush(CartItem.builder()
                         .userId(userId)
                         .product(product)
+                        .variant(variant)
                         .quantity(request.getQuantity())
-                        .savedPrice(product.getPrice())
+                        .savedPrice(variant.getPrice())
                         .build());
             } catch (DataIntegrityViolationException e) {
-                // 동시 요청으로 UK(user_id, product_id) 충돌 — 재조회 후 수량 업데이트
-                cartItem = cartRepository.findByUserIdAndProductId(userId, product.getId())
+                // 동시 요청으로 UK(user_id, variant_id) 충돌 — 재조회 후 수량 업데이트
+                cartItem = cartRepository.findByUserIdAndVariantId(userId, variant.getId())
                         .orElseThrow(() -> new BusinessException(ErrorCode.CART_ITEM_NOT_FOUND));
                 cartItem.updateQuantity(request.getQuantity());
             }
         }
 
         // 단건 재고 조회 (전체 장바구니 리로드 불필요)
-        Integer available = inventoryRepository.findByProductId(product.getId())
+        Integer available = inventoryRepository.findByVariantId(variant.getId())
                 .map(Inventory::getAvailable)
                 .orElse(null);
         StockStatus stockStatus = available != null
@@ -118,13 +124,13 @@ public class CartService {
     }
 
     /**
-     * 특정 상품을 장바구니에서 제거한다.
+     * 특정 변형을 장바구니에서 제거한다.
      *
-     * @throws BusinessException 장바구니에 해당 상품이 없는 경우
+     * @throws BusinessException 장바구니에 해당 변형이 없는 경우
      */
     @Transactional
-    public void removeItem(Long userId, Long productId) {
-        CartItem item = cartRepository.findByUserIdAndProductId(userId, productId)
+    public void removeItem(Long userId, Long variantId) {
+        CartItem item = cartRepository.findByUserIdAndVariantId(userId, variantId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.CART_ITEM_NOT_FOUND));
         cartRepository.delete(item);
     }
@@ -141,14 +147,10 @@ public class CartService {
      * <p>처리 흐름:
      * <ol>
      *   <li>장바구니가 비어 있으면 예외
-     *   <li>현재 상품 가격 기준으로 {@link OrderCreateRequest} 구성
+     *   <li>현재 variant 가격 기준으로 {@link OrderCreateRequest} 구성
      *   <li>{@link OrderCommandService#create} 호출 → 재고 예약 + 주문 생성
-     *   <li>주문 생성 성공 시 장바구니 비우기
+     *   <li>주문 생성 성공 시 장바구니에서 결제된 항목 제거
      * </ol>
-     *
-     * @param userId           주문자 ID
-     * @param checkoutRequest  멱등성 키 포함
-     * @return 생성된 주문 응답
      */
     @Transactional
     public OrderResponse checkout(Long userId, CartCheckoutRequest checkoutRequest) {
@@ -157,12 +159,12 @@ public class CartService {
             throw new BusinessException(ErrorCode.CART_EMPTY);
         }
 
-        // selectedProductIds가 없으면 전체, 있으면 해당 상품만 결제
-        List<Long> selected = checkoutRequest.getSelectedProductIds();
+        // selectedVariantIds가 없으면 전체, 있으면 해당 변형만 결제
+        List<Long> selected = checkoutRequest.getSelectedVariantIds();
         List<CartItem> items = (selected == null || selected.isEmpty())
                 ? allItems
                 : allItems.stream()
-                        .filter(i -> selected.contains(i.getProduct().getId()))
+                        .filter(i -> selected.contains(i.getVariant().getId()))
                         .toList();
 
         if (items.isEmpty()) {
@@ -172,8 +174,9 @@ public class CartService {
         List<OrderItemRequest> orderItems = items.stream()
                 .map(item -> OrderItemRequest.of(
                         item.getProduct().getId(),
+                        item.getVariant().getId(),
                         item.getQuantity(),
-                        item.getProduct().getPrice()))
+                        item.getVariant().getPrice()))
                 .toList();
 
         OrderCreateRequest orderRequest = OrderCreateRequest.of(
@@ -183,11 +186,11 @@ public class CartService {
 
         OrderResponse orderResponse = orderCommandService.create(orderRequest, userId);
 
-        // 결제한 상품만 장바구니에서 제거 (선택 결제 시 나머지 유지)
-        Set<Long> checkedOutProductIds = items.stream()
-                .map(i -> i.getProduct().getId())
+        // 결제한 변형만 장바구니에서 제거 (선택 결제 시 나머지 유지)
+        Set<Long> checkedOutVariantIds = items.stream()
+                .map(i -> i.getVariant().getId())
                 .collect(Collectors.toSet());
-        cartRepository.deleteByUserIdAndProductIdIn(userId, checkedOutProductIds);
+        cartRepository.deleteByUserIdAndVariantIdIn(userId, checkedOutVariantIds);
 
         return orderResponse;
     }

--- a/src/main/java/com/stockmanagement/domain/order/dto/OrderItemRequest.java
+++ b/src/main/java/com/stockmanagement/domain/order/dto/OrderItemRequest.java
@@ -25,6 +25,10 @@ public class OrderItemRequest {
     @NotNull(message = "상품 ID는 필수입니다.")
     private Long productId;
 
+    /** 주문할 상품 변형 ID */
+    @NotNull(message = "상품 변형 ID는 필수입니다.")
+    private Long variantId;
+
     /** 주문 수량 — 1 이상 10,000 이하 */
     @Min(value = 1, message = "수량은 1 이상이어야 합니다.")
     @Max(value = 10000, message = "수량은 10,000 이하여야 합니다.")
@@ -39,9 +43,10 @@ public class OrderItemRequest {
     private BigDecimal unitPrice;
 
     /** 장바구니 결제 전환 등 내부 호출용 팩토리 메서드. */
-    public static OrderItemRequest of(Long productId, int quantity, BigDecimal unitPrice) {
+    public static OrderItemRequest of(Long productId, Long variantId, int quantity, BigDecimal unitPrice) {
         OrderItemRequest req = new OrderItemRequest();
         req.productId = productId;
+        req.variantId = variantId;
         req.quantity = quantity;
         req.unitPrice = unitPrice;
         return req;

--- a/src/main/java/com/stockmanagement/domain/order/dto/OrderItemResponse.java
+++ b/src/main/java/com/stockmanagement/domain/order/dto/OrderItemResponse.java
@@ -24,6 +24,12 @@ public class OrderItemResponse {
     /** 상품명 — 주문 당시 이름 (Product 참조를 통해 현재 이름을 반환) */
     private final String productName;
 
+    /** 주문한 변형 ID */
+    private final Long variantId;
+
+    /** 변형 옵션 이름 (예: "빨강/L") */
+    private final String variantOptionName;
+
     /** 주문 수량 */
     private final int quantity;
 
@@ -50,6 +56,8 @@ public class OrderItemResponse {
                 .id(item.getId())
                 .productId(item.getProduct().getId())
                 .productName(item.getProduct().getName())
+                .variantId(item.getVariant().getId())
+                .variantOptionName(item.getVariant().getOptionName())
                 .quantity(item.getQuantity())
                 .unitPrice(item.getUnitPrice())
                 .subtotal(item.getSubtotal())

--- a/src/main/java/com/stockmanagement/domain/order/entity/OrderItem.java
+++ b/src/main/java/com/stockmanagement/domain/order/entity/OrderItem.java
@@ -1,6 +1,7 @@
 package com.stockmanagement.domain.order.entity;
 
 import com.stockmanagement.domain.product.entity.Product;
+import com.stockmanagement.domain.product.entity.ProductVariant;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -43,6 +44,11 @@ public class OrderItem {
     @JoinColumn(name = "product_id", nullable = false)
     private Product product;
 
+    /** 주문한 상품 변형 */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "variant_id", nullable = false)
+    private ProductVariant variant;
+
     /** 주문 수량 */
     @Column(nullable = false)
     private int quantity;
@@ -60,8 +66,9 @@ public class OrderItem {
     private LocalDateTime createdAt;
 
     @Builder
-    private OrderItem(Product product, int quantity, BigDecimal unitPrice) {
+    private OrderItem(Product product, ProductVariant variant, int quantity, BigDecimal unitPrice) {
         this.product = product;
+        this.variant = variant;
         this.quantity = quantity;
         this.unitPrice = unitPrice;
         this.subtotal = unitPrice.multiply(BigDecimal.valueOf(quantity));

--- a/src/main/java/com/stockmanagement/domain/order/service/OrderCommandService.java
+++ b/src/main/java/com/stockmanagement/domain/order/service/OrderCommandService.java
@@ -19,7 +19,8 @@ import com.stockmanagement.domain.order.repository.OrderRepository;
 import com.stockmanagement.domain.order.repository.OrderStatusHistoryRepository;
 import com.stockmanagement.domain.product.entity.Product;
 import com.stockmanagement.domain.product.entity.ProductStatus;
-import com.stockmanagement.domain.product.repository.ProductRepository;
+import com.stockmanagement.domain.product.entity.ProductVariant;
+import com.stockmanagement.domain.product.repository.ProductVariantRepository;
 import com.stockmanagement.common.event.OrderCancelledEvent;
 import com.stockmanagement.common.event.OrderCreatedEvent;
 import com.stockmanagement.common.outbox.OutboxEventStore;
@@ -53,7 +54,7 @@ import java.util.stream.Collectors;
 public class OrderCommandService {
 
     private final OrderRepository orderRepository;
-    private final ProductRepository productRepository;
+    private final ProductVariantRepository variantRepository;
     private final InventoryService inventoryService;
     private final OrderStatusHistoryRepository historyRepository;
     private final CouponService couponService;
@@ -88,34 +89,42 @@ public class OrderCommandService {
         List<OrderItem> items = new ArrayList<>();
         BigDecimal totalAmount = BigDecimal.ZERO;
 
-        List<Long> productIds = request.getItems().stream()
-                .map(OrderItemRequest::getProductId)
+        List<Long> variantIds = request.getItems().stream()
+                .map(OrderItemRequest::getVariantId)
                 .toList();
-        if (new HashSet<>(productIds).size() != productIds.size()) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT, "동일 상품이 중복으로 포함되어 있습니다. 수량을 합쳐서 제출해주세요.");
+        if (new HashSet<>(variantIds).size() != variantIds.size()) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT, "동일 변형이 중복으로 포함되어 있습니다. 수량을 합쳐서 제출해주세요.");
         }
 
-        Map<Long, Product> productMap = productRepository.findAllById(productIds).stream()
-                .collect(Collectors.toMap(Product::getId, p -> p));
+        Map<Long, ProductVariant> variantMap = variantRepository.findAllByIdInWithProduct(variantIds).stream()
+                .collect(Collectors.toMap(ProductVariant::getId, v -> v));
 
         for (OrderItemRequest itemRequest : request.getItems()) {
-            Product product = Optional.ofNullable(productMap.get(itemRequest.getProductId()))
-                    .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND));
+            ProductVariant variant = Optional.ofNullable(variantMap.get(itemRequest.getVariantId()))
+                    .orElseThrow(() -> new BusinessException(ErrorCode.VARIANT_NOT_FOUND));
+
+            Product product = variant.getProduct();
 
             if (product.getStatus() != ProductStatus.ACTIVE) {
                 throw new BusinessException(ErrorCode.PRODUCT_NOT_AVAILABLE);
             }
 
-            if (product.getPrice().compareTo(itemRequest.getUnitPrice()) != 0) {
+            if (variant.getStatus() != ProductStatus.ACTIVE) {
+                throw new BusinessException(ErrorCode.VARIANT_NOT_AVAILABLE);
+            }
+
+            if (variant.getPrice().compareTo(itemRequest.getUnitPrice()) != 0) {
                 throw new BusinessException(ErrorCode.INVALID_INPUT,
-                        String.format("상품 '%s'의 단가가 일치하지 않습니다. (요청: %s, 현재: %s)",
-                                product.getName(), itemRequest.getUnitPrice(), product.getPrice()));
+                        String.format("상품 '%s (%s)'의 단가가 일치하지 않습니다. (요청: %s, 현재: %s)",
+                                product.getName(), variant.getOptionName(),
+                                itemRequest.getUnitPrice(), variant.getPrice()));
             }
 
             OrderItem item = OrderItem.builder()
                     .product(product)
+                    .variant(variant)
                     .quantity(itemRequest.getQuantity())
-                    .unitPrice(product.getPrice())
+                    .unitPrice(variant.getPrice())
                     .build();
 
             items.add(item);
@@ -168,10 +177,10 @@ public class OrderCommandService {
                     .build());
         }
 
-        // 6. 재고 예약 (productId 오름차순 — 데드락 방지)
+        // 6. 재고 예약 (variantId 오름차순 — 데드락 방지)
         savedOrder.getItems().stream()
-                .sorted(java.util.Comparator.comparing(i -> i.getProduct().getId()))
-                .forEach(item -> inventoryService.reserve(item.getProduct().getId(), item.getQuantity()));
+                .sorted(java.util.Comparator.comparing(i -> i.getVariant().getId()))
+                .forEach(item -> inventoryService.reserve(item.getVariant().getId(), item.getQuantity()));
 
         // 7. 쿠폰 적용
         if (request.getCouponCode() != null && !request.getCouponCode().isBlank()) {
@@ -217,7 +226,7 @@ public class OrderCommandService {
         order.cancel(reason);
 
         for (OrderItem item : order.getItems()) {
-            inventoryService.releaseReservation(item.getProduct().getId(), item.getQuantity());
+            inventoryService.releaseReservation(item.getVariant().getId(), item.getQuantity());
         }
 
         couponService.releaseCoupon(order.getId());
@@ -241,7 +250,7 @@ public class OrderCommandService {
         order.cancel(null);
 
         for (OrderItem item : order.getItems()) {
-            inventoryService.releaseReservation(item.getProduct().getId(), item.getQuantity());
+            inventoryService.releaseReservation(item.getVariant().getId(), item.getQuantity());
         }
 
         couponService.releaseCoupon(order.getId());

--- a/src/main/java/com/stockmanagement/domain/order/service/OrderPaymentService.java
+++ b/src/main/java/com/stockmanagement/domain/order/service/OrderPaymentService.java
@@ -55,7 +55,7 @@ public class OrderPaymentService {
         order.confirm();
 
         for (OrderItem item : order.getItems()) {
-            inventoryService.confirmAllocation(item.getProduct().getId(), item.getQuantity());
+            inventoryService.confirmAllocation(item.getVariant().getId(), item.getQuantity());
         }
 
         recordHistory(order.getId(), previousStatus, OrderStatus.CONFIRMED, null);
@@ -78,7 +78,7 @@ public class OrderPaymentService {
         order.refund();
 
         for (OrderItem item : order.getItems()) {
-            inventoryService.releaseAllocation(item.getProduct().getId(), item.getQuantity());
+            inventoryService.releaseAllocation(item.getVariant().getId(), item.getQuantity());
         }
 
         couponService.releaseCoupon(order.getId());
@@ -107,7 +107,7 @@ public class OrderPaymentService {
         order.cancelByWebhook(reason);
 
         for (OrderItem item : order.getItems()) {
-            inventoryService.releaseReservation(item.getProduct().getId(), item.getQuantity());
+            inventoryService.releaseReservation(item.getVariant().getId(), item.getQuantity());
         }
 
         couponService.releaseCoupon(order.getId());

--- a/src/main/java/com/stockmanagement/domain/product/controller/ProductController.java
+++ b/src/main/java/com/stockmanagement/domain/product/controller/ProductController.java
@@ -7,6 +7,9 @@ import com.stockmanagement.domain.product.dto.ProductResponse;
 import com.stockmanagement.domain.product.dto.ProductSearchRequest;
 import com.stockmanagement.domain.product.dto.ProductStatusRequest;
 import com.stockmanagement.domain.product.dto.ProductUpdateRequest;
+import com.stockmanagement.domain.product.dto.ProductVariantCreateRequest;
+import com.stockmanagement.domain.product.dto.ProductVariantResponse;
+import com.stockmanagement.domain.product.dto.ProductVariantUpdateRequest;
 import com.stockmanagement.domain.product.dto.SuggestResponse;
 import com.stockmanagement.domain.product.service.ProductService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -20,6 +23,8 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @Tag(name = "상품", description = "상품 CRUD — 등록·조회·수정·삭제")
 @RestController
 @RequestMapping("/api/products")
@@ -28,7 +33,7 @@ public class ProductController {
 
     private final ProductService productService;
 
-    @Operation(summary = "상품 등록", description = "ADMIN 전용. SKU 중복 시 409.")
+    @Operation(summary = "상품 등록", description = "ADMIN 전용. SKU 중복 시 409. 기본 variant와 Inventory를 자동 생성한다.")
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<ProductResponse> create(@RequestBody @Valid ProductCreateRequest request) {
@@ -89,5 +94,38 @@ public class ProductController {
             @PathVariable Long id,
             @RequestBody @Valid ProductStatusRequest request) {
         return ApiResponse.ok(productService.changeStatus(id, request));
+    }
+
+    // ===== Variant 엔드포인트 =====
+
+    @Operation(summary = "변형 목록 조회", description = "상품의 모든 변형을 조회한다.")
+    @GetMapping("/{productId}/variants")
+    public ApiResponse<List<ProductVariantResponse>> getVariants(@PathVariable Long productId) {
+        return ApiResponse.ok(productService.getVariants(productId));
+    }
+
+    @Operation(summary = "변형 추가", description = "ADMIN 전용. SKU 중복 시 409. Inventory를 자동 생성한다.")
+    @PostMapping("/{productId}/variants")
+    @ResponseStatus(HttpStatus.CREATED)
+    public ApiResponse<ProductVariantResponse> addVariant(
+            @PathVariable Long productId,
+            @RequestBody @Valid ProductVariantCreateRequest request) {
+        return ApiResponse.ok(productService.addVariant(productId, request));
+    }
+
+    @Operation(summary = "변형 수정", description = "ADMIN 전용. optionName, price, status를 변경한다.")
+    @PutMapping("/{productId}/variants/{variantId}")
+    public ApiResponse<ProductVariantResponse> updateVariant(
+            @PathVariable Long productId,
+            @PathVariable Long variantId,
+            @RequestBody @Valid ProductVariantUpdateRequest request) {
+        return ApiResponse.ok(productService.updateVariant(productId, variantId, request));
+    }
+
+    @Operation(summary = "변형 비활성화", description = "ADMIN 전용. DISCONTINUED 상태로 전환.")
+    @DeleteMapping("/{productId}/variants/{variantId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deactivateVariant(@PathVariable Long productId, @PathVariable Long variantId) {
+        productService.deactivateVariant(productId, variantId);
     }
 }

--- a/src/main/java/com/stockmanagement/domain/product/dto/ProductResponse.java
+++ b/src/main/java/com/stockmanagement/domain/product/dto/ProductResponse.java
@@ -51,6 +51,8 @@ public class ProductResponse {
     private final Long reviewCount;
     /** 상품 이미지 목록 — null이면 이미지 정보 미포함 (상세 조회 시만 포함) */
     private final List<ProductImageResponse> images;
+    /** 상품 변형 목록 — null이면 변형 정보 미포함 (상세 조회 시만 포함) */
+    private final List<ProductVariantResponse> variants;
 
     /**
      * 현재 사용자의 리뷰 작성 가능 여부.
@@ -65,33 +67,36 @@ public class ProductResponse {
 
     /** Product 엔티티만으로 변환 (재고·리뷰 통계 미포함). */
     public static ProductResponse from(Product product) {
-        return from(product, null, null, null, null, null, null, null);
+        return from(product, null, null, null, null, null, null, null, null);
     }
 
     /** Product 엔티티 + 재고·리뷰 통계를 포함한 전체 응답으로 변환 (이미지 미포함). */
     public static ProductResponse from(Product product, Integer availableQuantity, StockStatus stockStatus,
                                        Double avgRating, Long reviewCount) {
-        return from(product, availableQuantity, stockStatus, avgRating, reviewCount, null, null, null);
+        return from(product, availableQuantity, stockStatus, avgRating, reviewCount, null, null, null, null);
     }
 
-    /** Product 엔티티 + 재고·리뷰 통계 + 이미지 목록을 포함한 전체 응답으로 변환. */
+    /** Product 엔티티 + 재고·리뷰 통계 + 이미지 + variants를 포함한 전체 응답으로 변환. */
     public static ProductResponse from(Product product, Integer availableQuantity, StockStatus stockStatus,
                                        Double avgRating, Long reviewCount,
-                                       List<ProductImageResponse> images) {
-        return from(product, availableQuantity, stockStatus, avgRating, reviewCount, images, null, null);
+                                       List<ProductImageResponse> images,
+                                       List<ProductVariantResponse> variants) {
+        return from(product, availableQuantity, stockStatus, avgRating, reviewCount, images, variants, null, null);
     }
 
-    /** Product 엔티티 + 재고·리뷰 통계 + 이미지 + canReview를 포함한 전체 응답으로 변환. */
+    /** Product 엔티티 + 재고·리뷰 통계 + 이미지 + variants + canReview를 포함한 전체 응답으로 변환. */
     public static ProductResponse from(Product product, Integer availableQuantity, StockStatus stockStatus,
                                        Double avgRating, Long reviewCount,
-                                       List<ProductImageResponse> images, Boolean canReview) {
-        return from(product, availableQuantity, stockStatus, avgRating, reviewCount, images, canReview, null);
+                                       List<ProductImageResponse> images,
+                                       List<ProductVariantResponse> variants, Boolean canReview) {
+        return from(product, availableQuantity, stockStatus, avgRating, reviewCount, images, variants, canReview, null);
     }
 
-    /** Product 엔티티 + 전체 필드(재고·리뷰·이미지·canReview·wishlisted)를 포함한 응답으로 변환. */
+    /** Product 엔티티 + 전체 필드(재고·리뷰·이미지·variants·canReview·wishlisted)를 포함한 응답으로 변환. */
     public static ProductResponse from(Product product, Integer availableQuantity, StockStatus stockStatus,
                                        Double avgRating, Long reviewCount,
-                                       List<ProductImageResponse> images, Boolean canReview,
+                                       List<ProductImageResponse> images,
+                                       List<ProductVariantResponse> variants, Boolean canReview,
                                        Boolean wishlisted) {
         return ProductResponse.builder()
                 .id(product.getId())
@@ -110,6 +115,7 @@ public class ProductResponse {
                 .avgRating(avgRating != null ? Math.round(avgRating * 10.0) / 10.0 : null)
                 .reviewCount(reviewCount)
                 .images(images)
+                .variants(variants)
                 .canReview(canReview)
                 .wishlisted(wishlisted)
                 .build();

--- a/src/main/java/com/stockmanagement/domain/product/dto/ProductVariantCreateRequest.java
+++ b/src/main/java/com/stockmanagement/domain/product/dto/ProductVariantCreateRequest.java
@@ -1,0 +1,30 @@
+package com.stockmanagement.domain.product.dto;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+/**
+ * 상품 변형 생성 요청 DTO.
+ */
+@Getter
+@NoArgsConstructor
+public class ProductVariantCreateRequest {
+
+    @NotBlank(message = "옵션 이름은 필수입니다.")
+    @Size(max = 100, message = "옵션 이름은 100자 이하여야 합니다.")
+    private String optionName;
+
+    @NotBlank(message = "SKU는 필수입니다.")
+    @Size(max = 100, message = "SKU는 100자 이하여야 합니다.")
+    private String sku;
+
+    @NotNull(message = "가격은 필수입니다.")
+    @DecimalMin(value = "0.01", message = "가격은 0보다 커야 합니다.")
+    private BigDecimal price;
+}

--- a/src/main/java/com/stockmanagement/domain/product/dto/ProductVariantResponse.java
+++ b/src/main/java/com/stockmanagement/domain/product/dto/ProductVariantResponse.java
@@ -1,0 +1,34 @@
+package com.stockmanagement.domain.product.dto;
+
+import com.stockmanagement.domain.product.entity.ProductStatus;
+import com.stockmanagement.domain.product.entity.ProductVariant;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.extern.jackson.Jacksonized;
+
+import java.math.BigDecimal;
+
+/**
+ * 상품 변형 응답 DTO.
+ */
+@Getter
+@Builder
+@Jacksonized
+public class ProductVariantResponse {
+
+    private final Long id;
+    private final String optionName;
+    private final String sku;
+    private final BigDecimal price;
+    private final ProductStatus status;
+
+    public static ProductVariantResponse from(ProductVariant variant) {
+        return ProductVariantResponse.builder()
+                .id(variant.getId())
+                .optionName(variant.getOptionName())
+                .sku(variant.getSku())
+                .price(variant.getPrice())
+                .status(variant.getStatus())
+                .build();
+    }
+}

--- a/src/main/java/com/stockmanagement/domain/product/dto/ProductVariantUpdateRequest.java
+++ b/src/main/java/com/stockmanagement/domain/product/dto/ProductVariantUpdateRequest.java
@@ -1,0 +1,25 @@
+package com.stockmanagement.domain.product.dto;
+
+import com.stockmanagement.domain.product.entity.ProductStatus;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+/**
+ * 상품 변형 수정 요청 DTO.
+ */
+@Getter
+@NoArgsConstructor
+public class ProductVariantUpdateRequest {
+
+    @Size(max = 100, message = "옵션 이름은 100자 이하여야 합니다.")
+    private String optionName;
+
+    @DecimalMin(value = "0.01", message = "가격은 0보다 커야 합니다.")
+    private BigDecimal price;
+
+    private ProductStatus status;
+}

--- a/src/main/java/com/stockmanagement/domain/product/entity/Product.java
+++ b/src/main/java/com/stockmanagement/domain/product/entity/Product.java
@@ -9,6 +9,8 @@ import org.hibernate.annotations.UpdateTimestamp;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * 상품 마스터 엔티티.
@@ -62,6 +64,11 @@ public class Product {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
     private ProductStatus status;
+
+    /** 상품에 속한 변형(variant) 목록 */
+    @OneToMany(mappedBy = "product", fetch = FetchType.LAZY)
+    @BatchSize(size = 50)
+    private List<ProductVariant> variants = new ArrayList<>();
 
     /** 최초 생성 시각 — Hibernate가 자동 설정, 이후 변경 불가 */
     @CreationTimestamp

--- a/src/main/java/com/stockmanagement/domain/product/entity/ProductVariant.java
+++ b/src/main/java/com/stockmanagement/domain/product/entity/ProductVariant.java
@@ -1,0 +1,84 @@
+package com.stockmanagement.domain.product.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * 상품 변형(variant) 엔티티.
+ *
+ * <p>하나의 {@link Product}에 속한 옵션 조합(색상·사이즈 등)을 나타낸다.
+ * 각 variant는 고유 SKU, 개별 가격, 독립적인 재고(Inventory)를 갖는다.
+ *
+ * <p>옵션이 없는 상품도 "기본" variant 1개를 필수로 가진다.
+ */
+@Entity
+@Table(name = "product_variants")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@BatchSize(size = 50)
+public class ProductVariant {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** 소속 상품 */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+    /** 옵션 이름 (예: "빨강/L", "기본") */
+    @Column(name = "option_name", nullable = false, length = 100)
+    private String optionName;
+
+    /** variant 고유 SKU */
+    @Column(nullable = false, length = 100, unique = true)
+    private String sku;
+
+    /** variant 개별 가격 */
+    @Column(nullable = false, precision = 15, scale = 2)
+    private BigDecimal price;
+
+    /** variant 상태 */
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ProductStatus status;
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Builder
+    private ProductVariant(Product product, String optionName, String sku,
+                           BigDecimal price, ProductStatus status) {
+        this.product = product;
+        this.optionName = optionName;
+        this.sku = sku;
+        this.price = price;
+        this.status = status != null ? status : ProductStatus.ACTIVE;
+    }
+
+    /** variant 정보를 수정한다. */
+    public void update(String optionName, BigDecimal price) {
+        if (optionName != null) this.optionName = optionName;
+        if (price != null) this.price = price;
+    }
+
+    /** variant 상태를 변경한다. */
+    public void changeStatus(ProductStatus status) {
+        this.status = status;
+    }
+}

--- a/src/main/java/com/stockmanagement/domain/product/repository/ProductVariantRepository.java
+++ b/src/main/java/com/stockmanagement/domain/product/repository/ProductVariantRepository.java
@@ -1,0 +1,30 @@
+package com.stockmanagement.domain.product.repository;
+
+import com.stockmanagement.domain.product.entity.ProductVariant;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 상품 변형 레포지토리.
+ */
+public interface ProductVariantRepository extends JpaRepository<ProductVariant, Long> {
+
+    /** 상품의 모든 variant를 조회한다. */
+    List<ProductVariant> findByProductId(Long productId);
+
+    /** 여러 variant를 product와 함께 일괄 조회한다 (주문 생성 시). */
+    @Query("SELECT v FROM ProductVariant v JOIN FETCH v.product WHERE v.id IN :ids")
+    List<ProductVariant> findAllByIdInWithProduct(@Param("ids") Collection<Long> ids);
+
+    /** variant를 product와 함께 조회한다. */
+    @Query("SELECT v FROM ProductVariant v JOIN FETCH v.product WHERE v.id = :id")
+    Optional<ProductVariant> findByIdWithProduct(@Param("id") Long id);
+
+    /** SKU 중복 확인 */
+    boolean existsBySku(String sku);
+}

--- a/src/main/java/com/stockmanagement/domain/product/service/ProductService.java
+++ b/src/main/java/com/stockmanagement/domain/product/service/ProductService.java
@@ -15,9 +15,14 @@ import com.stockmanagement.domain.product.dto.ProductResponse;
 import com.stockmanagement.domain.product.dto.ProductSearchRequest;
 import com.stockmanagement.domain.product.dto.ProductStatusRequest;
 import com.stockmanagement.domain.product.dto.ProductUpdateRequest;
+import com.stockmanagement.domain.product.dto.ProductVariantCreateRequest;
+import com.stockmanagement.domain.product.dto.ProductVariantResponse;
+import com.stockmanagement.domain.product.dto.ProductVariantUpdateRequest;
 import com.stockmanagement.domain.product.entity.Product;
 import com.stockmanagement.domain.product.entity.ProductStatus;
+import com.stockmanagement.domain.product.entity.ProductVariant;
 import com.stockmanagement.domain.product.repository.ProductRepository;
+import com.stockmanagement.domain.product.repository.ProductVariantRepository;
 import com.stockmanagement.domain.product.image.dto.ProductImageResponse;
 import com.stockmanagement.domain.product.image.repository.ProductImageRepository;
 import com.stockmanagement.domain.product.review.repository.ReviewRepository;
@@ -58,6 +63,7 @@ import java.util.stream.Collectors;
 public class ProductService {
 
     private final ProductRepository productRepository;
+    private final ProductVariantRepository variantRepository;
     private final ProductSearchService productSearchService;
     private final CategoryRepository categoryRepository;
     private final InventoryRepository inventoryRepository;
@@ -71,11 +77,11 @@ public class ProductService {
     /**
      * 상품을 등록한다.
      * SKU 중복 여부를 먼저 확인해 충돌을 방지한다.
-     * categoryId가 있으면 Category를 조회해 연결한다.
+     * 기본 variant("기본")와 Inventory를 자동 생성한다.
      */
     @Transactional
     public ProductResponse create(ProductCreateRequest request) {
-        if (productRepository.existsBySku(request.getSku())) {
+        if (variantRepository.existsBySku(request.getSku())) {
             throw new BusinessException(ErrorCode.DUPLICATE_SKU);
         }
         Category category = resolveCategory(request.getCategoryId());
@@ -87,11 +93,23 @@ public class ProductService {
                 .category(category)
                 .build();
         Product saved = productRepository.save(product);
+
+        // 기본 variant 자동 생성
+        ProductVariant defaultVariant = variantRepository.save(ProductVariant.builder()
+                .product(saved)
+                .optionName("기본")
+                .sku(request.getSku())
+                .price(request.getPrice())
+                .build());
+
+        // 기본 variant의 Inventory 자동 생성
+        inventoryRepository.save(Inventory.builder().variant(defaultVariant).build());
+
         eventPublisher.publishEvent(new ProductSyncEvent(saved.getId(), false));
         return ProductResponse.from(saved);
     }
 
-    /** 단건 조회 — 캐시 hit 시 Redis에서 반환, miss 시 DB + 재고·리뷰 통계 + 이미지 목록 조회 후 캐싱 */
+    /** 단건 조회 — 캐시 hit 시 Redis에서 반환, miss 시 DB + 재고·리뷰 통계 + 이미지 + variants 조회 후 캐싱 */
     @Cacheable(cacheNames = "products", key = "#id")
     public ProductResponse getById(Long id) {
         return buildProductResponseWithImages(findById(id));
@@ -105,19 +123,20 @@ public class ProductService {
      */
     public ProductResponse getByIdForUser(Long id, Long userId) {
         Product product = findById(id);
-        Integer available = inventoryRepository.findByProductId(id)
-                .map(Inventory::getAvailable).orElse(0);
+        int available = sumAvailableByProductId(id);
         StockStatus stockStatus = StockStatus.of(available, systemSettingService.getLowStockThreshold());
         ReviewStatsProjection stats = reviewRepository.findReviewStatsByProductId(id).orElse(null);
         List<ProductImageResponse> images = productImageRepository
                 .findByProductIdOrderByDisplayOrderAsc(id).stream()
                 .map(ProductImageResponse::from).toList();
+        List<ProductVariantResponse> variants = variantRepository.findByProductId(id).stream()
+                .map(ProductVariantResponse::from).toList();
         boolean purchased = orderRepository.existsPurchaseByUserIdAndProductId(userId, id);
         boolean reviewed = reviewRepository.existsByProductIdAndUserId(id, userId);
         return ProductResponse.from(product, null, stockStatus,
                 stats != null ? stats.getAvgRating() : null,
                 stats != null ? stats.getReviewCount() : 0L,
-                images, purchased && !reviewed);
+                images, variants, purchased && !reviewed);
     }
 
     /**
@@ -230,6 +249,55 @@ public class ProductService {
         return buildProductResponse(product);
     }
 
+    // ===== Variant CRUD =====
+
+    /** 상품의 variant 목록을 조회한다. */
+    public List<ProductVariantResponse> getVariants(Long productId) {
+        findById(productId);
+        return variantRepository.findByProductId(productId).stream()
+                .map(ProductVariantResponse::from).toList();
+    }
+
+    /** 상품에 variant를 추가한다. */
+    @Transactional
+    @CacheEvict(cacheNames = "products", key = "#productId")
+    public ProductVariantResponse addVariant(Long productId, ProductVariantCreateRequest request) {
+        Product product = findById(productId);
+        if (variantRepository.existsBySku(request.getSku())) {
+            throw new BusinessException(ErrorCode.DUPLICATE_SKU);
+        }
+        ProductVariant variant = variantRepository.save(ProductVariant.builder()
+                .product(product)
+                .optionName(request.getOptionName())
+                .sku(request.getSku())
+                .price(request.getPrice())
+                .build());
+        // 새 variant의 Inventory 자동 생성
+        inventoryRepository.save(Inventory.builder().variant(variant).build());
+        return ProductVariantResponse.from(variant);
+    }
+
+    /** variant 정보를 수정한다. */
+    @Transactional
+    @CacheEvict(cacheNames = "products", key = "#productId")
+    public ProductVariantResponse updateVariant(Long productId, Long variantId,
+                                                ProductVariantUpdateRequest request) {
+        ProductVariant variant = findVariant(productId, variantId);
+        variant.update(request.getOptionName(), request.getPrice());
+        if (request.getStatus() != null) {
+            variant.changeStatus(request.getStatus());
+        }
+        return ProductVariantResponse.from(variant);
+    }
+
+    /** variant를 비활성화한다 (DISCONTINUED 전환). */
+    @Transactional
+    @CacheEvict(cacheNames = "products", key = "#productId")
+    public void deactivateVariant(Long productId, Long variantId) {
+        ProductVariant variant = findVariant(productId, variantId);
+        variant.changeStatus(ProductStatus.DISCONTINUED);
+    }
+
     // ===== 내부 헬퍼 =====
 
     /** LIKE 패턴 와일드카드(!, %, _)를 이스케이프한다. ESCAPE ! 기준. */
@@ -237,17 +305,19 @@ public class ProductService {
         return com.stockmanagement.common.util.SqlUtils.escapeLike(value);
     }
 
+    /** 상품의 전체 variant 가용 재고를 합산한다. */
+    private int sumAvailableByProductId(Long productId) {
+        return inventoryRepository.findAllByProductId(productId).stream()
+                .mapToInt(Inventory::getAvailable).sum();
+    }
+
     /**
      * 단일 상품에 재고·리뷰 통계를 포함한 응답을 생성한다 (이미지 미포함).
      *
-     * <p>기존 avgRatingByProductId() + countByProductId() 2개 쿼리를
-     * findReviewStatsByProductId() 단일 쿼리로 대체한다.
-     * 재고 레코드가 없으면 availableQuantity=0, 리뷰가 없으면 avgRating=null, reviewCount=0.
+     * <p>재고 레코드가 없으면 availableQuantity=0, 리뷰가 없으면 avgRating=null, reviewCount=0.
      */
     private ProductResponse buildProductResponse(Product product) {
-        Integer available = inventoryRepository.findByProductId(product.getId())
-                .map(Inventory::getAvailable)
-                .orElse(0);
+        int available = sumAvailableByProductId(product.getId());
         StockStatus stockStatus = StockStatus.of(available, systemSettingService.getLowStockThreshold());
         ReviewStatsProjection stats = reviewRepository
                 .findReviewStatsByProductId(product.getId()).orElse(null);
@@ -257,14 +327,10 @@ public class ProductService {
     }
 
     /**
-     * 단일 상품에 재고·리뷰 통계 + 이미지 목록을 포함한 응답을 생성한다 (상세 조회용).
-     *
-     * <p>리뷰 통계는 findReviewStatsByProductId() 단일 쿼리로 조회한다.
+     * 단일 상품에 재고·리뷰 통계 + 이미지 + variants를 포함한 응답을 생성한다 (상세 조회용).
      */
     private ProductResponse buildProductResponseWithImages(Product product) {
-        Integer available = inventoryRepository.findByProductId(product.getId())
-                .map(Inventory::getAvailable)
-                .orElse(0);
+        int available = sumAvailableByProductId(product.getId());
         StockStatus stockStatus = StockStatus.of(available, systemSettingService.getLowStockThreshold());
         ReviewStatsProjection stats = reviewRepository
                 .findReviewStatsByProductId(product.getId()).orElse(null);
@@ -272,15 +338,17 @@ public class ProductService {
                 .findByProductIdOrderByDisplayOrderAsc(product.getId()).stream()
                 .map(ProductImageResponse::from)
                 .toList();
+        List<ProductVariantResponse> variants = variantRepository.findByProductId(product.getId()).stream()
+                .map(ProductVariantResponse::from).toList();
         return ProductResponse.from(product, available, stockStatus,
                 stats != null ? stats.getAvgRating() : null,
                 stats != null ? stats.getReviewCount() : 0L,
-                images);
+                images, variants);
     }
 
     /**
      * 상품 페이지에 재고·리뷰 통계를 배치로 보강한다 (N+1 방지).
-     * 재고/리뷰 없는 상품은 0으로 처리한다.
+     * 한 상품에 여러 variant 재고가 있을 수 있으므로 합산한다.
      */
     private Page<ProductResponse> enrichPage(Page<Product> products, Long userId) {
         if (products.isEmpty()) return products.map(ProductResponse::from);
@@ -288,8 +356,11 @@ public class ProductService {
         List<Long> ids = products.stream().map(Product::getId).toList();
         int threshold = systemSettingService.getLowStockThreshold();
 
+        // variant별 재고를 상품 단위로 합산
         Map<Long, Integer> availableMap = inventoryRepository.findAllByProductIdIn(ids).stream()
-                .collect(Collectors.toMap(i -> i.getProduct().getId(), Inventory::getAvailable));
+                .collect(Collectors.groupingBy(
+                        i -> i.getVariant().getProduct().getId(),
+                        Collectors.summingInt(Inventory::getAvailable)));
 
         Map<Long, ReviewStatsProjection> statsMap = reviewRepository
                 .findReviewStatsByProductIdIn(ids).stream()
@@ -310,6 +381,7 @@ public class ProductService {
                     stats != null ? stats.getReviewCount() : 0L,
                     null,
                     null,
+                    null,
                     userId != null ? wishlistedIds.contains(p.getId()) : null);
         });
     }
@@ -325,7 +397,9 @@ public class ProductService {
         int threshold = systemSettingService.getLowStockThreshold();
 
         Map<Long, Integer> availableMap = inventoryRepository.findAllByProductIdIn(ids).stream()
-                .collect(Collectors.toMap(i -> i.getProduct().getId(), Inventory::getAvailable));
+                .collect(Collectors.groupingBy(
+                        i -> i.getVariant().getProduct().getId(),
+                        Collectors.summingInt(Inventory::getAvailable)));
 
         Map<Long, ReviewStatsProjection> statsMap = reviewRepository
                 .findReviewStatsByProductIdIn(ids).stream()
@@ -372,6 +446,16 @@ public class ProductService {
         if (categoryId == null) return null;
         return categoryRepository.findById(categoryId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.CATEGORY_NOT_FOUND));
+    }
+
+    /** variant를 조회하고 해당 상품 소속인지 검증한다. */
+    private ProductVariant findVariant(Long productId, Long variantId) {
+        ProductVariant variant = variantRepository.findById(variantId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.VARIANT_NOT_FOUND));
+        if (!variant.getProduct().getId().equals(productId)) {
+            throw new BusinessException(ErrorCode.VARIANT_NOT_FOUND);
+        }
+        return variant;
     }
 
 }

--- a/src/main/java/com/stockmanagement/domain/product/wishlist/service/WishlistService.java
+++ b/src/main/java/com/stockmanagement/domain/product/wishlist/service/WishlistService.java
@@ -51,9 +51,8 @@ public class WishlistService {
                 .productId(productId)
                 .build();
 
-        int available = inventoryRepository.findByProductId(productId)
-                .map(Inventory::getAvailable)
-                .orElse(0);
+        int available = inventoryRepository.findAllByProductId(productId).stream()
+                .mapToInt(Inventory::getAvailable).sum();
         StockStatus stockStatus = StockStatus.of(available, systemSettingService.getLowStockThreshold());
         return WishlistResponse.of(wishlistRepository.save(item), product, stockStatus);
     }
@@ -97,7 +96,9 @@ public class WishlistService {
         Map<Long, Product> productMap = productRepository.findAllById(productIds).stream()
                 .collect(Collectors.toMap(Product::getId, Function.identity()));
         Map<Long, Integer> availableMap = inventoryRepository.findAllByProductIdIn(productIds).stream()
-                .collect(Collectors.toMap(i -> i.getProduct().getId(), Inventory::getAvailable));
+                .collect(Collectors.groupingBy(
+                        i -> i.getVariant().getProduct().getId(),
+                        Collectors.summingInt(Inventory::getAvailable)));
 
         return page.map(item -> {
             int avail = availableMap.getOrDefault(item.getProductId(), 0);

--- a/src/main/resources/db/migration/V56__create_product_variants.sql
+++ b/src/main/resources/db/migration/V56__create_product_variants.sql
@@ -1,0 +1,65 @@
+-- 상품 옵션/변형(variants) 시스템 도입
+-- Product 1:N ProductVariant, Inventory FK를 product_id → variant_id로 전환
+
+-- 1) product_variants 테이블 생성
+CREATE TABLE product_variants (
+    id          BIGINT         NOT NULL AUTO_INCREMENT,
+    product_id  BIGINT         NOT NULL,
+    option_name VARCHAR(100)   NOT NULL,
+    sku         VARCHAR(100)   NOT NULL,
+    price       DECIMAL(15,2)  NOT NULL,
+    status      VARCHAR(20)    NOT NULL DEFAULT 'ACTIVE',
+    created_at  DATETIME(6)    NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at  DATETIME(6)    NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_variant_sku (sku),
+    INDEX idx_variant_product (product_id),
+    CONSTRAINT fk_variant_product FOREIGN KEY (product_id) REFERENCES products (id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
+
+-- 2) 기존 상품마다 기본 variant 자동 생성
+INSERT INTO product_variants (product_id, option_name, sku, price, status, created_at, updated_at)
+SELECT id, '기본', sku, price, status, NOW(6), NOW(6) FROM products;
+
+-- 3) inventory에 variant_id 컬럼 추가 + 데이터 채우기
+ALTER TABLE inventory ADD COLUMN variant_id BIGINT NULL AFTER product_id;
+
+UPDATE inventory i
+    INNER JOIN product_variants pv ON pv.product_id = i.product_id
+SET i.variant_id = pv.id;
+
+ALTER TABLE inventory
+    MODIFY COLUMN variant_id BIGINT NOT NULL,
+    ADD UNIQUE KEY uk_inventory_variant (variant_id),
+    ADD CONSTRAINT fk_inventory_variant FOREIGN KEY (variant_id) REFERENCES product_variants (id);
+
+-- product_id UNIQUE → 일반 INDEX 전환 (컬럼 유지, 읽기 전용 JOIN 호환)
+-- 먼저 일반 인덱스 추가 후 UNIQUE 인덱스 제거 (FK가 새 인덱스로 전환)
+ALTER TABLE inventory
+    ADD INDEX idx_inventory_product (product_id),
+    DROP INDEX uk_inventory_product;
+
+-- 4) order_items에 variant_id 추가
+ALTER TABLE order_items ADD COLUMN variant_id BIGINT NULL AFTER product_id;
+
+UPDATE order_items oi
+    INNER JOIN product_variants pv ON pv.product_id = oi.product_id AND pv.option_name = '기본'
+SET oi.variant_id = pv.id;
+
+ALTER TABLE order_items
+    MODIFY COLUMN variant_id BIGINT NOT NULL,
+    ADD INDEX idx_order_items_variant (variant_id),
+    ADD CONSTRAINT fk_order_items_variant FOREIGN KEY (variant_id) REFERENCES product_variants (id);
+
+-- 5) cart_items에 variant_id 추가 + UK 변경
+ALTER TABLE cart_items ADD COLUMN variant_id BIGINT NULL AFTER product_id;
+
+UPDATE cart_items ci
+    INNER JOIN product_variants pv ON pv.product_id = ci.product_id AND pv.option_name = '기본'
+SET ci.variant_id = pv.id;
+
+ALTER TABLE cart_items
+    MODIFY COLUMN variant_id BIGINT NOT NULL,
+    ADD CONSTRAINT fk_cart_items_variant FOREIGN KEY (variant_id) REFERENCES product_variants (id),
+    DROP INDEX uk_cart_user_product,
+    ADD UNIQUE KEY uk_cart_user_variant (user_id, variant_id);

--- a/src/test/java/com/stockmanagement/domain/inventory/controller/InventoryControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/inventory/controller/InventoryControllerTest.java
@@ -111,19 +111,19 @@ class InventoryControllerTest {
         }
     }
 
-    // ===== GET /api/inventory/{productId} =====
+    // ===== GET /api/inventory/variants/{variantId} =====
 
     @Nested
-    @DisplayName("GET /api/inventory/{productId}")
-    class GetByProductId {
+    @DisplayName("GET /api/inventory/variants/{variantId}")
+    class GetByVariantId {
 
         @Test
         @WithMockUser(roles = "ADMIN")
         @DisplayName("ADMIN — 재고 현황 조회 → 200")
         void returnsInventory() throws Exception {
-            given(inventoryService.getByProductId(1L)).willReturn(mock(InventoryResponse.class));
+            given(inventoryService.getByVariantId(1L)).willReturn(mock(InventoryResponse.class));
 
-            mockMvc.perform(get("/api/inventory/1"))
+            mockMvc.perform(get("/api/inventory/variants/1"))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true));
         }
@@ -131,27 +131,27 @@ class InventoryControllerTest {
         @Test
         @DisplayName("인증 없음 → 401")
         void unauthorizedWithoutAuth() throws Exception {
-            mockMvc.perform(get("/api/inventory/1"))
+            mockMvc.perform(get("/api/inventory/variants/1"))
                     .andExpect(status().isUnauthorized());
         }
 
         @Test
         @WithMockUser(roles = "ADMIN")
-        @DisplayName("존재하지 않는 상품 재고 조회 → 404")
+        @DisplayName("존재하지 않는 variant 재고 조회 → 404")
         void returnsNotFound() throws Exception {
-            given(inventoryService.getByProductId(999L))
+            given(inventoryService.getByVariantId(999L))
                     .willThrow(new BusinessException(ErrorCode.INVENTORY_NOT_FOUND));
 
-            mockMvc.perform(get("/api/inventory/999"))
+            mockMvc.perform(get("/api/inventory/variants/999"))
                     .andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.success").value(false));
         }
     }
 
-    // ===== GET /api/inventory/{productId}/transactions =====
+    // ===== GET /api/inventory/variants/{variantId}/transactions =====
 
     @Nested
-    @DisplayName("GET /api/inventory/{productId}/transactions")
+    @DisplayName("GET /api/inventory/variants/{variantId}/transactions")
     class GetTransactions {
 
         @Test
@@ -161,7 +161,7 @@ class InventoryControllerTest {
             given(inventoryService.getTransactions(eq(1L), any(), eq(20)))
                     .willReturn(CursorPage.of(java.util.List.of(), 20, t -> t.getId()));
 
-            mockMvc.perform(get("/api/inventory/1/transactions"))
+            mockMvc.perform(get("/api/inventory/variants/1/transactions"))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.data.hasNext").value(false));
@@ -170,27 +170,27 @@ class InventoryControllerTest {
         @Test
         @DisplayName("인증 없음 → 401")
         void unauthorizedWithoutAuth() throws Exception {
-            mockMvc.perform(get("/api/inventory/1/transactions"))
+            mockMvc.perform(get("/api/inventory/variants/1/transactions"))
                     .andExpect(status().isUnauthorized());
         }
 
         @Test
         @WithMockUser(roles = "ADMIN")
-        @DisplayName("재고가 없는 상품 이력 조회 → 404")
+        @DisplayName("재고가 없는 variant 이력 조회 → 404")
         void returnsNotFoundWhenInventoryMissing() throws Exception {
             given(inventoryService.getTransactions(eq(999L), any(), eq(20)))
                     .willThrow(new BusinessException(ErrorCode.INVENTORY_NOT_FOUND));
 
-            mockMvc.perform(get("/api/inventory/999/transactions"))
+            mockMvc.perform(get("/api/inventory/variants/999/transactions"))
                     .andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.success").value(false));
         }
     }
 
-    // ===== POST /api/inventory/{productId}/receive =====
+    // ===== POST /api/inventory/variants/{variantId}/receive =====
 
     @Nested
-    @DisplayName("POST /api/inventory/{productId}/receive")
+    @DisplayName("POST /api/inventory/variants/{variantId}/receive")
     class Receive {
 
         private static final String VALID_JSON = "{\"quantity\":10}";
@@ -201,7 +201,7 @@ class InventoryControllerTest {
         void receivesInventory() throws Exception {
             given(inventoryService.receive(eq(1L), any())).willReturn(mock(InventoryResponse.class));
 
-            mockMvc.perform(post("/api/inventory/1/receive")
+            mockMvc.perform(post("/api/inventory/variants/1/receive")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(VALID_JSON))
                     .andExpect(status().isOk())
@@ -212,7 +212,7 @@ class InventoryControllerTest {
         @WithMockUser
         @DisplayName("USER — ADMIN 전용 → 403")
         void forbiddenForUser() throws Exception {
-            mockMvc.perform(post("/api/inventory/1/receive")
+            mockMvc.perform(post("/api/inventory/variants/1/receive")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(VALID_JSON))
                     .andExpect(status().isForbidden());
@@ -221,7 +221,7 @@ class InventoryControllerTest {
         @Test
         @DisplayName("인증 없음 → 401")
         void unauthorizedWithoutAuth() throws Exception {
-            mockMvc.perform(post("/api/inventory/1/receive")
+            mockMvc.perform(post("/api/inventory/variants/1/receive")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(VALID_JSON))
                     .andExpect(status().isUnauthorized());
@@ -231,7 +231,7 @@ class InventoryControllerTest {
         @WithMockUser(roles = "ADMIN")
         @DisplayName("quantity 누락 또는 0 이하 → 400")
         void validationFailure() throws Exception {
-            mockMvc.perform(post("/api/inventory/1/receive")
+            mockMvc.perform(post("/api/inventory/variants/1/receive")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content("{}"))
                     .andExpect(status().isBadRequest());

--- a/src/test/java/com/stockmanagement/domain/inventory/entity/InventoryTest.java
+++ b/src/test/java/com/stockmanagement/domain/inventory/entity/InventoryTest.java
@@ -4,6 +4,7 @@ import com.stockmanagement.common.exception.BusinessException;
 import com.stockmanagement.common.exception.ErrorCode;
 import com.stockmanagement.common.exception.InsufficientStockException;
 import com.stockmanagement.domain.product.entity.Product;
+import com.stockmanagement.domain.product.entity.ProductVariant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -17,6 +18,7 @@ import static org.assertj.core.api.Assertions.*;
 class InventoryTest {
 
     private Product product;
+    private ProductVariant variant;
 
     @BeforeEach
     void setUp() {
@@ -26,10 +28,16 @@ class InventoryTest {
                 .price(new BigDecimal("10000"))
                 .sku("SKU-001")
                 .build();
+        variant = ProductVariant.builder()
+                .product(product)
+                .optionName("기본")
+                .sku("SKU-001")
+                .price(new BigDecimal("10000"))
+                .build();
     }
 
     private Inventory createInventory() {
-        return Inventory.builder().product(product).build();
+        return Inventory.builder().variant(variant).build();
     }
 
     // ===== getAvailable() =====

--- a/src/test/java/com/stockmanagement/domain/inventory/entity/InventoryTransactionTest.java
+++ b/src/test/java/com/stockmanagement/domain/inventory/entity/InventoryTransactionTest.java
@@ -1,6 +1,7 @@
 package com.stockmanagement.domain.inventory.entity;
 
 import com.stockmanagement.domain.product.entity.Product;
+import com.stockmanagement.domain.product.entity.ProductVariant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -22,7 +23,13 @@ class InventoryTransactionTest {
                 .price(new BigDecimal("10000"))
                 .sku("SKU-001")
                 .build();
-        inventory = Inventory.builder().product(product).build();
+        ProductVariant variant = ProductVariant.builder()
+                .product(product)
+                .optionName("기본")
+                .sku("SKU-001")
+                .price(new BigDecimal("10000"))
+                .build();
+        inventory = Inventory.builder().variant(variant).build();
         inventory.receive(10);
         inventory.reserve(3);
     }

--- a/src/test/java/com/stockmanagement/domain/inventory/scheduler/InventorySnapshotSchedulerTest.java
+++ b/src/test/java/com/stockmanagement/domain/inventory/scheduler/InventorySnapshotSchedulerTest.java
@@ -66,7 +66,7 @@ class InventorySnapshotSchedulerTest {
     // ===== 헬퍼 =====
 
     private Inventory buildInventory(Long id, int onHand, int reserved, int allocated) {
-        Inventory inv = Inventory.builder().product(null).build();
+        Inventory inv = Inventory.builder().variant(null).build();
         ReflectionTestUtils.setField(inv, "id", id);
         ReflectionTestUtils.setField(inv, "onHand", onHand);
         ReflectionTestUtils.setField(inv, "reserved", reserved);

--- a/src/test/java/com/stockmanagement/domain/inventory/service/InventoryServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/inventory/service/InventoryServiceTest.java
@@ -15,7 +15,9 @@ import com.stockmanagement.domain.admin.setting.service.SystemSettingService;
 import com.stockmanagement.domain.inventory.repository.InventoryRepository;
 import com.stockmanagement.domain.inventory.repository.InventoryTransactionRepository;
 import com.stockmanagement.domain.product.entity.Product;
-import com.stockmanagement.domain.product.repository.ProductRepository;
+import com.stockmanagement.domain.product.entity.ProductVariant;
+import com.stockmanagement.domain.product.repository.ProductVariantRepository;
+import org.springframework.cache.CacheManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -52,7 +54,7 @@ class InventoryServiceTest {
     private InventoryTransactionRepository transactionRepository;
 
     @Mock
-    private ProductRepository productRepository;
+    private ProductVariantRepository variantRepository;
 
     @Mock
     private org.springframework.context.ApplicationEventPublisher eventPublisher;
@@ -60,10 +62,14 @@ class InventoryServiceTest {
     @Mock
     private SystemSettingService systemSettingService;
 
+    @Mock
+    private CacheManager cacheManager;
+
     @InjectMocks
     private InventoryService inventoryService;
 
     private Product product;
+    private ProductVariant variant;
 
     @BeforeEach
     void setUp() {
@@ -73,30 +79,37 @@ class InventoryServiceTest {
                 .price(new BigDecimal("10000"))
                 .sku("SKU-001")
                 .build();
+        variant = ProductVariant.builder()
+                .product(product)
+                .optionName("기본")
+                .sku("SKU-001")
+                .price(new BigDecimal("10000"))
+                .build();
         lenient().when(systemSettingService.getLowStockThreshold()).thenReturn(10);
+        lenient().when(cacheManager.getCache("products")).thenReturn(null);
     }
 
     /** onHand=10, reserved=3, available=7 인 재고 픽스처 */
     private Inventory inventoryWithStock() {
-        Inventory inv = Inventory.builder().product(product).build();
+        Inventory inv = Inventory.builder().variant(variant).build();
         inv.receive(10);
         inv.reserve(3);
         return inv;
     }
 
-    // ===== getByProductId() =====
+    // ===== getByVariantId() =====
 
     @Nested
-    @DisplayName("getByProductId()")
-    class GetByProductId {
+    @DisplayName("getByVariantId()")
+    class GetByVariantId {
 
         @Test
         @DisplayName("재고가 존재하면 수량 정보가 담긴 InventoryResponse를 반환한다")
         void returnsInventoryResponse() {
             Inventory inventory = inventoryWithStock();
-            given(inventoryRepository.findByProductId(1L)).willReturn(Optional.of(inventory));
+            given(inventoryRepository.findByVariantId(1L)).willReturn(Optional.of(inventory));
 
-            InventoryResponse response = inventoryService.getByProductId(1L);
+            InventoryResponse response = inventoryService.getByVariantId(1L);
 
             assertThat(response.getOnHand()).isEqualTo(10);
             assertThat(response.getReserved()).isEqualTo(3);
@@ -106,9 +119,9 @@ class InventoryServiceTest {
         @Test
         @DisplayName("재고 레코드가 없으면 INVENTORY_NOT_FOUND 예외를 발생시킨다")
         void throwsWhenNotFound() {
-            given(inventoryRepository.findByProductId(99L)).willReturn(Optional.empty());
+            given(inventoryRepository.findByVariantId(99L)).willReturn(Optional.empty());
 
-            assertThatThrownBy(() -> inventoryService.getByProductId(99L))
+            assertThatThrownBy(() -> inventoryService.getByVariantId(99L))
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                             .isEqualTo(ErrorCode.INVENTORY_NOT_FOUND));
@@ -125,7 +138,7 @@ class InventoryServiceTest {
         @DisplayName("재고가 존재하면 이력 목록을 반환한다 (커서 기반)")
         void returnsTransactionList() {
             Inventory inventory = inventoryWithStock();
-            given(inventoryRepository.findByProductId(1L)).willReturn(Optional.of(inventory));
+            given(inventoryRepository.findByVariantId(1L)).willReturn(Optional.of(inventory));
             InventoryTransaction tx = mock(InventoryTransaction.class);
             given(tx.getId()).willReturn(1L);
             given(tx.getType()).willReturn(InventoryTransactionType.RECEIVE);
@@ -134,7 +147,7 @@ class InventoryServiceTest {
             given(tx.getSnapshotReserved()).willReturn(0);
             given(tx.getSnapshotAllocated()).willReturn(0);
             given(tx.getCreatedAt()).willReturn(LocalDateTime.now());
-            given(transactionRepository.findByInventoryProductIdOrderByIdDesc(eq(1L), any(Pageable.class)))
+            given(transactionRepository.findByInventoryIdOrderByIdDesc(any(), any(Pageable.class)))
                     .willReturn(List.of(tx));
 
             var result = inventoryService.getTransactions(1L, null, 20);
@@ -146,7 +159,7 @@ class InventoryServiceTest {
         @Test
         @DisplayName("재고 레코드가 없으면 INVENTORY_NOT_FOUND 예외를 발생시킨다")
         void throwsWhenInventoryNotFound() {
-            given(inventoryRepository.findByProductId(99L)).willReturn(Optional.empty());
+            given(inventoryRepository.findByVariantId(99L)).willReturn(Optional.empty());
 
             assertThatThrownBy(() -> inventoryService.getTransactions(99L, null, 20))
                     .isInstanceOf(BusinessException.class)
@@ -175,8 +188,8 @@ class InventoryServiceTest {
         @DisplayName("기존 재고 레코드가 있으면 onHand를 증가시키고 이력을 기록한다")
         void increasesOnHandForExistingInventory() {
             Inventory inventory = inventoryWithStock(); // onHand=10
-            given(productRepository.findById(1L)).willReturn(Optional.of(product));
-            given(inventoryRepository.findByProductIdWithLock(1L)).willReturn(Optional.of(inventory));
+            given(variantRepository.findByIdWithProduct(1L)).willReturn(Optional.of(variant));
+            given(inventoryRepository.findByVariantIdWithLock(1L)).willReturn(Optional.of(inventory));
 
             InventoryResponse response = inventoryService.receive(1L, receiveRequest);
 
@@ -187,9 +200,9 @@ class InventoryServiceTest {
         @Test
         @DisplayName("재고 레코드가 없으면 자동 생성 후 onHand를 설정하고 이력을 기록한다")
         void createsInventoryWhenNotExists() {
-            Inventory newInventory = Inventory.builder().product(product).build();
-            given(productRepository.findById(1L)).willReturn(Optional.of(product));
-            given(inventoryRepository.findByProductIdWithLock(1L)).willReturn(Optional.empty());
+            Inventory newInventory = Inventory.builder().variant(variant).build();
+            given(variantRepository.findByIdWithProduct(1L)).willReturn(Optional.of(variant));
+            given(inventoryRepository.findByVariantIdWithLock(1L)).willReturn(Optional.empty());
             given(inventoryRepository.save(any(Inventory.class))).willReturn(newInventory);
 
             InventoryResponse response = inventoryService.receive(1L, receiveRequest);
@@ -200,14 +213,14 @@ class InventoryServiceTest {
         }
 
         @Test
-        @DisplayName("상품이 존재하지 않으면 PRODUCT_NOT_FOUND 예외를 발생시킨다")
-        void throwsWhenProductNotFound() {
-            given(productRepository.findById(99L)).willReturn(Optional.empty());
+        @DisplayName("variant가 존재하지 않으면 VARIANT_NOT_FOUND 예외를 발생시킨다")
+        void throwsWhenVariantNotFound() {
+            given(variantRepository.findByIdWithProduct(99L)).willReturn(Optional.empty());
 
             assertThatThrownBy(() -> inventoryService.receive(99L, receiveRequest))
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
-                            .isEqualTo(ErrorCode.PRODUCT_NOT_FOUND));
+                            .isEqualTo(ErrorCode.VARIANT_NOT_FOUND));
 
             verifyNoInteractions(inventoryRepository, transactionRepository);
         }
@@ -223,7 +236,7 @@ class InventoryServiceTest {
         @DisplayName("가용 재고가 충분하면 reserved가 증가하고 이력을 기록한다")
         void reservesSuccessfully() {
             Inventory inventory = inventoryWithStock(); // available=7
-            given(inventoryRepository.findByProductIdWithLock(1L)).willReturn(Optional.of(inventory));
+            given(inventoryRepository.findByVariantIdWithLock(1L)).willReturn(Optional.of(inventory));
 
             assertThatCode(() -> inventoryService.reserve(1L, 5)).doesNotThrowAnyException();
 
@@ -235,7 +248,7 @@ class InventoryServiceTest {
         @DisplayName("가용 재고 부족 시 InsufficientStockException이 전파된다")
         void propagatesInsufficientStockException() {
             Inventory inventory = inventoryWithStock(); // available=7
-            given(inventoryRepository.findByProductIdWithLock(1L)).willReturn(Optional.of(inventory));
+            given(inventoryRepository.findByVariantIdWithLock(1L)).willReturn(Optional.of(inventory));
 
             assertThatThrownBy(() -> inventoryService.reserve(1L, 8))
                     .isInstanceOf(InsufficientStockException.class);
@@ -244,7 +257,7 @@ class InventoryServiceTest {
         @Test
         @DisplayName("재고 레코드가 없으면 INVENTORY_NOT_FOUND 예외를 발생시킨다")
         void throwsWhenInventoryNotFound() {
-            given(inventoryRepository.findByProductIdWithLock(99L)).willReturn(Optional.empty());
+            given(inventoryRepository.findByVariantIdWithLock(99L)).willReturn(Optional.empty());
 
             assertThatThrownBy(() -> inventoryService.reserve(99L, 1))
                     .isInstanceOf(BusinessException.class)
@@ -263,7 +276,7 @@ class InventoryServiceTest {
         @DisplayName("예약 해제 시 reserved가 감소하고 이력을 기록한다")
         void releasesReservation() {
             Inventory inventory = inventoryWithStock(); // reserved=3
-            given(inventoryRepository.findByProductIdWithLock(1L)).willReturn(Optional.of(inventory));
+            given(inventoryRepository.findByVariantIdWithLock(1L)).willReturn(Optional.of(inventory));
 
             inventoryService.releaseReservation(1L, 3);
 
@@ -274,7 +287,7 @@ class InventoryServiceTest {
         @Test
         @DisplayName("재고 레코드가 없으면 INVENTORY_NOT_FOUND 예외를 발생시킨다")
         void throwsWhenInventoryNotFound() {
-            given(inventoryRepository.findByProductIdWithLock(99L)).willReturn(Optional.empty());
+            given(inventoryRepository.findByVariantIdWithLock(99L)).willReturn(Optional.empty());
 
             assertThatThrownBy(() -> inventoryService.releaseReservation(99L, 1))
                     .isInstanceOf(BusinessException.class)
@@ -293,7 +306,7 @@ class InventoryServiceTest {
         @DisplayName("결제 완료 시 reserved 감소, allocated 증가, 이력 기록")
         void confirmsAllocation() {
             Inventory inventory = inventoryWithStock(); // reserved=3
-            given(inventoryRepository.findByProductIdWithLock(1L)).willReturn(Optional.of(inventory));
+            given(inventoryRepository.findByVariantIdWithLock(1L)).willReturn(Optional.of(inventory));
 
             inventoryService.confirmAllocation(1L, 3);
 
@@ -305,7 +318,7 @@ class InventoryServiceTest {
         @Test
         @DisplayName("재고 레코드가 없으면 INVENTORY_NOT_FOUND 예외를 발생시킨다")
         void throwsWhenInventoryNotFound() {
-            given(inventoryRepository.findByProductIdWithLock(99L)).willReturn(Optional.empty());
+            given(inventoryRepository.findByVariantIdWithLock(99L)).willReturn(Optional.empty());
 
             assertThatThrownBy(() -> inventoryService.confirmAllocation(99L, 1))
                     .isInstanceOf(BusinessException.class)
@@ -325,7 +338,7 @@ class InventoryServiceTest {
         void releasesAllocation() {
             Inventory inventory = inventoryWithStock(); // reserved=3
             inventory.confirmAllocation(3); // reserved=0, allocated=3
-            given(inventoryRepository.findByProductIdWithLock(1L)).willReturn(Optional.of(inventory));
+            given(inventoryRepository.findByVariantIdWithLock(1L)).willReturn(Optional.of(inventory));
 
             inventoryService.releaseAllocation(1L, 3);
 
@@ -338,7 +351,7 @@ class InventoryServiceTest {
         void availableIncreasesAfterRelease() {
             Inventory inventory = inventoryWithStock(); // onHand=10, reserved=3, available=7
             inventory.confirmAllocation(3); // reserved=0, allocated=3, available=7
-            given(inventoryRepository.findByProductIdWithLock(1L)).willReturn(Optional.of(inventory));
+            given(inventoryRepository.findByVariantIdWithLock(1L)).willReturn(Optional.of(inventory));
 
             inventoryService.releaseAllocation(1L, 3);
 
@@ -349,7 +362,7 @@ class InventoryServiceTest {
         @Test
         @DisplayName("재고 레코드가 없으면 INVENTORY_NOT_FOUND 예외를 발생시킨다")
         void throwsWhenInventoryNotFound() {
-            given(inventoryRepository.findByProductIdWithLock(99L)).willReturn(Optional.empty());
+            given(inventoryRepository.findByVariantIdWithLock(99L)).willReturn(Optional.empty());
 
             assertThatThrownBy(() -> inventoryService.releaseAllocation(99L, 1))
                     .isInstanceOf(BusinessException.class)

--- a/src/test/java/com/stockmanagement/domain/order/cart/controller/CartControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/order/cart/controller/CartControllerTest.java
@@ -83,7 +83,7 @@ class CartControllerTest {
     @DisplayName("POST /api/cart/items")
     class AddOrUpdate {
 
-        private static final String ITEM_JSON = "{\"productId\":1,\"quantity\":2}";
+        private static final String ITEM_JSON = "{\"productId\":1,\"variantId\":1,\"quantity\":2}";
 
         @Test
         @DisplayName("인증된 사용자 — 상품 추가 → 200")
@@ -109,23 +109,23 @@ class CartControllerTest {
         }
     }
 
-    // ===== DELETE /api/cart/items/{productId} =====
+    // ===== DELETE /api/cart/items/variants/{variantId} =====
 
     @Nested
-    @DisplayName("DELETE /api/cart/items/{productId}")
+    @DisplayName("DELETE /api/cart/items/variants/{variantId}")
     class RemoveItem {
 
         @Test
-        @DisplayName("인증된 사용자 — 상품 제거 → 204")
+        @DisplayName("인증된 사용자 — 변형 제거 → 204")
         void removesItem() throws Exception {
-            mockMvc.perform(delete("/api/cart/items/1").with(authentication(USER_AUTH)))
+            mockMvc.perform(delete("/api/cart/items/variants/1").with(authentication(USER_AUTH)))
                     .andExpect(status().isNoContent());
         }
 
         @Test
         @DisplayName("인증 없음 → 401")
         void unauthenticated() throws Exception {
-            mockMvc.perform(delete("/api/cart/items/1"))
+            mockMvc.perform(delete("/api/cart/items/variants/1"))
                     .andExpect(status().isUnauthorized());
         }
     }

--- a/src/test/java/com/stockmanagement/domain/order/cart/service/CartServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/order/cart/service/CartServiceTest.java
@@ -12,7 +12,8 @@ import com.stockmanagement.domain.order.cart.repository.CartRepository;
 import com.stockmanagement.domain.order.dto.OrderResponse;
 import com.stockmanagement.domain.order.service.OrderCommandService;
 import com.stockmanagement.domain.product.entity.Product;
-import com.stockmanagement.domain.product.repository.ProductRepository;
+import com.stockmanagement.domain.product.entity.ProductVariant;
+import com.stockmanagement.domain.product.repository.ProductVariantRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -38,7 +39,7 @@ import static org.mockito.Mockito.verify;
 class CartServiceTest {
 
     @Mock CartRepository cartRepository;
-    @Mock ProductRepository productRepository;
+    @Mock ProductVariantRepository variantRepository;
     @Mock InventoryRepository inventoryRepository;
     @Mock OrderCommandService orderCommandService;
     @Mock SystemSettingService systemSettingService;
@@ -46,6 +47,7 @@ class CartServiceTest {
     @InjectMocks CartService cartService;
 
     private Product product;
+    private ProductVariant variant;
     private CartItem cartItem;
 
     @BeforeEach
@@ -54,8 +56,12 @@ class CartServiceTest {
                 .name("상품A").sku("SKU-A").price(BigDecimal.valueOf(1000))
                 .build();
 
+        variant = ProductVariant.builder()
+                .product(product).optionName("기본").sku("SKU-A").price(BigDecimal.valueOf(1000))
+                .build();
+
         cartItem = CartItem.builder()
-                .userId(1L).product(product).quantity(2)
+                .userId(1L).product(product).variant(variant).quantity(2)
                 .build();
     }
 
@@ -94,11 +100,11 @@ class CartServiceTest {
         @Test
         @DisplayName("기존에 없는 상품 → 새 CartItem 저장")
         void addsNewItem() {
-            CartItemRequest request = mockCartItemRequest(1L, 3);
-            given(productRepository.findById(1L)).willReturn(Optional.of(product));
-            given(cartRepository.findByUserIdAndProductId(anyLong(), any())).willReturn(Optional.empty());
+            CartItemRequest request = mockCartItemRequest(1L, 1L, 3);
+            given(variantRepository.findByIdWithProduct(1L)).willReturn(Optional.of(variant));
+            given(cartRepository.findByUserIdAndVariantId(anyLong(), any())).willReturn(Optional.empty());
             given(cartRepository.saveAndFlush(any())).willReturn(cartItem);
-            given(inventoryRepository.findByProductId(any())).willReturn(Optional.empty());
+            given(inventoryRepository.findByVariantId(any())).willReturn(Optional.empty());
 
             cartService.addOrUpdate(1L, request);
 
@@ -108,10 +114,10 @@ class CartServiceTest {
         @Test
         @DisplayName("이미 담긴 상품 → 수량만 업데이트")
         void updatesExistingItem() {
-            CartItemRequest request = mockCartItemRequest(1L, 5);
-            given(productRepository.findById(1L)).willReturn(Optional.of(product));
-            given(cartRepository.findByUserIdAndProductId(eq(1L), any())).willReturn(Optional.of(cartItem));
-            given(inventoryRepository.findByProductId(any())).willReturn(Optional.empty());
+            CartItemRequest request = mockCartItemRequest(1L, 1L, 5);
+            given(variantRepository.findByIdWithProduct(1L)).willReturn(Optional.of(variant));
+            given(cartRepository.findByUserIdAndVariantId(eq(1L), any())).willReturn(Optional.of(cartItem));
+            given(inventoryRepository.findByVariantId(any())).willReturn(Optional.empty());
 
             cartService.addOrUpdate(1L, request);
 
@@ -120,14 +126,14 @@ class CartServiceTest {
         }
 
         @Test
-        @DisplayName("존재하지 않는 상품 → PRODUCT_NOT_FOUND 예외")
-        void throwsWhenProductNotFound() {
-            CartItemRequest request = mockCartItemRequest(999L, 1);
-            given(productRepository.findById(999L)).willReturn(Optional.empty());
+        @DisplayName("존재하지 않는 변형 → VARIANT_NOT_FOUND 예외")
+        void throwsWhenVariantNotFound() {
+            CartItemRequest request = mockCartItemRequest(999L, 999L, 1);
+            given(variantRepository.findByIdWithProduct(999L)).willReturn(Optional.empty());
 
             assertThatThrownBy(() -> cartService.addOrUpdate(1L, request))
                     .isInstanceOf(BusinessException.class)
-                    .hasMessage(ErrorCode.PRODUCT_NOT_FOUND.getMessage());
+                    .hasMessage(ErrorCode.VARIANT_NOT_FOUND.getMessage());
         }
     }
 
@@ -138,7 +144,7 @@ class CartServiceTest {
         @Test
         @DisplayName("담긴 상품 제거 성공")
         void removesExistingItem() {
-            given(cartRepository.findByUserIdAndProductId(1L, 1L)).willReturn(Optional.of(cartItem));
+            given(cartRepository.findByUserIdAndVariantId(1L, 1L)).willReturn(Optional.of(cartItem));
 
             cartService.removeItem(1L, 1L);
 
@@ -148,7 +154,7 @@ class CartServiceTest {
         @Test
         @DisplayName("담기지 않은 상품 제거 → CART_ITEM_NOT_FOUND 예외")
         void throwsWhenItemNotFound() {
-            given(cartRepository.findByUserIdAndProductId(1L, 999L)).willReturn(Optional.empty());
+            given(cartRepository.findByUserIdAndVariantId(1L, 999L)).willReturn(Optional.empty());
 
             assertThatThrownBy(() -> cartService.removeItem(1L, 999L))
                     .isInstanceOf(BusinessException.class)
@@ -170,7 +176,7 @@ class CartServiceTest {
             cartService.checkout(1L, request);
 
             verify(orderCommandService).create(any(), anyLong());
-            verify(cartRepository).deleteByUserIdAndProductIdIn(eq(1L), any());
+            verify(cartRepository).deleteByUserIdAndVariantIdIn(eq(1L), any());
         }
 
         @Test
@@ -186,9 +192,10 @@ class CartServiceTest {
 
     // ===== 헬퍼 =====
 
-    private CartItemRequest mockCartItemRequest(Long productId, int quantity) {
+    private CartItemRequest mockCartItemRequest(Long productId, Long variantId, int quantity) {
         CartItemRequest req = new CartItemRequest();
         org.springframework.test.util.ReflectionTestUtils.setField(req, "productId", productId);
+        org.springframework.test.util.ReflectionTestUtils.setField(req, "variantId", variantId);
         org.springframework.test.util.ReflectionTestUtils.setField(req, "quantity", quantity);
         return req;
     }

--- a/src/test/java/com/stockmanagement/domain/order/controller/OrderControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/order/controller/OrderControllerTest.java
@@ -73,7 +73,7 @@ class OrderControllerTest {
 
         private static final String VALID_JSON =
                 "{\"userId\":1,\"idempotencyKey\":\"key-001\"," +
-                "\"items\":[{\"productId\":1,\"quantity\":2,\"unitPrice\":5000}]}";
+                "\"items\":[{\"productId\":1,\"variantId\":1,\"quantity\":2,\"unitPrice\":5000}]}";
 
         @Test
         @WithMockUser

--- a/src/test/java/com/stockmanagement/domain/order/service/OrderCommandServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/order/service/OrderCommandServiceTest.java
@@ -18,7 +18,8 @@ import com.stockmanagement.domain.order.repository.OrderDeliverySnapshotReposito
 import com.stockmanagement.domain.order.repository.OrderRepository;
 import com.stockmanagement.domain.order.repository.OrderStatusHistoryRepository;
 import com.stockmanagement.domain.product.entity.Product;
-import com.stockmanagement.domain.product.repository.ProductRepository;
+import com.stockmanagement.domain.product.entity.ProductVariant;
+import com.stockmanagement.domain.product.repository.ProductVariantRepository;
 import com.stockmanagement.common.outbox.OutboxEventStore;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -48,7 +49,7 @@ class OrderCommandServiceTest {
     private OrderRepository orderRepository;
 
     @Mock
-    private ProductRepository productRepository;
+    private ProductVariantRepository variantRepository;
 
     @Mock
     private InventoryService inventoryService;
@@ -75,6 +76,7 @@ class OrderCommandServiceTest {
     private OrderCommandService orderCommandService;
 
     private Product product;
+    private ProductVariant variant;
     private Order order;
 
     @BeforeEach
@@ -85,7 +87,15 @@ class OrderCommandServiceTest {
                 .price(new BigDecimal("10000"))
                 .sku("SKU-001")
                 .build();
-        ReflectionTestUtils.setField(product, "id", 1L); // findAllById 결과 Map 조회에 필요
+        ReflectionTestUtils.setField(product, "id", 1L);
+
+        variant = ProductVariant.builder()
+                .product(product)
+                .optionName("기본")
+                .sku("SKU-001")
+                .price(new BigDecimal("10000"))
+                .build();
+        ReflectionTestUtils.setField(variant, "id", 1L);
 
         order = Order.builder()
                 .userId(1L)
@@ -95,6 +105,7 @@ class OrderCommandServiceTest {
 
         OrderItem orderItem = OrderItem.builder()
                 .product(product)
+                .variant(variant)
                 .quantity(1)
                 .unitPrice(new BigDecimal("10000"))
                 .build();
@@ -111,7 +122,7 @@ class OrderCommandServiceTest {
         @DisplayName("정상 주문 생성 — Order 저장 및 재고 예약 호출")
         void createsOrderAndReservesStock() {
             OrderItemRequest itemRequest = mock(OrderItemRequest.class);
-            given(itemRequest.getProductId()).willReturn(1L);
+            given(itemRequest.getVariantId()).willReturn(1L);
             given(itemRequest.getQuantity()).willReturn(1);
             given(itemRequest.getUnitPrice()).willReturn(new BigDecimal("10000"));
 
@@ -121,13 +132,13 @@ class OrderCommandServiceTest {
             given(request.getItems()).willReturn(List.of(itemRequest));
 
             given(orderRepository.findByIdempotencyKey("idem-key-001")).willReturn(Optional.empty());
-            given(productRepository.findAllById(anyIterable())).willReturn(List.of(product));
+            given(variantRepository.findAllByIdInWithProduct(anyCollection())).willReturn(List.of(variant));
             given(orderRepository.save(any(Order.class))).willReturn(order);
 
             OrderResponse response = orderCommandService.create(request);
 
             verify(orderRepository).save(any(Order.class));
-            verify(inventoryService).reserve(any(), eq(1));
+            verify(inventoryService).reserve(eq(1L), eq(1));
             assertThat(response.getStatus()).isEqualTo(OrderStatus.PENDING);
             assertThat(response.getTotalAmount()).isEqualByComparingTo("10000");
             assertThat(response.getIdempotencyKey()).isEqualTo("idem-key-001");
@@ -137,7 +148,7 @@ class OrderCommandServiceTest {
         @DisplayName("멱등성 키 경쟁 조건 — save()에서 DataIntegrityViolationException 발생 시 기존 주문 반환")
         void returnsExistingOrderOnDataIntegrityViolation() {
             OrderItemRequest itemRequest = mock(OrderItemRequest.class);
-            given(itemRequest.getProductId()).willReturn(1L);
+            given(itemRequest.getVariantId()).willReturn(1L);
             given(itemRequest.getQuantity()).willReturn(1);
             given(itemRequest.getUnitPrice()).willReturn(new BigDecimal("10000"));
 
@@ -147,9 +158,9 @@ class OrderCommandServiceTest {
             given(request.getItems()).willReturn(List.of(itemRequest));
 
             given(orderRepository.findByIdempotencyKey("idem-key-race"))
-                    .willReturn(Optional.empty())   // 1차 조회: 없음 → 저장 진행
+                    .willReturn(Optional.empty())   // 1차 조회: 없음 -> 저장 진행
                     .willReturn(Optional.of(order)); // 2차 조회(catch 내부): 기존 주문 반환
-            given(productRepository.findAllById(anyIterable())).willReturn(List.of(product));
+            given(variantRepository.findAllByIdInWithProduct(anyCollection())).willReturn(List.of(variant));
             given(orderRepository.save(any(Order.class)))
                     .willThrow(new org.springframework.dao.DataIntegrityViolationException("duplicate"));
 
@@ -174,34 +185,32 @@ class OrderCommandServiceTest {
         }
 
         @Test
-        @DisplayName("존재하지 않는 상품 ID 포함 시 PRODUCT_NOT_FOUND 예외 발생")
-        void throwsWhenProductNotFound() {
-            // getUnitPrice/getQuantity는 상품 조회 실패 시 호출되지 않으므로 스텁 불필요
+        @DisplayName("존재하지 않는 변형 ID 포함 시 VARIANT_NOT_FOUND 예외 발생")
+        void throwsWhenVariantNotFound() {
             OrderItemRequest itemRequest = mock(OrderItemRequest.class);
-            given(itemRequest.getProductId()).willReturn(99L);
+            given(itemRequest.getVariantId()).willReturn(99L);
 
             OrderCreateRequest request = mock(OrderCreateRequest.class);
             given(request.getIdempotencyKey()).willReturn("idem-key-001");
             given(request.getItems()).willReturn(List.of(itemRequest));
 
             given(orderRepository.findByIdempotencyKey("idem-key-001")).willReturn(Optional.empty());
-            given(productRepository.findAllById(anyIterable())).willReturn(List.of()); // 존재하지 않는 상품
+            given(variantRepository.findAllByIdInWithProduct(anyCollection())).willReturn(List.of()); // 존재하지 않는 변형
 
             assertThatThrownBy(() -> orderCommandService.create(request))
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
-                            .isEqualTo(ErrorCode.PRODUCT_NOT_FOUND));
+                            .isEqualTo(ErrorCode.VARIANT_NOT_FOUND));
 
             verify(orderRepository, never()).save(any());
             verifyNoInteractions(inventoryService);
         }
 
         @Test
-        @DisplayName("요청 단가와 상품 가격 불일치 시 INVALID_INPUT 예외 발생")
+        @DisplayName("요청 단가와 변형 가격 불일치 시 INVALID_INPUT 예외 발생")
         void throwsWhenUnitPriceMismatch() {
-            // getQuantity/getUserId는 단가 불일치 예외 경로에서 호출되지 않으므로 스텁 불필요
             OrderItemRequest itemRequest = mock(OrderItemRequest.class);
-            given(itemRequest.getProductId()).willReturn(1L);
+            given(itemRequest.getVariantId()).willReturn(1L);
             given(itemRequest.getUnitPrice()).willReturn(new BigDecimal("9999")); // 불일치
 
             OrderCreateRequest request = mock(OrderCreateRequest.class);
@@ -209,7 +218,7 @@ class OrderCommandServiceTest {
             given(request.getItems()).willReturn(List.of(itemRequest));
 
             given(orderRepository.findByIdempotencyKey("idem-key-001")).willReturn(Optional.empty());
-            given(productRepository.findAllById(anyIterable())).willReturn(List.of(product)); // price=10000
+            given(variantRepository.findAllByIdInWithProduct(anyCollection())).willReturn(List.of(variant)); // price=10000
 
             assertThatThrownBy(() -> orderCommandService.create(request))
                     .isInstanceOf(BusinessException.class)
@@ -220,12 +229,12 @@ class OrderCommandServiceTest {
         }
 
         @Test
-        @DisplayName("동일 상품 중복 포함 시 INVALID_INPUT 예외 발생")
-        void throwsWhenDuplicateProductId() {
+        @DisplayName("동일 변형 중복 포함 시 INVALID_INPUT 예외 발생")
+        void throwsWhenDuplicateVariantId() {
             OrderItemRequest item1 = mock(OrderItemRequest.class);
-            given(item1.getProductId()).willReturn(1L);
+            given(item1.getVariantId()).willReturn(1L);
             OrderItemRequest item2 = mock(OrderItemRequest.class);
-            given(item2.getProductId()).willReturn(1L); // 중복 상품
+            given(item2.getVariantId()).willReturn(1L); // 중복 변형
 
             OrderCreateRequest request = mock(OrderCreateRequest.class);
             given(request.getIdempotencyKey()).willReturn("idem-key-dup");
@@ -246,7 +255,7 @@ class OrderCommandServiceTest {
         @DisplayName("쿠폰 코드 포함 주문 생성 — discountAmount 적용")
         void createOrderWithCoupon() {
             OrderItemRequest itemRequest = mock(OrderItemRequest.class);
-            given(itemRequest.getProductId()).willReturn(1L);
+            given(itemRequest.getVariantId()).willReturn(1L);
             given(itemRequest.getQuantity()).willReturn(1);
             given(itemRequest.getUnitPrice()).willReturn(new BigDecimal("10000"));
 
@@ -257,7 +266,7 @@ class OrderCommandServiceTest {
             given(request.getCouponCode()).willReturn("FIXED2000");
 
             given(orderRepository.findByIdempotencyKey("idem-key-coupon")).willReturn(Optional.empty());
-            given(productRepository.findAllById(anyIterable())).willReturn(List.of(product));
+            given(variantRepository.findAllByIdInWithProduct(anyCollection())).willReturn(List.of(variant));
             given(orderRepository.save(any(Order.class))).willReturn(order);
 
             CouponValidateResponse couponResult = CouponValidateResponse.builder()
@@ -271,7 +280,6 @@ class OrderCommandServiceTest {
             OrderResponse response = orderCommandService.create(request);
 
             verify(couponService).applyCoupon(eq("FIXED2000"), eq(1L), any(), any());
-            // Order.applyDiscount()가 호출되어 discountAmount가 설정됨
             assertThat(response).isNotNull();
         }
 
@@ -279,7 +287,7 @@ class OrderCommandServiceTest {
         @DisplayName("재고 부족 시 InsufficientStockException이 전파된다")
         void propagatesInsufficientStockException() {
             OrderItemRequest itemRequest = mock(OrderItemRequest.class);
-            given(itemRequest.getProductId()).willReturn(1L);
+            given(itemRequest.getVariantId()).willReturn(1L);
             given(itemRequest.getQuantity()).willReturn(100);
             given(itemRequest.getUnitPrice()).willReturn(new BigDecimal("10000"));
 
@@ -289,10 +297,10 @@ class OrderCommandServiceTest {
             given(request.getItems()).willReturn(List.of(itemRequest));
 
             given(orderRepository.findByIdempotencyKey("idem-key-001")).willReturn(Optional.empty());
-            given(productRepository.findAllById(anyIterable())).willReturn(List.of(product));
+            given(variantRepository.findAllByIdInWithProduct(anyCollection())).willReturn(List.of(variant));
             given(orderRepository.save(any(Order.class))).willReturn(order);
             doThrow(new InsufficientStockException(100, 5))
-                    .when(inventoryService).reserve(any(), anyInt());
+                    .when(inventoryService).reserve(anyLong(), anyInt());
 
             assertThatThrownBy(() -> orderCommandService.create(request))
                     .isInstanceOf(InsufficientStockException.class);
@@ -310,17 +318,17 @@ class OrderCommandServiceTest {
         void cancelsPendingOrder() {
             given(orderRepository.findByIdWithItemsForUpdate(1L)).willReturn(Optional.of(order));
 
-            OrderResponse response = orderCommandService.cancel(1L, 1L, false, null); // userId=1L, order.userId=1L
+            OrderResponse response = orderCommandService.cancel(1L, 1L, false, null);
 
             assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELLED);
-            verify(inventoryService).releaseReservation(any(), eq(1));
+            verify(inventoryService).releaseReservation(eq(1L), eq(1));
             assertThat(response.getStatus()).isEqualTo(OrderStatus.CANCELLED);
         }
 
         @Test
         @DisplayName("CONFIRMED 주문 취소 시도 — INVALID_ORDER_STATUS 예외 발생")
         void throwsWhenCancellingConfirmedOrder() {
-            order.confirm(); // PENDING → CONFIRMED
+            order.confirm(); // PENDING -> CONFIRMED
             given(orderRepository.findByIdWithItemsForUpdate(1L)).willReturn(Optional.of(order));
 
             assertThatThrownBy(() -> orderCommandService.cancel(1L, 1L, false, null))

--- a/src/test/java/com/stockmanagement/domain/order/service/OrderPaymentServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/order/service/OrderPaymentServiceTest.java
@@ -12,6 +12,7 @@ import com.stockmanagement.domain.order.repository.OrderRepository;
 import com.stockmanagement.domain.order.repository.OrderStatusHistoryRepository;
 import com.stockmanagement.domain.point.service.PointService;
 import com.stockmanagement.domain.product.entity.Product;
+import com.stockmanagement.domain.product.entity.ProductVariant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -56,6 +57,7 @@ class OrderPaymentServiceTest {
     private OrderPaymentService orderPaymentService;
 
     private Product product;
+    private ProductVariant variant;
     private Order order;
 
     @BeforeEach
@@ -68,6 +70,14 @@ class OrderPaymentServiceTest {
                 .build();
         ReflectionTestUtils.setField(product, "id", 1L);
 
+        variant = ProductVariant.builder()
+                .product(product)
+                .optionName("기본")
+                .sku("SKU-001")
+                .price(new BigDecimal("10000"))
+                .build();
+        ReflectionTestUtils.setField(variant, "id", 1L);
+
         order = Order.builder()
                 .userId(1L)
                 .totalAmount(new BigDecimal("10000"))
@@ -76,6 +86,7 @@ class OrderPaymentServiceTest {
 
         OrderItem orderItem = OrderItem.builder()
                 .product(product)
+                .variant(variant)
                 .quantity(1)
                 .unitPrice(new BigDecimal("10000"))
                 .build();
@@ -96,19 +107,19 @@ class OrderPaymentServiceTest {
             orderPaymentService.confirm(1L);
 
             assertThat(order.getStatus()).isEqualTo(OrderStatus.CONFIRMED);
-            verify(inventoryService).confirmAllocation(any(), eq(1));
+            verify(inventoryService).confirmAllocation(eq(1L), eq(1));
         }
 
         @Test
         @DisplayName("PAYMENT_IN_PROGRESS 주문 확정 — 일반 Toss 결제 경로 (CONFIRMED 전환)")
         void confirmsPaymentInProgressOrder() {
-            order.startPayment(); // PENDING → PAYMENT_IN_PROGRESS
+            order.startPayment(); // PENDING -> PAYMENT_IN_PROGRESS
             given(orderRepository.findByIdWithItemsForUpdate(1L)).willReturn(Optional.of(order));
 
             orderPaymentService.confirm(1L);
 
             assertThat(order.getStatus()).isEqualTo(OrderStatus.CONFIRMED);
-            verify(inventoryService).confirmAllocation(any(), eq(1));
+            verify(inventoryService).confirmAllocation(eq(1L), eq(1));
         }
 
         @Test
@@ -132,13 +143,13 @@ class OrderPaymentServiceTest {
         @Test
         @DisplayName("CONFIRMED 주문 환불 — CANCELLED 전환 및 재고 releaseAllocation 호출")
         void refundsConfirmedOrder() {
-            order.confirm(); // PENDING → CONFIRMED
+            order.confirm(); // PENDING -> CONFIRMED
             given(orderRepository.findByIdWithItemsForUpdate(1L)).willReturn(Optional.of(order));
 
             orderPaymentService.refund(1L);
 
             assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELLED);
-            verify(inventoryService).releaseAllocation(any(), eq(1));
+            verify(inventoryService).releaseAllocation(eq(1L), eq(1));
         }
 
         @Test

--- a/src/test/java/com/stockmanagement/domain/order/service/OrderQueryServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/order/service/OrderQueryServiceTest.java
@@ -14,6 +14,7 @@ import com.stockmanagement.domain.order.repository.OrderRepository;
 import com.stockmanagement.domain.order.repository.OrderStatusHistoryRepository;
 import com.stockmanagement.domain.point.service.PointService;
 import com.stockmanagement.domain.product.entity.Product;
+import com.stockmanagement.domain.product.entity.ProductVariant;
 import com.stockmanagement.domain.product.repository.ProductRepository;
 import com.stockmanagement.domain.shipment.repository.ShipmentRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -71,6 +72,7 @@ class OrderQueryServiceTest {
     private OrderQueryService orderQueryService;
 
     private Product product;
+    private ProductVariant variant;
     private Order order;
 
     @BeforeEach
@@ -83,6 +85,14 @@ class OrderQueryServiceTest {
                 .build();
         ReflectionTestUtils.setField(product, "id", 1L);
 
+        variant = ProductVariant.builder()
+                .product(product)
+                .optionName("기본")
+                .sku("SKU-001")
+                .price(new BigDecimal("10000"))
+                .build();
+        ReflectionTestUtils.setField(variant, "id", 1L);
+
         order = Order.builder()
                 .userId(1L)
                 .totalAmount(new BigDecimal("10000"))
@@ -91,6 +101,7 @@ class OrderQueryServiceTest {
 
         OrderItem orderItem = OrderItem.builder()
                 .product(product)
+                .variant(variant)
                 .quantity(1)
                 .unitPrice(new BigDecimal("10000"))
                 .build();

--- a/src/test/java/com/stockmanagement/domain/product/service/ProductServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/product/service/ProductServiceTest.java
@@ -10,9 +10,13 @@ import com.stockmanagement.domain.product.dto.ProductResponse;
 import com.stockmanagement.domain.product.dto.ProductUpdateRequest;
 import com.stockmanagement.domain.product.entity.Product;
 import com.stockmanagement.domain.product.entity.ProductStatus;
+import com.stockmanagement.domain.product.entity.ProductVariant;
 import com.stockmanagement.domain.product.image.repository.ProductImageRepository;
 import com.stockmanagement.domain.product.repository.ProductRepository;
+import com.stockmanagement.domain.product.repository.ProductVariantRepository;
 import com.stockmanagement.domain.product.review.repository.ReviewRepository;
+import com.stockmanagement.domain.product.wishlist.repository.WishlistRepository;
+import com.stockmanagement.domain.order.repository.OrderRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -45,6 +49,9 @@ class ProductServiceTest {
     private ProductRepository productRepository;
 
     @Mock
+    private ProductVariantRepository variantRepository;
+
+    @Mock
     private ProductSearchService productSearchService;
 
     @Mock
@@ -61,6 +68,12 @@ class ProductServiceTest {
 
     @Mock
     private ApplicationEventPublisher eventPublisher;
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @Mock
+    private WishlistRepository wishlistRepository;
 
     @Mock
     private SystemSettingService systemSettingService;
@@ -104,12 +117,15 @@ class ProductServiceTest {
         @Test
         @DisplayName("신규 SKU이면 상품을 저장하고 응답을 반환한다")
         void savesProductAndReturnsResponse() {
-            given(productRepository.existsBySku("SKU-001")).willReturn(false);
+            given(variantRepository.existsBySku("SKU-001")).willReturn(false);
             given(productRepository.save(any(Product.class))).willReturn(product);
+            given(variantRepository.save(any(ProductVariant.class))).willAnswer(inv -> inv.getArgument(0));
+            given(inventoryRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
 
             ProductResponse response = productService.create(request);
 
             verify(productRepository).save(any(Product.class));
+            verify(variantRepository).save(any(ProductVariant.class));
             assertThat(response.getName()).isEqualTo("테스트 상품");
             assertThat(response.getSku()).isEqualTo("SKU-001");
             assertThat(response.getStatus()).isEqualTo(ProductStatus.ACTIVE);
@@ -118,7 +134,7 @@ class ProductServiceTest {
         @Test
         @DisplayName("SKU가 중복이면 DUPLICATE_SKU 예외를 발생시킨다")
         void throwsWhenSkuDuplicated() {
-            given(productRepository.existsBySku("SKU-001")).willReturn(true);
+            given(variantRepository.existsBySku("SKU-001")).willReturn(true);
 
             assertThatThrownBy(() -> productService.create(request))
                     .isInstanceOf(BusinessException.class)

--- a/src/test/java/com/stockmanagement/domain/product/wishlist/service/WishlistServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/product/wishlist/service/WishlistServiceTest.java
@@ -64,7 +64,7 @@ class WishlistServiceTest {
         void success() {
             given(productRepository.findById(10L)).willReturn(Optional.of(mockProduct(10L)));
             given(wishlistRepository.existsByUserIdAndProductId(1L, 10L)).willReturn(false);
-            given(inventoryRepository.findByProductId(10L)).willReturn(Optional.empty());
+            given(inventoryRepository.findAllByProductId(10L)).willReturn(List.of());
             WishlistItem saved = mockItem(5L, 1L, 10L);
             given(wishlistRepository.save(any())).willReturn(saved);
 

--- a/src/test/java/com/stockmanagement/integration/AbstractIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/AbstractIntegrationTest.java
@@ -29,6 +29,7 @@ import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.Statement;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -150,6 +151,7 @@ abstract class AbstractIntegrationTest {
             stmt.execute("DELETE FROM inventory_transactions");
             stmt.execute("DELETE FROM inventory");
             stmt.execute("DELETE FROM product_images");
+            stmt.execute("DELETE FROM product_variants");
             stmt.execute("DELETE FROM products");
             stmt.execute("DELETE FROM daily_order_stats");
             stmt.execute("DELETE FROM daily_inventory_snapshots");
@@ -195,6 +197,14 @@ abstract class AbstractIntegrationTest {
                 .andExpect(status().isOk())
                 .andReturn().getResponse().getContentAsString();
         return objectMapper.readTree(body).path("data").path("accessToken").asText();
+    }
+
+    /** 상품의 기본 variant ID를 반환한다 (인벤토리 API 호출용). */
+    protected long getDefaultVariantId(long productId) throws Exception {
+        String body = mockMvc.perform(get("/api/products/" + productId + "/variants"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        return objectMapper.readTree(body).path("data").get(0).path("id").asLong();
     }
 
     /** ADMIN 사용자를 DB에 직접 저장 후 JWT 토큰을 반환한다. */

--- a/src/test/java/com/stockmanagement/integration/BatchIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/BatchIntegrationTest.java
@@ -166,8 +166,9 @@ class BatchIntegrationTest extends AbstractIntegrationTest {
                 .andExpect(status().isCreated())
                 .andReturn().getResponse().getContentAsString();
         long productId = objectMapper.readTree(body).path("data").path("id").asLong();
+        long variantId = getDefaultVariantId(productId);
 
-        mockMvc.perform(post("/api/inventory/" + productId + "/receive")
+        mockMvc.perform(post("/api/inventory/variants/" + variantId + "/receive")
                         .header("Authorization", "Bearer " + adminToken)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"quantity\":" + qty + "}"))

--- a/src/test/java/com/stockmanagement/integration/CacheIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/CacheIntegrationTest.java
@@ -36,7 +36,8 @@ class CacheIntegrationTest extends AbstractIntegrationTest {
     }
 
     private void receive(String adminToken, long productId, int quantity) throws Exception {
-        mockMvc.perform(post("/api/inventory/" + productId + "/receive")
+        long variantId = getDefaultVariantId(productId);
+        mockMvc.perform(post("/api/inventory/variants/" + variantId + "/receive")
                         .header("Authorization", "Bearer " + adminToken)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"quantity\":" + quantity + "}"))
@@ -54,10 +55,11 @@ class CacheIntegrationTest extends AbstractIntegrationTest {
         void cacheHit_returnsSameData() throws Exception {
             String adminToken = createAdminAndLogin("admin", "adminpass1", "admin@example.com");
             long productId = createProduct(adminToken, "캐시상품", "CACHE-SKU-1");
+            long variantId = getDefaultVariantId(productId);
             receive(adminToken, productId, 20);
 
             // 첫 번째 조회 — cache miss (DB → Redis 저장)
-            mockMvc.perform(get("/api/inventory/" + productId)
+            mockMvc.perform(get("/api/inventory/variants/" + variantId)
                             .header("Authorization", "Bearer " + adminToken))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data.onHand").value(20))
@@ -65,7 +67,7 @@ class CacheIntegrationTest extends AbstractIntegrationTest {
 
             // 두 번째 조회 — cache hit (Redis에서 역직렬화)
             // 동일한 값이 반환되면 직렬화/역직렬화가 정상 동작하는 것
-            mockMvc.perform(get("/api/inventory/" + productId)
+            mockMvc.perform(get("/api/inventory/variants/" + variantId)
                             .header("Authorization", "Bearer " + adminToken))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data.onHand").value(20))
@@ -77,10 +79,11 @@ class CacheIntegrationTest extends AbstractIntegrationTest {
         void cacheEvict_afterReceive_returnsFreshData() throws Exception {
             String adminToken = createAdminAndLogin("admin", "adminpass1", "admin@example.com");
             long productId = createProduct(adminToken, "입고캐시상품", "CACHE-SKU-2");
+            long variantId = getDefaultVariantId(productId);
             receive(adminToken, productId, 10);
 
             // 첫 조회 — cache miss: onHand=10 캐싱
-            mockMvc.perform(get("/api/inventory/" + productId)
+            mockMvc.perform(get("/api/inventory/variants/" + variantId)
                             .header("Authorization", "Bearer " + adminToken))
                     .andExpect(jsonPath("$.data.onHand").value(10));
 
@@ -88,7 +91,7 @@ class CacheIntegrationTest extends AbstractIntegrationTest {
             receive(adminToken, productId, 15);
 
             // 재조회 — cache miss (evict됨): 최신 데이터(25) 반환
-            mockMvc.perform(get("/api/inventory/" + productId)
+            mockMvc.perform(get("/api/inventory/variants/" + variantId)
                             .header("Authorization", "Bearer " + adminToken))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data.onHand").value(25))
@@ -100,10 +103,11 @@ class CacheIntegrationTest extends AbstractIntegrationTest {
         void cacheEvict_afterReserve_returnsFreshData() throws Exception {
             String adminToken = createAdminAndLogin("admin", "adminpass1", "admin@example.com");
             long productId = createProduct(adminToken, "주문캐시상품", "CACHE-SKU-3");
+            long variantId = getDefaultVariantId(productId);
             receive(adminToken, productId, 30);
 
             // 첫 조회 — available=30 캐싱
-            mockMvc.perform(get("/api/inventory/" + productId)
+            mockMvc.perform(get("/api/inventory/variants/" + variantId)
                             .header("Authorization", "Bearer " + adminToken))
                     .andExpect(jsonPath("$.data.available").value(30));
 
@@ -115,12 +119,12 @@ class CacheIntegrationTest extends AbstractIntegrationTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(String.format(
                                     "{\"userId\":%d,\"idempotencyKey\":\"cache-test-001\"," +
-                                    "\"items\":[{\"productId\":%d,\"quantity\":5,\"unitPrice\":10000}]}",
-                                    buyerId, productId)))
+                                    "\"items\":[{\"productId\":%d,\"variantId\":%d,\"quantity\":5,\"unitPrice\":10000}]}",
+                                    buyerId, productId, variantId)))
                     .andExpect(status().isCreated());
 
             // 재조회 — cache miss: reserved=5, available=25
-            mockMvc.perform(get("/api/inventory/" + productId)
+            mockMvc.perform(get("/api/inventory/variants/" + variantId)
                             .header("Authorization", "Bearer " + adminToken))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data.reserved").value(5))
@@ -139,6 +143,7 @@ class CacheIntegrationTest extends AbstractIntegrationTest {
         void cacheHit_returnsSameOrder() throws Exception {
             String adminToken = createAdminAndLogin("admin", "adminpass1", "admin@example.com");
             long productId = createProduct(adminToken, "주문용상품", "CACHE-ORD-1");
+            long variantId = getDefaultVariantId(productId);
             receive(adminToken, productId, 20);
 
             String userToken = signupAndLogin("buyer", "Buyerpass1!", "buyer@example.com");
@@ -150,8 +155,8 @@ class CacheIntegrationTest extends AbstractIntegrationTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(String.format(
                                     "{\"userId\":%d,\"idempotencyKey\":\"cache-ord-001\"," +
-                                    "\"items\":[{\"productId\":%d,\"quantity\":2,\"unitPrice\":10000}]}",
-                                    buyerId, productId)))
+                                    "\"items\":[{\"productId\":%d,\"variantId\":%d,\"quantity\":2,\"unitPrice\":10000}]}",
+                                    buyerId, productId, variantId)))
                     .andExpect(status().isCreated())
                     .andReturn().getResponse().getContentAsString();
             long orderId = objectMapper.readTree(orderBody).path("data").path("id").asLong();
@@ -176,6 +181,7 @@ class CacheIntegrationTest extends AbstractIntegrationTest {
         void cacheEvict_afterCancel_returnsCancelledStatus() throws Exception {
             String adminToken = createAdminAndLogin("admin", "adminpass1", "admin@example.com");
             long productId = createProduct(adminToken, "취소캐시상품", "CACHE-ORD-2");
+            long variantId = getDefaultVariantId(productId);
             receive(adminToken, productId, 20);
 
             String userToken = signupAndLogin("buyer", "Buyerpass1!", "buyer@example.com");
@@ -187,8 +193,8 @@ class CacheIntegrationTest extends AbstractIntegrationTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(String.format(
                                     "{\"userId\":%d,\"idempotencyKey\":\"cache-ord-002\"," +
-                                    "\"items\":[{\"productId\":%d,\"quantity\":3,\"unitPrice\":10000}]}",
-                                    buyerId, productId)))
+                                    "\"items\":[{\"productId\":%d,\"variantId\":%d,\"quantity\":3,\"unitPrice\":10000}]}",
+                                    buyerId, productId, variantId)))
                     .andExpect(status().isCreated())
                     .andReturn().getResponse().getContentAsString();
             long orderId = objectMapper.readTree(orderBody).path("data").path("id").asLong();

--- a/src/test/java/com/stockmanagement/integration/CartIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/CartIntegrationTest.java
@@ -21,8 +21,9 @@ class CartIntegrationTest extends AbstractIntegrationTest {
                 .andExpect(status().isCreated())
                 .andReturn().getResponse().getContentAsString();
         long productId = objectMapper.readTree(body).path("data").path("id").asLong();
+        long variantId = getDefaultVariantId(productId);
 
-        mockMvc.perform(post("/api/inventory/" + productId + "/receive")
+        mockMvc.perform(post("/api/inventory/variants/" + variantId + "/receive")
                         .header("Authorization", "Bearer " + adminToken)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"quantity\":" + qty + "}"))
@@ -35,13 +36,14 @@ class CartIntegrationTest extends AbstractIntegrationTest {
     void addItemAndGetCart() throws Exception {
         String adminToken = createAdminAndLogin("admin", "pass1", "admin@test.com");
         long productId = createProductAndReceive(adminToken, "SKU-C1", 2000, 50);
+        long variantId = getDefaultVariantId(productId);
         String userToken = signupAndLogin("buyer", "Password1!", "buyer@test.com");
 
         // 담기
         mockMvc.perform(post("/api/cart/items")
                         .header("Authorization", "Bearer " + userToken)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"productId\":" + productId + ",\"quantity\":3}"))
+                        .content("{\"productId\":" + productId + ",\"variantId\":" + variantId + ",\"quantity\":3}"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.quantity").value(3))
                 .andExpect(jsonPath("$.data.subtotal").value(6000));
@@ -60,18 +62,19 @@ class CartIntegrationTest extends AbstractIntegrationTest {
     void addSameItemUpdatesQuantity() throws Exception {
         String adminToken = createAdminAndLogin("admin", "pass1", "admin@test.com");
         long productId = createProductAndReceive(adminToken, "SKU-C2", 1000, 50);
+        long variantId = getDefaultVariantId(productId);
         String userToken = signupAndLogin("buyer", "Password1!", "buyer@test.com");
 
         mockMvc.perform(post("/api/cart/items")
                         .header("Authorization", "Bearer " + userToken)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"productId\":" + productId + ",\"quantity\":2}"))
+                        .content("{\"productId\":" + productId + ",\"variantId\":" + variantId + ",\"quantity\":2}"))
                 .andExpect(status().isOk());
 
         mockMvc.perform(post("/api/cart/items")
                         .header("Authorization", "Bearer " + userToken)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"productId\":" + productId + ",\"quantity\":5}"))
+                        .content("{\"productId\":" + productId + ",\"variantId\":" + variantId + ",\"quantity\":5}"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.quantity").value(5))
                 .andExpect(jsonPath("$.data.subtotal").value(5000));
@@ -82,22 +85,24 @@ class CartIntegrationTest extends AbstractIntegrationTest {
     void removeItem() throws Exception {
         String adminToken = createAdminAndLogin("admin", "pass1", "admin@test.com");
         long p1 = createProductAndReceive(adminToken, "SKU-C3", 1000, 10);
+        long v1 = getDefaultVariantId(p1);
         long p2 = createProductAndReceive(adminToken, "SKU-C4", 2000, 10);
+        long v2 = getDefaultVariantId(p2);
         String userToken = signupAndLogin("buyer", "Password1!", "buyer@test.com");
 
         mockMvc.perform(post("/api/cart/items")
                         .header("Authorization", "Bearer " + userToken)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"productId\":" + p1 + ",\"quantity\":1}"))
+                        .content("{\"productId\":" + p1 + ",\"variantId\":" + v1 + ",\"quantity\":1}"))
                 .andExpect(status().isOk());
         mockMvc.perform(post("/api/cart/items")
                         .header("Authorization", "Bearer " + userToken)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"productId\":" + p2 + ",\"quantity\":1}"))
+                        .content("{\"productId\":" + p2 + ",\"variantId\":" + v2 + ",\"quantity\":1}"))
                 .andExpect(status().isOk());
 
         // p1 제거
-        mockMvc.perform(delete("/api/cart/items/" + p1)
+        mockMvc.perform(delete("/api/cart/items/variants/" + v1)
                         .header("Authorization", "Bearer " + userToken))
                 .andExpect(status().isNoContent());
 
@@ -113,12 +118,13 @@ class CartIntegrationTest extends AbstractIntegrationTest {
     void clearCart() throws Exception {
         String adminToken = createAdminAndLogin("admin", "pass1", "admin@test.com");
         long productId = createProductAndReceive(adminToken, "SKU-C5", 500, 20);
+        long variantId = getDefaultVariantId(productId);
         String userToken = signupAndLogin("buyer", "Password1!", "buyer@test.com");
 
         mockMvc.perform(post("/api/cart/items")
                         .header("Authorization", "Bearer " + userToken)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"productId\":" + productId + ",\"quantity\":2}"))
+                        .content("{\"productId\":" + productId + ",\"variantId\":" + variantId + ",\"quantity\":2}"))
                 .andExpect(status().isOk());
 
         mockMvc.perform(delete("/api/cart")
@@ -137,6 +143,7 @@ class CartIntegrationTest extends AbstractIntegrationTest {
     void checkout() throws Exception {
         String adminToken = createAdminAndLogin("admin", "pass1", "admin@test.com");
         long productId = createProductAndReceive(adminToken, "SKU-C6", 3000, 20);
+        long variantId = getDefaultVariantId(productId);
         String userToken = signupAndLogin("buyer", "Password1!", "buyer@test.com");
         long userId = userRepository.findByUsername("buyer").orElseThrow().getId();
 
@@ -144,7 +151,7 @@ class CartIntegrationTest extends AbstractIntegrationTest {
         mockMvc.perform(post("/api/cart/items")
                         .header("Authorization", "Bearer " + userToken)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"productId\":" + productId + ",\"quantity\":2}"))
+                        .content("{\"productId\":" + productId + ",\"variantId\":" + variantId + ",\"quantity\":2}"))
                 .andExpect(status().isOk());
 
         // 주문 전환
@@ -163,7 +170,7 @@ class CartIntegrationTest extends AbstractIntegrationTest {
                 .andExpect(jsonPath("$.data.items").isEmpty());
 
         // 재고 예약 확인 — ADMIN 전용 엔드포인트
-        mockMvc.perform(get("/api/inventory/" + productId)
+        mockMvc.perform(get("/api/inventory/variants/" + variantId)
                         .header("Authorization", "Bearer " + adminToken))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.reserved").value(2))

--- a/src/test/java/com/stockmanagement/integration/ConcurrencyIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/ConcurrencyIntegrationTest.java
@@ -5,7 +5,9 @@ import com.stockmanagement.domain.inventory.entity.Inventory;
 import com.stockmanagement.domain.inventory.repository.InventoryRepository;
 import com.stockmanagement.domain.inventory.service.InventoryService;
 import com.stockmanagement.domain.product.entity.Product;
+import com.stockmanagement.domain.product.entity.ProductVariant;
 import com.stockmanagement.domain.product.repository.ProductRepository;
+import com.stockmanagement.domain.product.repository.ProductVariantRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,6 +39,7 @@ class ConcurrencyIntegrationTest extends AbstractIntegrationTest {
     @Autowired InventoryService inventoryService;
     @Autowired InventoryRepository inventoryRepository;
     @Autowired ProductRepository productRepository;
+    @Autowired ProductVariantRepository variantRepository;
 
     /**
      * 재고 10개 상품에 20개 스레드가 동시에 각 1개 예약 시도.
@@ -52,13 +55,16 @@ class ConcurrencyIntegrationTest extends AbstractIntegrationTest {
                 .price(BigDecimal.valueOf(10000))
                 .build());
 
+        ProductVariant variant = variantRepository.save(ProductVariant.builder()
+                .product(product).optionName("기본").sku("SKU-CONCURRENT-001")
+                .price(BigDecimal.valueOf(10000)).build());
+
         int stockQty = 10;
-        // Inventory.builder()는 product만 받고 onHand=0 초기화 → receive()로 재고 추가
-        Inventory inventory = Inventory.builder().product(product).build();
+        Inventory inventory = Inventory.builder().variant(variant).build();
         inventory.receive(stockQty);
         inventoryRepository.save(inventory);
 
-        long productId = product.getId();
+        long variantId = variant.getId();
 
         // ===== 동시 실행 =====
         int threadCount = 20;
@@ -75,7 +81,7 @@ class ConcurrencyIntegrationTest extends AbstractIntegrationTest {
                 readyLatch.countDown();
                 try {
                     startLatch.await(); // 일제히 시작
-                    inventoryService.reserve(productId, 1);
+                    inventoryService.reserve(variantId, 1);
                     successCount.incrementAndGet();
                 } catch (InsufficientStockException e) {
                     failCount.incrementAndGet();
@@ -111,7 +117,7 @@ class ConcurrencyIntegrationTest extends AbstractIntegrationTest {
                 .isGreaterThanOrEqualTo(threadCount - stockQty);
 
         // DB 최종 상태: reserved == 성공 건수, available >= 0 (불변 조건)
-        Inventory finalState = inventoryRepository.findByProductId(productId).orElseThrow();
+        Inventory finalState = inventoryRepository.findByVariantId(variantId).orElseThrow();
         assertThat(finalState.getReserved())
                 .as("최종 reserved는 성공한 예약 건수와 일치해야 한다")
                 .isEqualTo(succeeded);
@@ -136,22 +142,26 @@ class ConcurrencyIntegrationTest extends AbstractIntegrationTest {
                 .price(BigDecimal.valueOf(5000))
                 .build());
 
-        Inventory inventory = Inventory.builder().product(product).build();
+        ProductVariant variant = variantRepository.save(ProductVariant.builder()
+                .product(product).optionName("기본").sku("SKU-ZERO-001")
+                .price(BigDecimal.valueOf(5000)).build());
+
+        Inventory inventory = Inventory.builder().variant(variant).build();
         inventory.receive(2);
         inventoryRepository.save(inventory);
 
-        long productId = product.getId();
+        long variantId = variant.getId();
 
         // 2개 정상 예약
-        inventoryService.reserve(productId, 1);
-        inventoryService.reserve(productId, 1);
+        inventoryService.reserve(variantId, 1);
+        inventoryService.reserve(variantId, 1);
 
         // 재고 소진 상태에서 1개 추가 시도 → 예외 발생 확인
-        assertThatThrownBy(() -> inventoryService.reserve(productId, 1))
+        assertThatThrownBy(() -> inventoryService.reserve(variantId, 1))
                 .isInstanceOf(InsufficientStockException.class);
 
         // available = 0 유지
-        Inventory finalState = inventoryRepository.findByProductId(productId).orElseThrow();
+        Inventory finalState = inventoryRepository.findByVariantId(variantId).orElseThrow();
         assertThat(finalState.getAvailable()).isZero();
         assertThat(finalState.getReserved()).isEqualTo(2);
     }

--- a/src/test/java/com/stockmanagement/integration/CouponIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/CouponIntegrationTest.java
@@ -44,8 +44,9 @@ class CouponIntegrationTest extends AbstractIntegrationTest {
                 .andExpect(status().isCreated())
                 .andReturn().getResponse().getContentAsString();
         long productId = objectMapper.readTree(body).path("data").path("id").asLong();
+        long variantId = getDefaultVariantId(productId);
 
-        mockMvc.perform(post("/api/inventory/" + productId + "/receive")
+        mockMvc.perform(post("/api/inventory/variants/" + variantId + "/receive")
                         .header("Authorization", "Bearer " + adminToken)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"quantity\":" + qty + "}"))
@@ -56,11 +57,12 @@ class CouponIntegrationTest extends AbstractIntegrationTest {
     /** 주문 생성 후 orderId 반환. userId는 실제 DB에서 조회한 값을 사용해야 한다. */
     private long createOrder(String userToken, long userId, long productId, int price,
                              String couponCode) throws Exception {
+        long variantId = getDefaultVariantId(productId);
         String couponPart = couponCode != null ? ",\"couponCode\":\"" + couponCode + "\"" : "";
         String json = String.format(
                 "{\"userId\":%d,\"idempotencyKey\":\"%s\"%s," +
-                "\"items\":[{\"productId\":%d,\"quantity\":1,\"unitPrice\":%d}]}",
-                userId, UUID.randomUUID(), couponPart, productId, price);
+                "\"items\":[{\"productId\":%d,\"variantId\":%d,\"quantity\":1,\"unitPrice\":%d}]}",
+                userId, UUID.randomUUID(), couponPart, productId, variantId, price);
 
         String body = mockMvc.perform(post("/api/orders")
                         .header("Authorization", "Bearer " + userToken)
@@ -78,6 +80,7 @@ class CouponIntegrationTest extends AbstractIntegrationTest {
     void applyCouponOnOrder() throws Exception {
         String adminToken = createAdminAndLogin("admin", "Password1!", "a@test.com");
         long productId = createProductAndReceive(adminToken, "SKU-COUP1", 30000, 10);
+        long variantId = getDefaultVariantId(productId);
         createCoupon(adminToken, "FIXED5000", "FIXED_AMOUNT", 5000, 100);
 
         String userToken = signupAndLogin("buyer", "Password1!", "b@test.com");
@@ -88,8 +91,8 @@ class CouponIntegrationTest extends AbstractIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(String.format(
                                 "{\"userId\":%d,\"idempotencyKey\":\"%s\",\"couponCode\":\"FIXED5000\"," +
-                                "\"items\":[{\"productId\":%d,\"quantity\":1,\"unitPrice\":30000}]}",
-                                userId, UUID.randomUUID(), productId)))
+                                "\"items\":[{\"productId\":%d,\"variantId\":%d,\"quantity\":1,\"unitPrice\":30000}]}",
+                                userId, UUID.randomUUID(), productId, variantId)))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.data.discountAmount").value(5000))
                 .andReturn().getResponse().getContentAsString();
@@ -104,6 +107,7 @@ class CouponIntegrationTest extends AbstractIntegrationTest {
     void percentageCouponWithCap() throws Exception {
         String adminToken = createAdminAndLogin("admin", "Password1!", "a@test.com");
         long productId = createProductAndReceive(adminToken, "SKU-COUP2", 50000, 10);
+        long variantId = getDefaultVariantId(productId);
 
         // 10% 할인, 캡 3000
         String json = "{\"code\":\"PCT10DISC\",\"name\":\"10% 할인\"," +
@@ -126,8 +130,8 @@ class CouponIntegrationTest extends AbstractIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(String.format(
                                 "{\"userId\":%d,\"idempotencyKey\":\"%s\",\"couponCode\":\"PCT10DISC\"," +
-                                "\"items\":[{\"productId\":%d,\"quantity\":1,\"unitPrice\":50000}]}",
-                                userId, UUID.randomUUID(), productId)))
+                                "\"items\":[{\"productId\":%d,\"variantId\":%d,\"quantity\":1,\"unitPrice\":50000}]}",
+                                userId, UUID.randomUUID(), productId, variantId)))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.data.discountAmount").value(3000));
     }
@@ -166,6 +170,7 @@ class CouponIntegrationTest extends AbstractIntegrationTest {
     void exhaustedCoupon() throws Exception {
         String adminToken = createAdminAndLogin("admin", "Password1!", "a@test.com");
         long productId = createProductAndReceive(adminToken, "SKU-COUP4", 10000, 10);
+        long variantId = getDefaultVariantId(productId);
         createCoupon(adminToken, "ONE1TIME", "FIXED_AMOUNT", 1000, 1);
 
         // 첫 번째 사용자 — 성공
@@ -181,8 +186,8 @@ class CouponIntegrationTest extends AbstractIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(String.format(
                                 "{\"userId\":%d,\"idempotencyKey\":\"%s\",\"couponCode\":\"ONE1TIME\"," +
-                                "\"items\":[{\"productId\":%d,\"quantity\":1,\"unitPrice\":10000}]}",
-                                user2Id, UUID.randomUUID(), productId)))
+                                "\"items\":[{\"productId\":%d,\"variantId\":%d,\"quantity\":1,\"unitPrice\":10000}]}",
+                                user2Id, UUID.randomUUID(), productId, variantId)))
                 .andExpect(status().isUnprocessableEntity());
     }
 
@@ -191,6 +196,7 @@ class CouponIntegrationTest extends AbstractIntegrationTest {
     void sameUserCouponReuse() throws Exception {
         String adminToken = createAdminAndLogin("admin", "Password1!", "a@test.com");
         long productId = createProductAndReceive(adminToken, "SKU-COUP5", 10000, 10);
+        long variantId = getDefaultVariantId(productId);
         createCoupon(adminToken, "ONCE1USER", "FIXED_AMOUNT", 1000, 100);
 
         String userToken = signupAndLogin("buyer", "Password1!", "b@test.com");
@@ -204,8 +210,8 @@ class CouponIntegrationTest extends AbstractIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(String.format(
                                 "{\"userId\":%d,\"idempotencyKey\":\"%s\",\"couponCode\":\"ONCE1USER\"," +
-                                "\"items\":[{\"productId\":%d,\"quantity\":1,\"unitPrice\":10000}]}",
-                                userId, UUID.randomUUID(), productId)))
+                                "\"items\":[{\"productId\":%d,\"variantId\":%d,\"quantity\":1,\"unitPrice\":10000}]}",
+                                userId, UUID.randomUUID(), productId, variantId)))
                 .andExpect(status().isUnprocessableEntity());
     }
 
@@ -231,6 +237,7 @@ class CouponIntegrationTest extends AbstractIntegrationTest {
     void deactivateCoupon() throws Exception {
         String adminToken = createAdminAndLogin("admin", "Password1!", "a@test.com");
         long productId = createProductAndReceive(adminToken, "SKU-COUP6", 10000, 10);
+        long variantId = getDefaultVariantId(productId);
         long couponId  = createCoupon(adminToken, "DEACT001", "FIXED_AMOUNT", 1000, 100);
 
         // 비활성화
@@ -247,8 +254,8 @@ class CouponIntegrationTest extends AbstractIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(String.format(
                                 "{\"userId\":%d,\"idempotencyKey\":\"%s\",\"couponCode\":\"DEACT001\"," +
-                                "\"items\":[{\"productId\":%d,\"quantity\":1,\"unitPrice\":10000}]}",
-                                userId, UUID.randomUUID(), productId)))
+                                "\"items\":[{\"productId\":%d,\"variantId\":%d,\"quantity\":1,\"unitPrice\":10000}]}",
+                                userId, UUID.randomUUID(), productId, variantId)))
                 .andExpect(status().isUnprocessableEntity());
     }
 
@@ -348,6 +355,7 @@ class CouponIntegrationTest extends AbstractIntegrationTest {
     void orderWithoutCoupon() throws Exception {
         String adminToken = createAdminAndLogin("admin", "Password1!", "a@test.com");
         long productId = createProductAndReceive(adminToken, "SKU-COUP7", 15000, 10);
+        long variantId = getDefaultVariantId(productId);
 
         String userToken = signupAndLogin("buyer", "Password1!", "b@test.com");
         long userId = userRepository.findByUsername("buyer").orElseThrow().getId();
@@ -357,8 +365,8 @@ class CouponIntegrationTest extends AbstractIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(String.format(
                                 "{\"userId\":%d,\"idempotencyKey\":\"%s\"," +
-                                "\"items\":[{\"productId\":%d,\"quantity\":1,\"unitPrice\":15000}]}",
-                                userId, UUID.randomUUID(), productId)))
+                                "\"items\":[{\"productId\":%d,\"variantId\":%d,\"quantity\":1,\"unitPrice\":15000}]}",
+                                userId, UUID.randomUUID(), productId, variantId)))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.data.discountAmount").value(0));
     }

--- a/src/test/java/com/stockmanagement/integration/DeliveryAddressIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/DeliveryAddressIntegrationTest.java
@@ -178,7 +178,8 @@ class DeliveryAddressIntegrationTest extends AbstractIntegrationTest {
                 .andExpect(status().isCreated())
                 .andReturn().getResponse().getContentAsString();
         long productId = objectMapper.readTree(body).path("data").path("id").asLong();
-        mockMvc.perform(post("/api/inventory/" + productId + "/receive")
+        long variantId = getDefaultVariantId(productId);
+        mockMvc.perform(post("/api/inventory/variants/" + variantId + "/receive")
                         .header("Authorization", "Bearer " + adminToken)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"quantity\":10}"))
@@ -194,8 +195,8 @@ class DeliveryAddressIntegrationTest extends AbstractIntegrationTest {
                         .content(String.format(
                                 "{\"userId\":%d,\"idempotencyKey\":\"ik-001\"," +
                                 "\"deliveryAddressId\":%d," +
-                                "\"items\":[{\"productId\":%d,\"quantity\":1,\"unitPrice\":5000}]}",
-                                userId, addressId, productId)))
+                                "\"items\":[{\"productId\":%d,\"variantId\":%d,\"quantity\":1,\"unitPrice\":5000}]}",
+                                userId, addressId, productId, variantId)))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.data.deliveryAddressId").value(addressId));
     }

--- a/src/test/java/com/stockmanagement/integration/InventoryConcurrencyTest.java
+++ b/src/test/java/com/stockmanagement/integration/InventoryConcurrencyTest.java
@@ -37,7 +37,7 @@ class InventoryConcurrencyTest extends AbstractIntegrationTest {
 
     // ===== 헬퍼 =====
 
-    /** 상품을 등록하고 초기 입고(seedQuantity)를 수행해 inventory 레코드를 생성한다. */
+    /** 상품을 등록하고 초기 입고(seedQuantity)를 수행해 inventory 레코드를 생성한다. 상품 ID를 반환한다. */
     private long setupProduct(String adminToken, String sku, int seedQuantity) throws Exception {
         String body = mockMvc.perform(post("/api/products")
                         .header("Authorization", "Bearer " + adminToken)
@@ -47,9 +47,10 @@ class InventoryConcurrencyTest extends AbstractIntegrationTest {
                 .andExpect(status().isCreated())
                 .andReturn().getResponse().getContentAsString();
         long productId = objectMapper.readTree(body).path("data").path("id").asLong();
+        long variantId = getDefaultVariantId(productId);
 
         // inventory 레코드 사전 생성 — 동시성 테스트에서 첫 INSERT 경합 방지
-        mockMvc.perform(post("/api/inventory/" + productId + "/receive")
+        mockMvc.perform(post("/api/inventory/variants/" + variantId + "/receive")
                         .header("Authorization", "Bearer " + adminToken)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"quantity\":" + seedQuantity + "}"))
@@ -103,9 +104,10 @@ class InventoryConcurrencyTest extends AbstractIntegrationTest {
         String adminToken = createAdminAndLogin("admin", "adminpass1", "admin@example.com");
         // seedQuantity=5로 inventory 레코드 생성, 이후 동시 입고 10건(각 1)
         long productId = setupProduct(adminToken, "SKU-CONC-R", 5);
+        long variantId = getDefaultVariantId(productId);
 
         runConcurrently(() ->
-                mockMvc.perform(post("/api/inventory/" + productId + "/receive")
+                mockMvc.perform(post("/api/inventory/variants/" + variantId + "/receive")
                                 .header("Authorization", "Bearer " + adminToken)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content("{\"quantity\":1}"))
@@ -113,7 +115,7 @@ class InventoryConcurrencyTest extends AbstractIntegrationTest {
         );
 
         // 최종 onHand = seed(5) + 동시 입고(10 × 1) = 15
-        mockMvc.perform(get("/api/inventory/" + productId)
+        mockMvc.perform(get("/api/inventory/variants/" + variantId)
                         .header("Authorization", "Bearer " + adminToken))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.onHand").value(15));
@@ -124,6 +126,7 @@ class InventoryConcurrencyTest extends AbstractIntegrationTest {
     void concurrentReserve_partialSuccess_noOverselling() throws Exception {
         String adminToken = createAdminAndLogin("admin", "adminpass1", "admin@example.com");
         long productId = setupProduct(adminToken, "SKU-CONC-S", 5); // 가용 재고 5
+        long variantId = getDefaultVariantId(productId);
 
         String userToken = signupAndLogin("buyer", "Buyerpass1!", "buyer@example.com");
         long buyerId = userRepository.findByUsername("buyer").orElseThrow().getId();
@@ -141,8 +144,8 @@ class InventoryConcurrencyTest extends AbstractIntegrationTest {
                     startLatch.await();
                     String orderJson = String.format(
                             "{\"userId\":%d,\"idempotencyKey\":\"conc-key-%d\"," +
-                            "\"items\":[{\"productId\":%d,\"quantity\":1,\"unitPrice\":1000}]}",
-                            buyerId, idx, productId);
+                            "\"items\":[{\"productId\":%d,\"variantId\":%d,\"quantity\":1,\"unitPrice\":1000}]}",
+                            buyerId, idx, productId, variantId);
 
                     int httpStatus = mockMvc.perform(post("/api/orders")
                                     .header("Authorization", "Bearer " + userToken)
@@ -171,7 +174,7 @@ class InventoryConcurrencyTest extends AbstractIntegrationTest {
         assertThat(failCount.get()).isEqualTo(5);
 
         // 최종 재고: reserved=5, available=0 — overselling 없음
-        mockMvc.perform(get("/api/inventory/" + productId)
+        mockMvc.perform(get("/api/inventory/variants/" + variantId)
                         .header("Authorization", "Bearer " + adminToken))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.reserved").value(5))

--- a/src/test/java/com/stockmanagement/integration/InventoryIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/InventoryIntegrationTest.java
@@ -52,12 +52,28 @@ class InventoryIntegrationTest extends AbstractIntegrationTest {
         return objectMapper.readTree(body).path("data").path("id").asLong();
     }
 
+    /** 상품의 기본 variant에 입고한다. */
     private void receive(String adminToken, long productId, int quantity) throws Exception {
-        mockMvc.perform(post("/api/inventory/" + productId + "/receive")
+        long variantId = getDefaultVariantId(productId);
+        mockMvc.perform(post("/api/inventory/variants/" + variantId + "/receive")
                         .header("Authorization", "Bearer " + adminToken)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"quantity\":" + quantity + "}"))
                 .andExpect(status().isOk());
+    }
+
+    /** 주문 생성 — variantId를 포함한 JSON을 전송한다. */
+    private String createOrder(String userToken, long userId, long productId, int quantity, int unitPrice, String idempotencyKey) throws Exception {
+        long variantId = getDefaultVariantId(productId);
+        return mockMvc.perform(post("/api/orders")
+                        .header("Authorization", "Bearer " + userToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(String.format(
+                                "{\"userId\":%d,\"idempotencyKey\":\"%s\"," +
+                                "\"items\":[{\"productId\":%d,\"variantId\":%d,\"quantity\":%d,\"unitPrice\":%d}]}",
+                                userId, idempotencyKey, productId, variantId, quantity, unitPrice)))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
     }
 
     // ===== 입고 처리 =====
@@ -67,8 +83,9 @@ class InventoryIntegrationTest extends AbstractIntegrationTest {
     void receive_updatesStock() throws Exception {
         String adminToken = createAdminAndLogin("admin", "adminpass1", "admin@example.com");
         long productId = createProduct(adminToken, "상품A", "SKU-A", 1000);
+        long variantId = getDefaultVariantId(productId);
 
-        mockMvc.perform(post("/api/inventory/" + productId + "/receive")
+        mockMvc.perform(post("/api/inventory/variants/" + variantId + "/receive")
                         .header("Authorization", "Bearer " + adminToken)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"quantity\":30}"))
@@ -84,11 +101,12 @@ class InventoryIntegrationTest extends AbstractIntegrationTest {
     void receive_accumulates() throws Exception {
         String adminToken = createAdminAndLogin("admin", "adminpass1", "admin@example.com");
         long productId = createProduct(adminToken, "상품B", "SKU-B", 2000);
+        long variantId = getDefaultVariantId(productId);
 
         receive(adminToken, productId, 10);
         receive(adminToken, productId, 20);
 
-        mockMvc.perform(get("/api/inventory/" + productId)
+        mockMvc.perform(get("/api/inventory/variants/" + variantId)
                         .header("Authorization", "Bearer " + adminToken))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.onHand").value(30))
@@ -100,9 +118,10 @@ class InventoryIntegrationTest extends AbstractIntegrationTest {
     void receive_userRole_403() throws Exception {
         String adminToken = createAdminAndLogin("admin", "adminpass1", "admin@example.com");
         long productId = createProduct(adminToken, "상품C", "SKU-C", 3000);
+        long variantId = getDefaultVariantId(productId);
         String userToken = signupAndLogin("user", "Userpass1!", "user@example.com");
 
-        mockMvc.perform(post("/api/inventory/" + productId + "/receive")
+        mockMvc.perform(post("/api/inventory/variants/" + variantId + "/receive")
                         .header("Authorization", "Bearer " + userToken)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"quantity\":10}"))
@@ -114,7 +133,7 @@ class InventoryIntegrationTest extends AbstractIntegrationTest {
     void receive_productNotFound_404() throws Exception {
         String adminToken = createAdminAndLogin("admin", "adminpass1", "admin@example.com");
 
-        mockMvc.perform(post("/api/inventory/99999/receive")
+        mockMvc.perform(post("/api/inventory/variants/99999/receive")
                         .header("Authorization", "Bearer " + adminToken)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"quantity\":10}"))
@@ -129,9 +148,10 @@ class InventoryIntegrationTest extends AbstractIntegrationTest {
     void getTransactions_afterReceive() throws Exception {
         String adminToken = createAdminAndLogin("admin", "adminpass1", "admin@example.com");
         long productId = createProduct(adminToken, "상품D", "SKU-D", 5000);
+        long variantId = getDefaultVariantId(productId);
         receive(adminToken, productId, 15);
 
-        mockMvc.perform(get("/api/inventory/" + productId + "/transactions")
+        mockMvc.perform(get("/api/inventory/variants/" + variantId + "/transactions")
                         .header("Authorization", "Bearer " + adminToken))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.content.length()").value(1))
@@ -147,11 +167,12 @@ class InventoryIntegrationTest extends AbstractIntegrationTest {
     void getTransactions_multipleReceives_latestFirst() throws Exception {
         String adminToken = createAdminAndLogin("admin", "adminpass1", "admin@example.com");
         long productId = createProduct(adminToken, "상품E", "SKU-E", 1000);
+        long variantId = getDefaultVariantId(productId);
 
         receive(adminToken, productId, 10); // 첫 번째 입고
         receive(adminToken, productId, 5);  // 두 번째 입고
 
-        mockMvc.perform(get("/api/inventory/" + productId + "/transactions")
+        mockMvc.perform(get("/api/inventory/variants/" + variantId + "/transactions")
                         .header("Authorization", "Bearer " + adminToken))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.content.length()").value(2))
@@ -165,23 +186,17 @@ class InventoryIntegrationTest extends AbstractIntegrationTest {
     void getTransactions_afterReserve() throws Exception {
         String adminToken = createAdminAndLogin("admin", "adminpass1", "admin@example.com");
         long productId = createProduct(adminToken, "상품F", "SKU-F", 2000);
+        long variantId = getDefaultVariantId(productId);
         receive(adminToken, productId, 20);
 
         String userToken = signupAndLogin("buyer", "Buyerpass1!", "buyer@example.com");
         long buyerId = userRepository.findByUsername("buyer").orElseThrow().getId();
 
         // 주문 생성 → reserve() 호출
-        mockMvc.perform(post("/api/orders")
-                        .header("Authorization", "Bearer " + userToken)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(String.format(
-                                "{\"userId\":%d,\"idempotencyKey\":\"reserve-test-001\"," +
-                                "\"items\":[{\"productId\":%d,\"quantity\":4,\"unitPrice\":2000}]}",
-                                buyerId, productId)))
-                .andExpect(status().isCreated());
+        createOrder(userToken, buyerId, productId, 4, 2000, "reserve-test-001");
 
         // 이력: RESERVE(최신), RECEIVE 순
-        mockMvc.perform(get("/api/inventory/" + productId + "/transactions")
+        mockMvc.perform(get("/api/inventory/variants/" + variantId + "/transactions")
                         .header("Authorization", "Bearer " + adminToken))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.content.length()").value(2))
@@ -192,13 +207,11 @@ class InventoryIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
-    @DisplayName("재고 레코드 없는 상품 이력 조회 → 404")
+    @DisplayName("존재하지 않는 variant 이력 조회 → 404")
     void getTransactions_noInventory_404() throws Exception {
         String adminToken = createAdminAndLogin("admin", "adminpass1", "admin@example.com");
-        // 상품만 등록하고 입고하지 않음
-        long productId = createProduct(adminToken, "상품G", "SKU-G", 1000);
 
-        mockMvc.perform(get("/api/inventory/" + productId + "/transactions")
+        mockMvc.perform(get("/api/inventory/variants/99999/transactions")
                         .header("Authorization", "Bearer " + adminToken))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.success").value(false));
@@ -207,7 +220,7 @@ class InventoryIntegrationTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("미인증 이력 조회 → 401")
     void getTransactions_unauthenticated_403() throws Exception {
-        mockMvc.perform(get("/api/inventory/1/transactions"))
+        mockMvc.perform(get("/api/inventory/variants/1/transactions"))
                 .andExpect(status().isUnauthorized());
     }
 
@@ -279,14 +292,7 @@ class InventoryIntegrationTest extends AbstractIntegrationTest {
             // 품절 상품 재고 전량 주문 → reserved=2, available=0
             String userToken = signupAndLogin("buyer", "Buyerpass1!", "buyer@example.com");
             long buyerId = userRepository.findByUsername("buyer").orElseThrow().getId();
-            mockMvc.perform(post("/api/orders")
-                            .header("Authorization", "Bearer " + userToken)
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(String.format(
-                                    "{\"userId\":%d,\"idempotencyKey\":\"outofstock-test\"," +
-                                    "\"items\":[{\"productId\":%d,\"quantity\":2,\"unitPrice\":2000}]}",
-                                    buyerId, soldOut)))
-                    .andExpect(status().isCreated());
+            createOrder(userToken, buyerId, soldOut, 2, 2000, "outofstock-test");
 
             mockMvc.perform(get("/api/inventory")
                             .header("Authorization", "Bearer " + adminToken)

--- a/src/test/java/com/stockmanagement/integration/OrderFilterIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/OrderFilterIntegrationTest.java
@@ -17,6 +17,7 @@ class OrderFilterIntegrationTest extends AbstractIntegrationTest {
     private long userId1;
     private long userId2;
     private long productId;
+    private long variantId;
 
     @BeforeEach
     void setUp() throws Exception {
@@ -26,6 +27,7 @@ class OrderFilterIntegrationTest extends AbstractIntegrationTest {
         userId1 = userRepository.findByUsername("user1").orElseThrow().getId();
         userId2 = userRepository.findByUsername("user2").orElseThrow().getId();
         productId = createProductAndReceive("SKU-F1", 1000, 100);
+        variantId = getDefaultVariantId(productId);
     }
 
     // ===== 공통 헬퍼 =====
@@ -39,7 +41,8 @@ class OrderFilterIntegrationTest extends AbstractIntegrationTest {
                 .andReturn().getResponse().getContentAsString();
         long pid = objectMapper.readTree(body).path("data").path("id").asLong();
 
-        mockMvc.perform(post("/api/inventory/" + pid + "/receive")
+        long vid = getDefaultVariantId(pid);
+        mockMvc.perform(post("/api/inventory/variants/" + vid + "/receive")
                         .header("Authorization", "Bearer " + adminToken)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"quantity\":" + qty + "}"))
@@ -53,8 +56,8 @@ class OrderFilterIntegrationTest extends AbstractIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(String.format(
                                 "{\"userId\":%d,\"idempotencyKey\":\"%s\"," +
-                                "\"items\":[{\"productId\":%d,\"quantity\":1,\"unitPrice\":1000}]}",
-                                userId, idempotencyKey, productId)))
+                                "\"items\":[{\"productId\":%d,\"variantId\":%d,\"quantity\":1,\"unitPrice\":1000}]}",
+                                userId, idempotencyKey, productId, variantId)))
                 .andExpect(status().isCreated());
     }
 
@@ -64,8 +67,8 @@ class OrderFilterIntegrationTest extends AbstractIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(String.format(
                                 "{\"userId\":%d,\"idempotencyKey\":\"%s\"," +
-                                "\"items\":[{\"productId\":%d,\"quantity\":1,\"unitPrice\":1000}]}",
-                                userId, idempotencyKey, productId)))
+                                "\"items\":[{\"productId\":%d,\"variantId\":%d,\"quantity\":1,\"unitPrice\":1000}]}",
+                                userId, idempotencyKey, productId, variantId)))
                 .andExpect(status().isCreated())
                 .andReturn().getResponse().getContentAsString();
         return objectMapper.readTree(body).path("data").path("id").asLong();

--- a/src/test/java/com/stockmanagement/integration/OrderFlowIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/OrderFlowIntegrationTest.java
@@ -30,7 +30,8 @@ class OrderFlowIntegrationTest extends AbstractIntegrationTest {
         long productId = objectMapper.readTree(createProductBody).path("data").path("id").asLong();
 
         // 2. 입고 처리 (onHand = 50)
-        mockMvc.perform(post("/api/inventory/" + productId + "/receive")
+        long variantId = getDefaultVariantId(productId);
+        mockMvc.perform(post("/api/inventory/variants/" + variantId + "/receive")
                         .header("Authorization", "Bearer " + adminToken)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"quantity\":50}"))
@@ -38,7 +39,7 @@ class OrderFlowIntegrationTest extends AbstractIntegrationTest {
                 .andExpect(jsonPath("$.data.onHand").value(50))
                 .andExpect(jsonPath("$.data.available").value(50));
 
-        // 3. 일반 유저 생성 + 주문 생성 (수량 3, 단가 10000 — product.price와 일치)
+        // 3. 일반 유저 생성 + 주문 생성 (수량 3, 단가 10000 — variant.price와 일치)
         String userToken = signupAndLogin("buyer", "Password1@3", "buyer@example.com");
         long buyerId = userRepository.findByUsername("buyer").orElseThrow().getId();
 
@@ -47,8 +48,8 @@ class OrderFlowIntegrationTest extends AbstractIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(String.format(
                                 "{\"userId\":%d,\"idempotencyKey\":\"order-key-001\"," +
-                                "\"items\":[{\"productId\":%d,\"quantity\":3,\"unitPrice\":10000}]}",
-                                buyerId, productId)))
+                                "\"items\":[{\"productId\":%d,\"variantId\":%d,\"quantity\":3,\"unitPrice\":10000}]}",
+                                buyerId, productId, variantId)))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.data.status").value("PENDING"))
                 .andExpect(jsonPath("$.data.totalAmount").value(30000))
@@ -56,8 +57,8 @@ class OrderFlowIntegrationTest extends AbstractIntegrationTest {
 
         long orderId = objectMapper.readTree(createOrderBody).path("data").path("id").asLong();
 
-        // 4. 재고 예약 확인 (reserved = 3, available = 47) — ADMIN 전용 엔드포인트
-        mockMvc.perform(get("/api/inventory/" + productId)
+        // 4. 재고 예약 확인 (reserved = 3, available = 47)
+        mockMvc.perform(get("/api/inventory/variants/" + variantId)
                         .header("Authorization", "Bearer " + adminToken))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.onHand").value(50))
@@ -70,8 +71,8 @@ class OrderFlowIntegrationTest extends AbstractIntegrationTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.status").value("CANCELLED"));
 
-        // 6. 재고 예약 해제 확인 (reserved = 0, available = 50 복원) — ADMIN 전용 엔드포인트
-        mockMvc.perform(get("/api/inventory/" + productId)
+        // 6. 재고 예약 해제 확인 (reserved = 0, available = 50 복원)
+        mockMvc.perform(get("/api/inventory/variants/" + variantId)
                         .header("Authorization", "Bearer " + adminToken))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.reserved").value(0))
@@ -81,7 +82,6 @@ class OrderFlowIntegrationTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("단가 불일치 → 400")
     void createOrder_priceMismatch_400() throws Exception {
-        // 상품 가격 10000으로 등록
         String adminToken = createAdminAndLogin("admin2", "adminpass2", "admin2@example.com");
         String createProductBody = mockMvc.perform(post("/api/products")
                         .header("Authorization", "Bearer " + adminToken)
@@ -91,8 +91,9 @@ class OrderFlowIntegrationTest extends AbstractIntegrationTest {
                 .andReturn().getResponse().getContentAsString();
 
         long productId = objectMapper.readTree(createProductBody).path("data").path("id").asLong();
+        long variantId = getDefaultVariantId(productId);
 
-        mockMvc.perform(post("/api/inventory/" + productId + "/receive")
+        mockMvc.perform(post("/api/inventory/variants/" + variantId + "/receive")
                         .header("Authorization", "Bearer " + adminToken)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"quantity\":10}"))
@@ -107,8 +108,8 @@ class OrderFlowIntegrationTest extends AbstractIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(String.format(
                                 "{\"userId\":%d,\"idempotencyKey\":\"price-mismatch-001\"," +
-                                "\"items\":[{\"productId\":%d,\"quantity\":1,\"unitPrice\":9999}]}",
-                                buyerId, productId)))
+                                "\"items\":[{\"productId\":%d,\"variantId\":%d,\"quantity\":1,\"unitPrice\":9999}]}",
+                                buyerId, productId, variantId)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.success").value(false));
     }
@@ -116,7 +117,6 @@ class OrderFlowIntegrationTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("재고 부족 → 409")
     void createOrder_insufficientStock_409() throws Exception {
-        // 입고 5, 주문 10 → 재고 부족
         String adminToken = createAdminAndLogin("admin3", "adminpass3", "admin3@example.com");
         String createProductBody = mockMvc.perform(post("/api/products")
                         .header("Authorization", "Bearer " + adminToken)
@@ -126,8 +126,9 @@ class OrderFlowIntegrationTest extends AbstractIntegrationTest {
                 .andReturn().getResponse().getContentAsString();
 
         long productId = objectMapper.readTree(createProductBody).path("data").path("id").asLong();
+        long variantId = getDefaultVariantId(productId);
 
-        mockMvc.perform(post("/api/inventory/" + productId + "/receive")
+        mockMvc.perform(post("/api/inventory/variants/" + variantId + "/receive")
                         .header("Authorization", "Bearer " + adminToken)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"quantity\":5}"))
@@ -142,8 +143,8 @@ class OrderFlowIntegrationTest extends AbstractIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(String.format(
                                 "{\"userId\":%d,\"idempotencyKey\":\"stock-001\"," +
-                                "\"items\":[{\"productId\":%d,\"quantity\":10,\"unitPrice\":5000}]}",
-                                buyerId, productId)))
+                                "\"items\":[{\"productId\":%d,\"variantId\":%d,\"quantity\":10,\"unitPrice\":5000}]}",
+                                buyerId, productId, variantId)))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.success").value(false));
     }
@@ -160,8 +161,9 @@ class OrderFlowIntegrationTest extends AbstractIntegrationTest {
                 .andReturn().getResponse().getContentAsString();
 
         long productId = objectMapper.readTree(createProductBody).path("data").path("id").asLong();
+        long variantId = getDefaultVariantId(productId);
 
-        mockMvc.perform(post("/api/inventory/" + productId + "/receive")
+        mockMvc.perform(post("/api/inventory/variants/" + variantId + "/receive")
                         .header("Authorization", "Bearer " + adminToken)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"quantity\":20}"))
@@ -172,8 +174,8 @@ class OrderFlowIntegrationTest extends AbstractIntegrationTest {
 
         String orderJson = String.format(
                 "{\"userId\":%d,\"idempotencyKey\":\"idem-key-001\"," +
-                "\"items\":[{\"productId\":%d,\"quantity\":2,\"unitPrice\":2000}]}",
-                buyerId, productId);
+                "\"items\":[{\"productId\":%d,\"variantId\":%d,\"quantity\":2,\"unitPrice\":2000}]}",
+                buyerId, productId, variantId);
 
         // 첫 번째 주문
         String firstResponse = mockMvc.perform(post("/api/orders")
@@ -198,8 +200,8 @@ class OrderFlowIntegrationTest extends AbstractIntegrationTest {
         // 동일한 주문 ID 반환 확인
         assertEquals(firstOrderId, secondOrderId);
 
-        // 재고 이중 예약 없음 — reserved = 2 (중복 아님) — ADMIN 전용 엔드포인트
-        mockMvc.perform(get("/api/inventory/" + productId)
+        // 재고 이중 예약 없음 — reserved = 2 (중복 아님)
+        mockMvc.perform(get("/api/inventory/variants/" + variantId)
                         .header("Authorization", "Bearer " + adminToken))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.reserved").value(2))
@@ -218,8 +220,9 @@ class OrderFlowIntegrationTest extends AbstractIntegrationTest {
                 .andReturn().getResponse().getContentAsString();
 
         long productId = objectMapper.readTree(createProductBody).path("data").path("id").asLong();
+        long variantId = getDefaultVariantId(productId);
 
-        mockMvc.perform(post("/api/inventory/" + productId + "/receive")
+        mockMvc.perform(post("/api/inventory/variants/" + variantId + "/receive")
                         .header("Authorization", "Bearer " + adminToken)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"quantity\":10}"))
@@ -234,8 +237,8 @@ class OrderFlowIntegrationTest extends AbstractIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(String.format(
                                 "{\"userId\":%d,\"idempotencyKey\":\"cancel-test-001\"," +
-                                "\"items\":[{\"productId\":%d,\"quantity\":1,\"unitPrice\":3000}]}",
-                                buyerId, productId)))
+                                "\"items\":[{\"productId\":%d,\"variantId\":%d,\"quantity\":1,\"unitPrice\":3000}]}",
+                                buyerId, productId, variantId)))
                 .andExpect(status().isCreated())
                 .andReturn().getResponse().getContentAsString();
 

--- a/src/test/java/com/stockmanagement/integration/PaymentIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/PaymentIntegrationTest.java
@@ -56,8 +56,9 @@ class PaymentIntegrationTest extends AbstractIntegrationTest {
                 .andExpect(status().isCreated())
                 .andReturn().getResponse().getContentAsString();
         long productId = objectMapper.readTree(productBody).path("data").path("id").asLong();
+        long variantId = getDefaultVariantId(productId);
 
-        mockMvc.perform(post("/api/inventory/" + productId + "/receive")
+        mockMvc.perform(post("/api/inventory/variants/" + variantId + "/receive")
                         .header("Authorization", "Bearer " + adminToken)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"quantity\":50}"))
@@ -68,8 +69,8 @@ class PaymentIntegrationTest extends AbstractIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(String.format(
                                 "{\"userId\":%d,\"idempotencyKey\":\"key-%s\"," +
-                                "\"items\":[{\"productId\":%d,\"quantity\":%d,\"unitPrice\":%d}]}",
-                                userId, sku + System.nanoTime(), productId, quantity, price)))
+                                "\"items\":[{\"productId\":%d,\"variantId\":%d,\"quantity\":%d,\"unitPrice\":%d}]}",
+                                userId, sku + System.nanoTime(), productId, variantId, quantity, price)))
                 .andExpect(status().isCreated())
                 .andReturn().getResponse().getContentAsString();
         return objectMapper.readTree(orderBody).path("data").path("id").asLong();
@@ -199,8 +200,9 @@ class PaymentIntegrationTest extends AbstractIntegrationTest {
                     .andExpect(status().isCreated())
                     .andReturn().getResponse().getContentAsString();
             long productId = objectMapper.readTree(productBody).path("data").path("id").asLong();
+            long variantId = getDefaultVariantId(productId);
 
-            mockMvc.perform(post("/api/inventory/" + productId + "/receive")
+            mockMvc.perform(post("/api/inventory/variants/" + variantId + "/receive")
                             .header("Authorization", "Bearer " + adminToken)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content("{\"quantity\":10}"))
@@ -211,8 +213,8 @@ class PaymentIntegrationTest extends AbstractIntegrationTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(String.format(
                                     "{\"userId\":%d,\"idempotencyKey\":\"confirm-test-001\"," +
-                                    "\"items\":[{\"productId\":%d,\"quantity\":1,\"unitPrice\":5000}]}",
-                                    userId, productId)))
+                                    "\"items\":[{\"productId\":%d,\"variantId\":%d,\"quantity\":1,\"unitPrice\":5000}]}",
+                                    userId, productId, variantId)))
                     .andExpect(status().isCreated())
                     .andReturn().getResponse().getContentAsString();
             long orderId = objectMapper.readTree(orderBody).path("data").path("id").asLong();

--- a/src/test/java/com/stockmanagement/integration/PointIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/PointIntegrationTest.java
@@ -27,8 +27,9 @@ class PointIntegrationTest extends AbstractIntegrationTest {
                 .andExpect(status().isCreated())
                 .andReturn().getResponse().getContentAsString();
         long productId = objectMapper.readTree(body).path("data").path("id").asLong();
+        long variantId = getDefaultVariantId(productId);
 
-        mockMvc.perform(post("/api/inventory/" + productId + "/receive")
+        mockMvc.perform(post("/api/inventory/variants/" + variantId + "/receive")
                         .header("Authorization", "Bearer " + adminToken)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"quantity\":" + qty + "}"))
@@ -87,6 +88,7 @@ class PointIntegrationTest extends AbstractIntegrationTest {
     void createOrder_withPoints() throws Exception {
         String adminToken = createAdminAndLogin("admin", "adminpass1", "admin@test.com");
         long productId = createProductAndReceive(adminToken, "SKU-PT1", 20000, 10);
+        long variantId = getDefaultVariantId(productId);
 
         String userToken = signupAndLogin("buyer", "Password1!", "b@test.com");
         long userId = userRepository.findByUsername("buyer").orElseThrow().getId();
@@ -98,8 +100,8 @@ class PointIntegrationTest extends AbstractIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(String.format(
                                 "{\"userId\":%d,\"idempotencyKey\":\"%s\",\"usePoints\":3000," +
-                                "\"items\":[{\"productId\":%d,\"quantity\":1,\"unitPrice\":20000}]}",
-                                userId, UUID.randomUUID(), productId)))
+                                "\"items\":[{\"productId\":%d,\"variantId\":%d,\"quantity\":1,\"unitPrice\":20000}]}",
+                                userId, UUID.randomUUID(), productId, variantId)))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.data.usedPoints").value(3000));
 
@@ -115,6 +117,7 @@ class PointIntegrationTest extends AbstractIntegrationTest {
     void createOrder_insufficientPoints() throws Exception {
         String adminToken = createAdminAndLogin("admin", "adminpass1", "admin@test.com");
         long productId = createProductAndReceive(adminToken, "SKU-PT2", 10000, 10);
+        long variantId = getDefaultVariantId(productId);
 
         String userToken = signupAndLogin("buyer2", "Password1!", "b2@test.com");
         long userId = userRepository.findByUsername("buyer2").orElseThrow().getId();
@@ -126,8 +129,8 @@ class PointIntegrationTest extends AbstractIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(String.format(
                                 "{\"userId\":%d,\"idempotencyKey\":\"%s\",\"usePoints\":1000," +
-                                "\"items\":[{\"productId\":%d,\"quantity\":1,\"unitPrice\":10000}]}",
-                                userId, UUID.randomUUID(), productId)))
+                                "\"items\":[{\"productId\":%d,\"variantId\":%d,\"quantity\":1,\"unitPrice\":10000}]}",
+                                userId, UUID.randomUUID(), productId, variantId)))
                 .andExpect(status().isBadRequest());
     }
 }

--- a/src/test/java/com/stockmanagement/integration/RateLimitIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/RateLimitIntegrationTest.java
@@ -30,8 +30,9 @@ class RateLimitIntegrationTest extends AbstractIntegrationTest {
                 .andExpect(status().isCreated())
                 .andReturn().getResponse().getContentAsString();
         long productId = objectMapper.readTree(productBody).path("data").path("id").asLong();
+        long variantId = getDefaultVariantId(productId);
 
-        mockMvc.perform(post("/api/inventory/" + productId + "/receive")
+        mockMvc.perform(post("/api/inventory/variants/" + variantId + "/receive")
                         .header("Authorization", "Bearer " + adminToken)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"quantity\":20}"))
@@ -47,8 +48,8 @@ class RateLimitIntegrationTest extends AbstractIntegrationTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(String.format(
                                     "{\"userId\":%d,\"idempotencyKey\":\"rl-test-%d\"," +
-                                    "\"items\":[{\"productId\":%d,\"quantity\":1,\"unitPrice\":10000}]}",
-                                    buyerId, i, productId)))
+                                    "\"items\":[{\"productId\":%d,\"variantId\":%d,\"quantity\":1,\"unitPrice\":10000}]}",
+                                    buyerId, i, productId, variantId)))
                     .andExpect(status().isCreated());
         }
 
@@ -58,8 +59,8 @@ class RateLimitIntegrationTest extends AbstractIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(String.format(
                                 "{\"userId\":%d,\"idempotencyKey\":\"rl-test-11\"," +
-                                "\"items\":[{\"productId\":%d,\"quantity\":1,\"unitPrice\":10000}]}",
-                                buyerId, productId)))
+                                "\"items\":[{\"productId\":%d,\"variantId\":%d,\"quantity\":1,\"unitPrice\":10000}]}",
+                                buyerId, productId, variantId)))
                 .andExpect(status().isTooManyRequests())
                 .andExpect(jsonPath("$.success").value(false));
     }
@@ -79,8 +80,9 @@ class RateLimitIntegrationTest extends AbstractIntegrationTest {
                 .andExpect(status().isCreated())
                 .andReturn().getResponse().getContentAsString();
         long productId = objectMapper.readTree(productBody).path("data").path("id").asLong();
+        long variantId = getDefaultVariantId(productId);
 
-        mockMvc.perform(post("/api/inventory/" + productId + "/receive")
+        mockMvc.perform(post("/api/inventory/variants/" + variantId + "/receive")
                         .header("Authorization", "Bearer " + adminToken)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"quantity\":30}"))
@@ -96,8 +98,8 @@ class RateLimitIntegrationTest extends AbstractIntegrationTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(String.format(
                                     "{\"userId\":%d,\"idempotencyKey\":\"rl-a-test-%d\"," +
-                                    "\"items\":[{\"productId\":%d,\"quantity\":1,\"unitPrice\":10000}]}",
-                                    userAId, i, productId)))
+                                    "\"items\":[{\"productId\":%d,\"variantId\":%d,\"quantity\":1,\"unitPrice\":10000}]}",
+                                    userAId, i, productId, variantId)))
                     .andExpect(status().isCreated());
         }
 
@@ -107,8 +109,8 @@ class RateLimitIntegrationTest extends AbstractIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(String.format(
                                 "{\"userId\":%d,\"idempotencyKey\":\"rl-a-test-11\"," +
-                                "\"items\":[{\"productId\":%d,\"quantity\":1,\"unitPrice\":10000}]}",
-                                userAId, productId)))
+                                "\"items\":[{\"productId\":%d,\"variantId\":%d,\"quantity\":1,\"unitPrice\":10000}]}",
+                                userAId, productId, variantId)))
                 .andExpect(status().isTooManyRequests());
 
         // userB는 다른 카운터 → 첫 요청이므로 정상 처리
@@ -117,8 +119,8 @@ class RateLimitIntegrationTest extends AbstractIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(String.format(
                                 "{\"userId\":%d,\"idempotencyKey\":\"rl-b-test-1\"," +
-                                "\"items\":[{\"productId\":%d,\"quantity\":1,\"unitPrice\":10000}]}",
-                                userBId, productId)))
+                                "\"items\":[{\"productId\":%d,\"variantId\":%d,\"quantity\":1,\"unitPrice\":10000}]}",
+                                userBId, productId, variantId)))
                 .andExpect(status().isCreated());
     }
 }

--- a/src/test/java/com/stockmanagement/integration/ReviewIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/ReviewIntegrationTest.java
@@ -28,8 +28,9 @@ class ReviewIntegrationTest extends AbstractIntegrationTest {
                 .andExpect(status().isCreated())
                 .andReturn().getResponse().getContentAsString();
         long productId = objectMapper.readTree(body).path("data").path("id").asLong();
+        long variantId = getDefaultVariantId(productId);
 
-        mockMvc.perform(post("/api/inventory/" + productId + "/receive")
+        mockMvc.perform(post("/api/inventory/variants/" + variantId + "/receive")
                         .header("Authorization", "Bearer " + adminToken)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"quantity\":" + qty + "}"))
@@ -42,13 +43,14 @@ class ReviewIntegrationTest extends AbstractIntegrationTest {
      * TossPayments API 없이 구매 완료 상태를 시뮬레이션한다.
      */
     private void placeConfirmedOrder(String userToken, long userId, long productId, int price) throws Exception {
+        long variantId = getDefaultVariantId(productId);
         String body = mockMvc.perform(post("/api/orders")
                         .header("Authorization", "Bearer " + userToken)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(String.format(
                                 "{\"userId\":%d,\"idempotencyKey\":\"%s\"," +
-                                "\"items\":[{\"productId\":%d,\"quantity\":1,\"unitPrice\":%d}]}",
-                                userId, UUID.randomUUID(), productId, price)))
+                                "\"items\":[{\"productId\":%d,\"variantId\":%d,\"quantity\":1,\"unitPrice\":%d}]}",
+                                userId, UUID.randomUUID(), productId, variantId, price)))
                 .andExpect(status().isCreated())
                 .andReturn().getResponse().getContentAsString();
         long orderId = objectMapper.readTree(body).path("data").path("id").asLong();


### PR DESCRIPTION
## Summary
- Product 1:N ProductVariant 구조로 옵션/변형(색상·사이즈 등) 관리 체계 도입
- Inventory·Order·Cart 전체 도메인을 variant 기반으로 전환
- 상품 생성 시 기본 variant("기본") + Inventory 자동 생성으로 하위 호환성 유지
- V56 Flyway 마이그레이션으로 기존 데이터 무중단 전환

## 주요 변경

### 신규
| 파일 | 설명 |
|---|---|
| `ProductVariant` | 엔티티 — product FK, optionName, sku(UK), price, status |
| `ProductVariantRepository` | findByProductId, findByIdWithProduct, existsBySku 등 |
| `ProductVariantCreateRequest/UpdateRequest/Response` | CRUD DTO |
| `V56__create_product_variants.sql` | product_variants 테이블 + inventory/order_items/cart_items variant_id FK |

### 수정
| 영역 | 변경 |
|---|---|
| `Inventory` | product_id → variant_id FK 전환, product_id 읽기 전용 유지 |
| `InventoryController` | `/api/inventory/variants/{variantId}` 경로 체계 |
| `InventoryService` | `getByProductId()` → `getByVariantId()`, reserve/release/confirm variant 기반 |
| `OrderItem` | variant FK 추가, 가격 검증을 variant.price 기준으로 전환 |
| `OrderCommandService` | ProductRepository → ProductVariantRepository 전환 |
| `CartItem` | variant FK 추가, UK(userId, variantId) |
| `CartController` | `DELETE /api/cart/items/variants/{variantId}` 경로 변경 |
| `CartService` | ProductRepository → ProductVariantRepository 전환 |
| `ProductService` | create() 시 기본 variant + Inventory 자동 생성, variant CRUD 메서드 추가 |
| `ProductController` | variant CRUD 엔드포인트 추가 (`/api/products/{id}/variants`) |
| `SecurityConfig` | variant 엔드포인트 ADMIN 권한 설정 |
| `ErrorCode` | VARIANT_NOT_FOUND, VARIANT_NOT_AVAILABLE 추가 |

## Test plan
- [x] 779개 테스트 전체 통과 (단위 540 + 통합 189 + 기타)
- [x] 단위 테스트: InventoryTest, InventoryServiceTest, CartServiceTest, OrderCommandServiceTest, ProductServiceTest 등 variant 반영
- [x] 통합 테스트: 12개 파일 API 경로·JSON 전면 갱신
- [x] 동시성 테스트: ConcurrencyIntegrationTest variant 기반 reserve 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)