### PR TITLE
feat: 주문 아이템별 부분 취소 (#113)

### DIFF
--- a/src/main/java/com/stockmanagement/common/exception/ErrorCode.java
+++ b/src/main/java/com/stockmanagement/common/exception/ErrorCode.java
@@ -35,6 +35,8 @@ public enum ErrorCode {
     ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "주문을 찾을 수 없습니다."),
     INVALID_ORDER_STATUS(HttpStatus.CONFLICT, "현재 주문 상태에서 허용되지 않는 작업입니다."),
     ORDER_ACCESS_DENIED(HttpStatus.FORBIDDEN, "본인의 주문만 접근할 수 있습니다."),
+    ORDER_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 주문에서 아이템을 찾을 수 없습니다."),
+    ORDER_ITEM_ALREADY_CANCELLED(HttpStatus.CONFLICT, "이미 취소된 주문 아이템입니다."),
 
     // ===== Payment =====
     PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "결제 정보를 찾을 수 없습니다."),

--- a/src/main/java/com/stockmanagement/domain/order/controller/OrderController.java
+++ b/src/main/java/com/stockmanagement/domain/order/controller/OrderController.java
@@ -8,6 +8,8 @@ import com.stockmanagement.common.security.SecurityUtils;
 import com.stockmanagement.domain.order.dto.OrderCancelRequest;
 import com.stockmanagement.domain.order.dto.OrderCreateRequest;
 import com.stockmanagement.domain.order.dto.OrderDetailResponse;
+import com.stockmanagement.domain.order.dto.OrderItemCancelRequest;
+import com.stockmanagement.domain.order.dto.OrderItemCancelResponse;
 import com.stockmanagement.domain.order.dto.OrderPreviewRequest;
 import com.stockmanagement.domain.order.dto.OrderPreviewResponse;
 import com.stockmanagement.domain.order.dto.OrderResponse;
@@ -109,6 +111,18 @@ public class OrderController {
         boolean isAdmin = SecurityUtils.isAdmin(authentication);
         String reason = request != null ? request.reason() : null;
         return ApiResponse.ok(orderCommandService.cancel(id, userId, isAdmin, reason));
+    }
+
+    @Operation(summary = "주문 아이템 부분 취소",
+               description = "CONFIRMED/PARTIAL_CANCELLED 주문에서 지정 아이템을 취소한다. Toss 부분 환불 + 재고 해제 + 포인트 비례 반환.")
+    @PostMapping("/{id}/items/cancel")
+    public ApiResponse<OrderItemCancelResponse> cancelItems(
+            @PathVariable Long id,
+            @RequestBody @Valid OrderItemCancelRequest request,
+            @CurrentUserId Long userId,
+            Authentication authentication) {
+        boolean isAdmin = SecurityUtils.isAdmin(authentication);
+        return ApiResponse.ok(orderCommandService.cancelItems(id, userId, isAdmin, request));
     }
 
     @Operation(summary = "주문 상태 변경 이력 조회", description = "생성·취소·확정·환불 등 모든 상태 전이를 시간순으로 반환. ADMIN은 모든 주문, USER는 본인 주문만 가능.")

--- a/src/main/java/com/stockmanagement/domain/order/dto/OrderItemCancelRequest.java
+++ b/src/main/java/com/stockmanagement/domain/order/dto/OrderItemCancelRequest.java
@@ -1,0 +1,24 @@
+package com.stockmanagement.domain.order.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * 주문 아이템 부분 취소 요청 DTO.
+ */
+@Getter
+@NoArgsConstructor
+public class OrderItemCancelRequest {
+
+    /** 취소할 주문 아이템 ID 목록 */
+    @NotEmpty(message = "취소할 아이템을 하나 이상 선택해야 합니다.")
+    private List<Long> itemIds;
+
+    /** 취소 사유 (선택) */
+    @Size(max = 255, message = "취소 사유는 255자 이내여야 합니다.")
+    private String reason;
+}

--- a/src/main/java/com/stockmanagement/domain/order/dto/OrderItemCancelResponse.java
+++ b/src/main/java/com/stockmanagement/domain/order/dto/OrderItemCancelResponse.java
@@ -1,0 +1,30 @@
+package com.stockmanagement.domain.order.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * 주문 아이템 부분 취소 응답 DTO.
+ */
+@Getter
+@Builder
+public class OrderItemCancelResponse {
+
+    /** 주문 ID */
+    private final Long orderId;
+
+    /** 변경된 주문 상태 */
+    private final String orderStatus;
+
+    /** Toss 환불 금액 */
+    private final BigDecimal refundAmount;
+
+    /** 반환된 포인트 */
+    private final long refundedPoints;
+
+    /** 취소된 아이템 목록 */
+    private final List<OrderItemResponse> cancelledItems;
+}

--- a/src/main/java/com/stockmanagement/domain/order/dto/OrderItemResponse.java
+++ b/src/main/java/com/stockmanagement/domain/order/dto/OrderItemResponse.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.extern.jackson.Jacksonized;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 
 /**
  * 주문 항목 응답 DTO.
@@ -45,6 +46,12 @@ public class OrderItemResponse {
     /** 상품 대표 이미지 URL — null이면 이미지 없음 */
     private final String thumbnailUrl;
 
+    /** 주문 아이템 상태 (ACTIVE, CANCELLED) */
+    private final String status;
+
+    /** 부분 취소 시각 — ACTIVE이면 null */
+    private final LocalDateTime cancelledAt;
+
     /** OrderItem 엔티티를 응답 DTO로 변환 (hasReview 미포함). */
     public static OrderItemResponse from(OrderItem item) {
         return from(item, null);
@@ -63,6 +70,8 @@ public class OrderItemResponse {
                 .subtotal(item.getSubtotal())
                 .hasReview(hasReview)
                 .thumbnailUrl(item.getProduct().getThumbnailUrl())
+                .status(item.getStatus().name())
+                .cancelledAt(item.getCancelledAt())
                 .build();
     }
 }

--- a/src/main/java/com/stockmanagement/domain/order/entity/Order.java
+++ b/src/main/java/com/stockmanagement/domain/order/entity/Order.java
@@ -197,7 +197,7 @@ public class Order {
      */
     public void startCancellation() {
         if (this.status == OrderStatus.CANCEL_IN_PROGRESS) return; // 재시도 시 idempotent
-        if (this.status != OrderStatus.CONFIRMED) {
+        if (this.status != OrderStatus.CONFIRMED && this.status != OrderStatus.PARTIAL_CANCELLED) {
             throw new BusinessException(ErrorCode.INVALID_ORDER_STATUS);
         }
         this.status = OrderStatus.CANCEL_IN_PROGRESS;
@@ -224,10 +224,44 @@ public class Order {
      * @throws BusinessException if the current status is not CONFIRMED or CANCEL_IN_PROGRESS
      */
     public void refund() {
-        if (this.status != OrderStatus.CONFIRMED && this.status != OrderStatus.CANCEL_IN_PROGRESS) {
+        if (this.status != OrderStatus.CONFIRMED
+                && this.status != OrderStatus.PARTIAL_CANCELLED
+                && this.status != OrderStatus.CANCEL_IN_PROGRESS) {
             throw new BusinessException(ErrorCode.INVALID_ORDER_STATUS);
         }
         this.status = OrderStatus.CANCELLED;
+    }
+
+    /**
+     * 부분 취소를 적용한다 — 아이템 일부 취소 후 호출.
+     *
+     * <p>모든 아이템이 CANCELLED이면 CANCELLED, 아니면 PARTIAL_CANCELLED로 전환.
+     * CONFIRMED/PARTIAL_CANCELLED 상태에서만 호출 가능.
+     *
+     * @param reason 취소 사유 (null 허용)
+     * @throws BusinessException CONFIRMED/PARTIAL_CANCELLED가 아닌 상태에서 호출 시
+     */
+    public void partialCancel(String reason) {
+        if (this.status != OrderStatus.CONFIRMED && this.status != OrderStatus.PARTIAL_CANCELLED) {
+            throw new BusinessException(ErrorCode.INVALID_ORDER_STATUS);
+        }
+        this.cancelReason = reason;
+
+        if (isAllItemsCancelled()) {
+            this.status = OrderStatus.CANCELLED;
+        } else {
+            this.status = OrderStatus.PARTIAL_CANCELLED;
+        }
+    }
+
+    /** 모든 아이템이 취소되었는지 확인한다. */
+    public boolean isAllItemsCancelled() {
+        return !items.isEmpty() && items.stream().noneMatch(OrderItem::isActive);
+    }
+
+    /** ACTIVE 상태인 아이템만 반환한다. */
+    public List<OrderItem> getActiveItems() {
+        return items.stream().filter(OrderItem::isActive).toList();
     }
 
     /**

--- a/src/main/java/com/stockmanagement/domain/order/entity/OrderItem.java
+++ b/src/main/java/com/stockmanagement/domain/order/entity/OrderItem.java
@@ -1,5 +1,7 @@
 package com.stockmanagement.domain.order.entity;
 
+import com.stockmanagement.common.exception.BusinessException;
+import com.stockmanagement.common.exception.ErrorCode;
 import com.stockmanagement.domain.product.entity.Product;
 import com.stockmanagement.domain.product.entity.ProductVariant;
 import jakarta.persistence.*;
@@ -61,6 +63,15 @@ public class OrderItem {
     @Column(nullable = false, precision = 15, scale = 2)
     private BigDecimal subtotal;
 
+    /** 주문 항목 상태 — 부분 취소 시 CANCELLED로 전환 */
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private OrderItemStatus status;
+
+    /** 부분 취소 시각 — ACTIVE 상태에서는 null */
+    @Column(name = "cancelled_at")
+    private LocalDateTime cancelledAt;
+
     @CreationTimestamp
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
@@ -72,6 +83,27 @@ public class OrderItem {
         this.quantity = quantity;
         this.unitPrice = unitPrice;
         this.subtotal = unitPrice.multiply(BigDecimal.valueOf(quantity));
+        this.status = OrderItemStatus.ACTIVE;
+    }
+
+    // ===== 비즈니스 메서드 =====
+
+    /**
+     * 아이템을 부분 취소한다.
+     *
+     * @throws BusinessException 이미 취소된 아이템일 경우
+     */
+    public void cancel() {
+        if (this.status == OrderItemStatus.CANCELLED) {
+            throw new BusinessException(ErrorCode.ORDER_ITEM_ALREADY_CANCELLED);
+        }
+        this.status = OrderItemStatus.CANCELLED;
+        this.cancelledAt = LocalDateTime.now();
+    }
+
+    /** 활성 상태인지 확인한다. */
+    public boolean isActive() {
+        return this.status == OrderItemStatus.ACTIVE;
     }
 
     /**

--- a/src/main/java/com/stockmanagement/domain/order/entity/OrderItemStatus.java
+++ b/src/main/java/com/stockmanagement/domain/order/entity/OrderItemStatus.java
@@ -1,0 +1,14 @@
+package com.stockmanagement.domain.order.entity;
+
+/**
+ * 주문 항목 상태.
+ *
+ * <ul>
+ *   <li>{@code ACTIVE} — 정상 (기본값)
+ *   <li>{@code CANCELLED} — 부분 취소됨
+ * </ul>
+ */
+public enum OrderItemStatus {
+    ACTIVE,
+    CANCELLED
+}

--- a/src/main/java/com/stockmanagement/domain/order/entity/OrderStatus.java
+++ b/src/main/java/com/stockmanagement/domain/order/entity/OrderStatus.java
@@ -7,6 +7,7 @@ package com.stockmanagement.domain.order.entity;
  * PENDING              → 주문 생성 완료, 재고 예약 완료, 결제 대기 중
  * PAYMENT_IN_PROGRESS  → Toss API 승인 요청 중 (만료 스케줄러 접근 불가)
  * CONFIRMED            → 결제 성공 (Payment 도메인에서 전환)
+ * PARTIAL_CANCELLED    → 일부 아이템 취소됨 (부분 환불 완료)
  * CANCEL_IN_PROGRESS   → Toss API 취소 요청 중 (취소 실패 시 CONFIRMED로 복원)
  * CANCELLED            → 주문 취소, 재고 예약 해제 완료
  * </pre>
@@ -18,6 +19,9 @@ package com.stockmanagement.domain.order.entity;
  *   <li>PAYMENT_IN_PROGRESS → PENDING (결제 실패/오류 시 복원)
  *   <li>PENDING → CONFIRMED (가상계좌 Webhook 경로)
  *   <li>PENDING → CANCELLED (주문 취소 / 만료 스케줄러)
+ *   <li>CONFIRMED → PARTIAL_CANCELLED (일부 아이템 취소)
+ *   <li>PARTIAL_CANCELLED → PARTIAL_CANCELLED (추가 아이템 취소)
+ *   <li>PARTIAL_CANCELLED → CANCELLED (모든 아이템 취소)
  *   <li>CONFIRMED → CANCEL_IN_PROGRESS (Toss 취소 API 호출 직전 선점)
  *   <li>CANCEL_IN_PROGRESS → CANCELLED (취소 성공)
  *   <li>CANCEL_IN_PROGRESS → CONFIRMED (Toss 오류 시 복원)
@@ -42,6 +46,9 @@ public enum OrderStatus {
 
     /** 결제 완료 — 출고 확정 상태 */
     CONFIRMED,
+
+    /** 일부 아이템 취소됨 — 부분 환불 완료 상태 */
+    PARTIAL_CANCELLED,
 
     /**
      * Toss API 취소 요청 중.

--- a/src/main/java/com/stockmanagement/domain/order/service/OrderCommandService.java
+++ b/src/main/java/com/stockmanagement/domain/order/service/OrderCommandService.java
@@ -2,12 +2,17 @@ package com.stockmanagement.domain.order.service;
 
 import com.stockmanagement.common.exception.BusinessException;
 import com.stockmanagement.common.exception.ErrorCode;
+import com.stockmanagement.common.lock.DistributedLock;
 import com.stockmanagement.domain.coupon.service.CouponService;
 import com.stockmanagement.domain.inventory.service.InventoryService;
+import com.stockmanagement.domain.payment.service.PaymentService;
 import com.stockmanagement.domain.point.service.PointService;
 import com.stockmanagement.domain.user.address.service.DeliveryAddressService;
 import com.stockmanagement.domain.order.dto.OrderCreateRequest;
+import com.stockmanagement.domain.order.dto.OrderItemCancelRequest;
+import com.stockmanagement.domain.order.dto.OrderItemCancelResponse;
 import com.stockmanagement.domain.order.dto.OrderItemRequest;
+import com.stockmanagement.domain.order.dto.OrderItemResponse;
 import com.stockmanagement.domain.order.dto.OrderResponse;
 import com.stockmanagement.domain.order.entity.Order;
 import com.stockmanagement.domain.order.entity.OrderItem;
@@ -31,14 +36,17 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.dao.DataIntegrityViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -59,6 +67,7 @@ public class OrderCommandService {
     private final OrderStatusHistoryRepository historyRepository;
     private final CouponService couponService;
     private final PointService pointService;
+    private final PaymentService paymentService;
     private final OutboxEventStore outboxEventStore;
     private final DeliveryAddressService deliveryAddressService;
     private final OrderDeliverySnapshotRepository deliverySnapshotRepository;
@@ -259,6 +268,148 @@ public class OrderCommandService {
         recordHistory(order.getId(), previousStatus, OrderStatus.CANCELLED, "system:expiry");
         outboxEventStore.save(new OrderCancelledEvent(order.getId(), order.getUserId(), "SYSTEM_EXPIRY"));
     }
+
+    // ===== 아이템 부분 취소 =====
+
+    /**
+     * 주문 아이템을 부분 취소한다.
+     *
+     * <p>CONFIRMED/PARTIAL_CANCELLED 상태 주문에서 지정 아이템을 취소하고 Toss 부분 환불을 수행한다.
+     * 분산 락으로 동일 주문 동시 부분 취소를 방지한다.
+     *
+     * <p>흐름:
+     * <ol>
+     *   <li>[Short TX] 검증 + 환불 금액 계산
+     *   <li>[No TX] Toss 부분 환불 API 호출
+     *   <li>[Short TX] 아이템 CANCELLED 처리 + 재고 해제 + 포인트 반환 + 주문 상태 전이
+     * </ol>
+     */
+    @DistributedLock(key = "'order-item-cancel:' + #orderId")
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    public OrderItemCancelResponse cancelItems(Long orderId, Long userId, boolean isAdmin,
+                                               OrderItemCancelRequest request) {
+        // 1. Short TX: 검증 + 환불 금액 계산
+        CancelItemsContext ctx = validateAndPrepare(orderId, userId, isAdmin, request.getItemIds());
+
+        // 2. Toss 부분 환불 (DB 커넥션 미점유)
+        if (ctx.refundAmount.compareTo(BigDecimal.ZERO) > 0) {
+            paymentService.cancelPartialForItems(orderId, ctx.refundAmount, request.getReason());
+        }
+
+        // 3. Short TX: 아이템 취소 + 재고 해제 + 포인트 반환 + 주문 상태 전이
+        return applyItemCancel(orderId, request.getItemIds(), request.getReason(),
+                ctx.refundAmount, ctx.pointsToRefund);
+    }
+
+    /**
+     * [Short TX] 부분 취소 검증 + 환불 금액 계산.
+     */
+    @Transactional
+    CancelItemsContext validateAndPrepare(Long orderId, Long userId, boolean isAdmin,
+                                          List<Long> itemIds) {
+        Order order = orderRepository.findByIdWithItemsForUpdate(orderId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
+
+        validateOrderOwnership(order, userId, isAdmin);
+
+        // CONFIRMED 또는 PARTIAL_CANCELLED 상태만 부분 취소 가능
+        if (order.getStatus() != OrderStatus.CONFIRMED
+                && order.getStatus() != OrderStatus.PARTIAL_CANCELLED) {
+            throw new BusinessException(ErrorCode.INVALID_ORDER_STATUS);
+        }
+
+        // 요청 아이템 검증
+        Set<Long> requestedIds = new HashSet<>(itemIds);
+        Map<Long, OrderItem> itemMap = order.getItems().stream()
+                .collect(Collectors.toMap(OrderItem::getId, i -> i));
+
+        List<OrderItem> targetItems = new ArrayList<>();
+        for (Long itemId : requestedIds) {
+            OrderItem item = itemMap.get(itemId);
+            if (item == null) {
+                throw new BusinessException(ErrorCode.ORDER_ITEM_NOT_FOUND);
+            }
+            if (!item.isActive()) {
+                throw new BusinessException(ErrorCode.ORDER_ITEM_ALREADY_CANCELLED);
+            }
+            targetItems.add(item);
+        }
+
+        // 환불 금액 계산 (비례 안분)
+        BigDecimal cancelledSubtotal = targetItems.stream()
+                .map(OrderItem::getSubtotal)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        BigDecimal cancelRatio = cancelledSubtotal.divide(
+                order.getTotalAmount(), 10, RoundingMode.DOWN);
+
+        BigDecimal proportionalDiscount = order.getDiscountAmount()
+                .multiply(cancelRatio).setScale(0, RoundingMode.DOWN);
+
+        long proportionalPoints = BigDecimal.valueOf(order.getUsedPoints())
+                .multiply(cancelRatio).setScale(0, RoundingMode.DOWN).longValue();
+
+        BigDecimal refundAmount = cancelledSubtotal
+                .subtract(proportionalDiscount)
+                .subtract(BigDecimal.valueOf(proportionalPoints))
+                .max(BigDecimal.ZERO);
+
+        return new CancelItemsContext(refundAmount, proportionalPoints);
+    }
+
+    /**
+     * [Short TX] 아이템 취소 + 재고 해제 + 포인트 반환 + 주문 상태 전이.
+     */
+    @Transactional
+    @CacheEvict(cacheNames = "orders", key = "#orderId")
+    OrderItemCancelResponse applyItemCancel(Long orderId, List<Long> itemIds, String reason,
+                                            BigDecimal refundAmount, long pointsToRefund) {
+        Order order = orderRepository.findByIdWithItemsForUpdate(orderId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
+
+        OrderStatus previousStatus = order.getStatus();
+        Set<Long> requestedIds = new HashSet<>(itemIds);
+
+        // 아이템 취소 + 재고 해제
+        List<OrderItemResponse> cancelledResponses = new ArrayList<>();
+        for (OrderItem item : order.getItems()) {
+            if (requestedIds.contains(item.getId()) && item.isActive()) {
+                item.cancel();
+                inventoryService.releaseAllocation(item.getVariant().getId(), item.getQuantity());
+                cancelledResponses.add(OrderItemResponse.from(item));
+            }
+        }
+
+        // 비례 포인트 반환
+        if (pointsToRefund > 0) {
+            pointService.refundPartial(order.getUserId(), orderId, pointsToRefund);
+        }
+
+        // 주문 상태 전이
+        order.partialCancel(reason);
+
+        // 모든 아이템 취소 → 쿠폰 반환 + EARN 포인트 처리
+        if (order.isAllItemsCancelled()) {
+            couponService.releaseCoupon(orderId);
+            pointService.expirePending(orderId);
+        }
+
+        recordHistory(orderId, previousStatus, order.getStatus(),
+                "partial-cancel:items=" + itemIds);
+        outboxEventStore.save(new OrderCancelledEvent(
+                orderId, order.getUserId(), "PARTIAL_ITEM_CANCELLED"));
+
+        return OrderItemCancelResponse.builder()
+                .orderId(orderId)
+                .orderStatus(order.getStatus().name())
+                .refundAmount(refundAmount)
+                .refundedPoints(pointsToRefund)
+                .cancelledItems(cancelledResponses)
+                .build();
+    }
+
+    /** 부분 취소 검증 결과 컨텍스트. */
+    record CancelItemsContext(BigDecimal refundAmount, long pointsToRefund) {}
 
     /**
      * 회원 탈퇴 시 사용자의 모든 PENDING 주문을 강제 취소한다.

--- a/src/main/java/com/stockmanagement/domain/order/service/OrderPaymentService.java
+++ b/src/main/java/com/stockmanagement/domain/order/service/OrderPaymentService.java
@@ -75,16 +75,18 @@ public class OrderPaymentService {
         Order order = orderRepository.findByIdWithItemsForUpdate(id)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
 
+        OrderStatus previousStatus = order.getStatus();
         order.refund();
 
-        for (OrderItem item : order.getItems()) {
+        // ACTIVE 아이템만 재고 해제 — 부분 취소로 이미 CANCELLED된 아이템은 건너뜀
+        for (OrderItem item : order.getActiveItems()) {
             inventoryService.releaseAllocation(item.getVariant().getId(), item.getQuantity());
         }
 
         couponService.releaseCoupon(order.getId());
         pointService.refundByOrder(order.getUserId(), order.getId());
 
-        recordHistory(order.getId(), OrderStatus.CONFIRMED, OrderStatus.CANCELLED, null);
+        recordHistory(order.getId(), previousStatus, OrderStatus.CANCELLED, null);
         outboxEventStore.save(new OrderCancelledEvent(order.getId(), order.getUserId(), "PAYMENT_REFUNDED"));
     }
 

--- a/src/main/java/com/stockmanagement/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/stockmanagement/domain/payment/service/PaymentService.java
@@ -24,6 +24,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -375,6 +376,29 @@ public class PaymentService {
             }
         }
         return paymentRepository.findByOrderId(orderId).map(PaymentResponse::from);
+    }
+
+    /**
+     * 주문 아이템 부분 취소를 위한 Toss 부분 환불 + Payment 엔티티 업데이트.
+     *
+     * <p>OrderCommandService.cancelItems()에서 호출된다.
+     * 기존 cancel()과 달리 Order 상태 전이는 하지 않는다 (호출자가 분산 락으로 관리).
+     *
+     * @param orderId      주문 ID
+     * @param cancelAmount 부분 환불 금액
+     * @param reason       취소 사유
+     */
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    public void cancelPartialForItems(Long orderId, BigDecimal cancelAmount, String reason) {
+        // 1. Short TX: Payment 로드 + paymentKey 확보
+        String paymentKey = transactionHelper.getPaymentKeyForOrder(orderId);
+
+        // 2. Toss API 호출 (DB 커넥션 미점유)
+        tossPaymentsClient.cancel(paymentKey,
+                new TossCancelRequest(reason, cancelAmount));
+
+        // 3. Short TX: Payment 상태 업데이트
+        transactionHelper.applyPartialCancelOnly(paymentKey, reason, cancelAmount);
     }
 
     // ===== Private helpers =====

--- a/src/main/java/com/stockmanagement/domain/payment/service/PaymentTransactionHelper.java
+++ b/src/main/java/com/stockmanagement/domain/payment/service/PaymentTransactionHelper.java
@@ -403,6 +403,51 @@ class PaymentTransactionHelper {
                 tossOrderId, payment.getOrderId());
     }
 
+    // ===== 아이템 부분 취소 전용 =====
+
+    /**
+     * 주문 ID로 결제의 paymentKey를 조회한다 (Short TX).
+     *
+     * @param orderId 주문 ID
+     * @return paymentKey
+     * @throws BusinessException 결제 없음 또는 취소 불가 상태
+     */
+    @Transactional
+    String getPaymentKeyForOrder(Long orderId) {
+        Payment payment = paymentRepository.findByOrderId(orderId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PAYMENT_NOT_FOUND));
+
+        if (payment.getStatus() != PaymentStatus.DONE
+                && payment.getStatus() != PaymentStatus.PARTIAL_CANCELLED) {
+            throw new BusinessException(ErrorCode.INVALID_PAYMENT_STATUS);
+        }
+
+        return payment.getPaymentKey();
+    }
+
+    /**
+     * Payment 엔티티만 부분 취소 처리한다 (Short TX).
+     * Order 상태 전이는 수행하지 않는다 — OrderCommandService가 담당.
+     *
+     * @param paymentKey   Toss 결제 키
+     * @param cancelReason 취소 사유
+     * @param cancelAmount 부분 취소 금액
+     */
+    @Transactional
+    void applyPartialCancelOnly(String paymentKey, String cancelReason, BigDecimal cancelAmount) {
+        Payment payment = paymentRepository.findByPaymentKeyWithLock(paymentKey)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PAYMENT_NOT_FOUND));
+
+        if (payment.getStatus() == PaymentStatus.CANCELLED) {
+            return; // 이미 전액 취소됨
+        }
+
+        payment.cancel(cancelReason, cancelAmount);
+
+        log.info("[Payment] 아이템 부분 취소 완료: paymentKey={}, cancelAmount={}, newStatus={}",
+                paymentKey, cancelAmount, payment.getStatus());
+    }
+
     private LocalDateTime parseDateTime(String dateTimeStr) {
         if (dateTimeStr == null) return null;
         return OffsetDateTime.parse(dateTimeStr).toLocalDateTime();

--- a/src/main/java/com/stockmanagement/domain/point/service/PointService.java
+++ b/src/main/java/com/stockmanagement/domain/point/service/PointService.java
@@ -232,29 +232,40 @@ public class PointService {
      */
     @Transactional
     public void refundByOrder(Long userId, Long orderId) {
-        // 멱등성: 이미 REFUND 처리된 주문이면 중복 실행 방지
-        if (pointTransactionRepository.existsByOrderIdAndType(orderId, PointTransactionType.REFUND)) {
-            return;
-        }
         List<PointTransaction> orderTxns = pointTransactionRepository.findByOrderId(orderId);
         if (orderTxns.isEmpty()) return;
+
+        // 이미 부분 환불된 포인트 합산
+        long alreadyRefunded = orderTxns.stream()
+                .filter(tx -> tx.getType() == PointTransactionType.REFUND)
+                .mapToLong(PointTransaction::getAmount)
+                .sum();
+
+        // USE 트랜잭션의 총 사용 포인트
+        long totalUsed = orderTxns.stream()
+                .filter(tx -> tx.getType() == PointTransactionType.USE)
+                .mapToLong(tx -> Math.abs(tx.getAmount()))
+                .sum();
+
+        // 잔여 환불 포인트 = 총 사용 - 이미 환불된 양
+        long remainingRefund = totalUsed - alreadyRefunded;
 
         UserPoint userPoint = getOrCreate(userId);
         List<PointTransaction> newTxns = new ArrayList<>();
 
+        if (remainingRefund > 0) {
+            userPoint.refund(remainingRefund);
+            newTxns.add(PointTransaction.builder()
+                    .userId(userId)
+                    .amount(remainingRefund)
+                    .type(PointTransactionType.REFUND)
+                    .description("주문 취소 포인트 반환 (주문 #" + orderId + ")")
+                    .orderId(orderId)
+                    .build());
+        }
+
         orderTxns.forEach(tx -> {
-            if (tx.getType() == PointTransactionType.USE) {
-                // 사용 포인트 반환
-                long refundAmount = Math.abs(tx.getAmount());
-                userPoint.refund(refundAmount);
-                newTxns.add(PointTransaction.builder()
-                        .userId(userId)
-                        .amount(refundAmount)
-                        .type(PointTransactionType.REFUND)
-                        .description("주문 취소 포인트 반환 (주문 #" + orderId + ")")
-                        .orderId(orderId)
-                        .build());
-            } else if (tx.getType() == PointTransactionType.EARN) {
+            if (tx.getType() == PointTransactionType.EARN) {
                 if (tx.getStatus() == PointTransactionStatus.PENDING) {
                     // PENDING 적립 → EXPIRED (잔액 변동 없음)
                     tx.expire();
@@ -284,6 +295,32 @@ public class PointService {
         if (!newTxns.isEmpty()) {
             pointTransactionRepository.saveAll(newTxns);
         }
+    }
+
+    /**
+     * 부분 취소 시 비례 포인트를 반환한다.
+     *
+     * <p>전체 취소({@link #refundByOrder})와 달리 지정 금액만 반환하며 EARN 처리를 하지 않는다.
+     * EARN 처리는 모든 아이템 취소 시 전체 취소 흐름에서 수행한다.
+     *
+     * @param userId         사용자 ID
+     * @param orderId        주문 ID
+     * @param pointsToRefund 반환할 포인트
+     */
+    @Transactional
+    public void refundPartial(Long userId, Long orderId, long pointsToRefund) {
+        if (pointsToRefund <= 0) return;
+
+        UserPoint userPoint = getOrCreate(userId);
+        userPoint.refund(pointsToRefund);
+
+        pointTransactionRepository.save(PointTransaction.builder()
+                .userId(userId)
+                .amount(pointsToRefund)
+                .type(PointTransactionType.REFUND)
+                .description("부분 취소 포인트 반환 (주문 #" + orderId + ")")
+                .orderId(orderId)
+                .build());
     }
 
     /**

--- a/src/main/resources/db/migration/V57__add_order_item_status.sql
+++ b/src/main/resources/db/migration/V57__add_order_item_status.sql
@@ -1,0 +1,4 @@
+-- 주문 아이템별 부분 취소 지원을 위한 상태 컬럼 추가
+ALTER TABLE order_items
+    ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'ACTIVE',
+    ADD COLUMN cancelled_at DATETIME(6) NULL;

--- a/src/test/java/com/stockmanagement/domain/point/service/PointServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/point/service/PointServiceTest.java
@@ -225,8 +225,6 @@ class PointServiceTest {
         @Test
         @DisplayName("USE + EARN(CONFIRMED) 이력 있음 → 반환 + 회수 처리")
         void refundsBothUseAndEarn() {
-            given(pointTransactionRepository.existsByOrderIdAndType(100L, PointTransactionType.REFUND))
-                    .willReturn(false);
             UserPoint up = mockUserPoint(1L, 200); // earn된 상태
             given(userPointRepository.findByUserIdWithLock(1L)).willReturn(Optional.of(up));
 
@@ -257,8 +255,6 @@ class PointServiceTest {
                     .status(PointTransactionStatus.PENDING)
                     .description("적립 예정").orderId(100L).build();
 
-            given(pointTransactionRepository.existsByOrderIdAndType(100L, PointTransactionType.REFUND))
-                    .willReturn(false);
             given(pointTransactionRepository.findByOrderId(100L)).willReturn(List.of(pendingEarnTx));
             UserPoint up = mockUserPoint(1L, 0);
             given(userPointRepository.findByUserIdWithLock(1L)).willReturn(Optional.of(up));


### PR DESCRIPTION
## Summary
- CONFIRMED/PARTIAL_CANCELLED 주문에서 개별 아이템을 선택 취소하는 `POST /api/orders/{id}/items/cancel` 엔드포인트 추가
- Short TX → Toss 부분 환불 HTTP → Short TX 패턴으로 DB 커넥션 점유 최소화
- 비례 포인트 환불(`refundPartial`), 전체 취소 시 기환불 금액 차감 처리

## Changes
| 파일 | 변경 내용 |
|---|---|
| `V57__add_order_item_status.sql` | order_items에 status, cancelled_at 컬럼 추가 |
| `OrderItemStatus` | ACTIVE, CANCELLED enum |
| `OrderItemCancelRequest/Response` | 부분 취소 요청/응답 DTO |
| `OrderItem` | status 필드, cancel(), isActive() |
| `Order` | partialCancel(), getActiveItems(), isAllItemsCancelled() |
| `OrderStatus` | PARTIAL_CANCELLED 상태 추가 |
| `OrderCommandService` | cancelItems() 오케스트레이터 (분산 락 + NOT_SUPPORTED) |
| `PaymentService` | cancelPartialForItems() 부분 환불 |
| `PaymentTransactionHelper` | getPaymentKeyForOrder(), applyPartialCancelOnly() |
| `PointService` | refundPartial() 추가, refundByOrder() 기환불 차감 로직 |
| `OrderPaymentService` | refund()에서 CANCELLED 아이템 제외 |

## Test plan
- [x] 전체 테스트 통과 (BUILD SUCCESSFUL)
- [ ] CONFIRMED 주문에서 일부 아이템 취소 → PARTIAL_CANCELLED 전환 확인
- [ ] PARTIAL_CANCELLED 주문에서 나머지 아이템 전부 취소 → CANCELLED 전환 확인
- [ ] 이미 취소된 아이템 재취소 시 409 에러 확인
- [ ] 포인트 비례 환불 금액 정확성 검증

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)