### PR TITLE
perf: 오프셋 → 커서 기반 페이지네이션 전환 (#15)

### DIFF
--- a/src/main/java/com/stockmanagement/domain/coupon/controller/CouponController.java
+++ b/src/main/java/com/stockmanagement/domain/coupon/controller/CouponController.java
@@ -1,6 +1,7 @@
 package com.stockmanagement.domain.coupon.controller;
 
 import com.stockmanagement.common.dto.ApiResponse;
+import com.stockmanagement.common.dto.CursorPage;
 import com.stockmanagement.common.security.CurrentUserId;
 import com.stockmanagement.domain.coupon.dto.CouponClaimRequest;
 import com.stockmanagement.domain.coupon.dto.CouponCreateRequest;
@@ -13,16 +14,20 @@ import com.stockmanagement.domain.coupon.service.CouponService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
 
 import java.util.List;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Coupon", description = "쿠폰 관리 API")
+@Validated
 @RestController
 @RequestMapping("/api/v1/coupons")
 @RequiredArgsConstructor
@@ -39,9 +44,10 @@ public class CouponController {
 
     @Operation(summary = "공개 쿠폰 목록 — 다운로드 가능한 쿠폰 (인증 불필요)")
     @GetMapping("/public")
-    public ApiResponse<Page<CouponResponse>> getPublicCoupons(
-            @PageableDefault(size = 20) Pageable pageable) {
-        return ApiResponse.ok(couponService.getPublicCoupons(pageable));
+    public ApiResponse<CursorPage<CouponResponse>> getPublicCoupons(
+            @RequestParam(required = false) Long lastId,
+            @Min(1) @Max(100) @RequestParam(defaultValue = "20") int size) {
+        return ApiResponse.ok(couponService.getPublicCoupons(lastId, size));
     }
 
     @Operation(summary = "쿠폰 목록 [ADMIN]")

--- a/src/main/java/com/stockmanagement/domain/coupon/repository/CouponRepository.java
+++ b/src/main/java/com/stockmanagement/domain/coupon/repository/CouponRepository.java
@@ -12,6 +12,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface CouponRepository extends JpaRepository<Coupon, Long> {
@@ -30,6 +31,32 @@ public interface CouponRepository extends JpaRepository<Coupon, Long> {
             """)
     Page<Coupon> findAvailablePublicCoupons(@Param("now") LocalDateTime now, Pageable pageable);
 
+
+    /** 커서 기반 공개 쿠폰 조회 — 첫 페이지. */
+    @Query("""
+            SELECT c FROM Coupon c
+            WHERE c.isPublic = true
+              AND c.active = true
+              AND c.validFrom <= :now
+              AND c.validUntil > :now
+              AND (c.maxUsageCount IS NULL OR c.usageCount < c.maxUsageCount)
+            ORDER BY c.id DESC
+            """)
+    List<Coupon> findAvailablePublicCouponsCursor(@Param("now") LocalDateTime now, Pageable pageable);
+
+    /** 커서 기반 공개 쿠폰 조회 — 다음 페이지 (id < lastId). */
+    @Query("""
+            SELECT c FROM Coupon c
+            WHERE c.isPublic = true
+              AND c.active = true
+              AND c.validFrom <= :now
+              AND c.validUntil > :now
+              AND (c.maxUsageCount IS NULL OR c.usageCount < c.maxUsageCount)
+              AND c.id < :lastId
+            ORDER BY c.id DESC
+            """)
+    List<Coupon> findAvailablePublicCouponsCursorAfter(@Param("now") LocalDateTime now,
+                                                       @Param("lastId") Long lastId, Pageable pageable);
 
     /**
      * 만료된 활성 쿠폰을 단일 벌크 UPDATE로 비활성화한다.

--- a/src/main/java/com/stockmanagement/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/stockmanagement/domain/coupon/service/CouponService.java
@@ -17,10 +17,12 @@ import com.stockmanagement.domain.coupon.entity.UserCoupon;
 import com.stockmanagement.domain.coupon.repository.CouponRepository;
 import com.stockmanagement.domain.coupon.repository.CouponUsageRepository;
 import com.stockmanagement.domain.coupon.repository.UserCouponRepository;
+import com.stockmanagement.common.dto.CursorPage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -85,10 +87,15 @@ public class CouponService {
         return couponRepository.findAll(pageable).map(CouponResponse::from);
     }
 
-    /** 공개 쿠폰 목록 조회 — 인증 불필요. */
-    public Page<CouponResponse> getPublicCoupons(Pageable pageable) {
-        return couponRepository.findAvailablePublicCoupons(LocalDateTime.now(), pageable)
-                .map(CouponResponse::from);
+    /** 공개 쿠폰 목록 조회 — 인증 불필요 (커서 기반). */
+    public CursorPage<CouponResponse> getPublicCoupons(Long lastId, int size) {
+        LocalDateTime now = LocalDateTime.now();
+        PageRequest limit = PageRequest.of(0, size + 1);
+        List<Coupon> items = lastId == null
+                ? couponRepository.findAvailablePublicCouponsCursor(now, limit)
+                : couponRepository.findAvailablePublicCouponsCursorAfter(now, lastId, limit);
+        List<CouponResponse> responses = items.stream().map(CouponResponse::from).toList();
+        return CursorPage.of(responses, size, CouponResponse::getId);
     }
 
     public CouponResponse getById(Long id) {

--- a/src/main/java/com/stockmanagement/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/stockmanagement/domain/notification/controller/NotificationController.java
@@ -1,18 +1,18 @@
 package com.stockmanagement.domain.notification.controller;
 
 import com.stockmanagement.common.dto.ApiResponse;
+import com.stockmanagement.common.dto.CursorPage;
 import com.stockmanagement.common.security.CurrentUserId;
 import com.stockmanagement.domain.notification.dto.NotificationResponse;
 import com.stockmanagement.domain.notification.dto.UnreadCountResponse;
 import com.stockmanagement.domain.notification.service.NotificationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 /**
@@ -26,6 +26,7 @@ import org.springframework.web.bind.annotation.*;
  * </pre>
  */
 @Tag(name = "알림", description = "인앱 알림 — 목록 조회 · 읽음 처리")
+@Validated
 @RestController
 @RequestMapping("/api/v1/notifications")
 @RequiredArgsConstructor
@@ -33,14 +34,14 @@ public class NotificationController {
 
     private final NotificationService notificationService;
 
-    @Operation(summary = "내 알림 목록", description = "?read=true|false 로 필터. 미지정 시 전체. 기본: 최신순, 20건.")
+    @Operation(summary = "내 알림 목록", description = "?read=true|false 로 필터. 미지정 시 전체. 커서 기반 페이지네이션.")
     @GetMapping
-    public ApiResponse<Page<NotificationResponse>> getNotifications(
+    public ApiResponse<CursorPage<NotificationResponse>> getNotifications(
             @RequestParam(required = false) Boolean read,
-            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
-            Pageable pageable,
+            @RequestParam(required = false) Long lastId,
+            @Min(1) @Max(100) @RequestParam(defaultValue = "20") int size,
             @CurrentUserId Long userId) {
-        return ApiResponse.ok(notificationService.getNotifications(userId, read, pageable));
+        return ApiResponse.ok(notificationService.getNotifications(userId, read, lastId, size));
     }
 
     @Operation(summary = "알림 읽음 처리", description = "단건 알림을 읽음 처리한다.")

--- a/src/main/java/com/stockmanagement/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/stockmanagement/domain/notification/repository/NotificationRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
@@ -17,6 +18,18 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     Page<Notification> findByUserIdAndReadAtIsNullOrderByCreatedAtDesc(Long userId, Pageable pageable);
 
     Page<Notification> findByUserIdAndReadAtIsNotNullOrderByCreatedAtDesc(Long userId, Pageable pageable);
+
+    // 커서 기반 — 전체
+    List<Notification> findByUserIdOrderByIdDesc(Long userId, Pageable pageable);
+    List<Notification> findByUserIdAndIdLessThanOrderByIdDesc(Long userId, Long lastId, Pageable pageable);
+
+    // 커서 기반 — 미읽음
+    List<Notification> findByUserIdAndReadAtIsNullOrderByIdDesc(Long userId, Pageable pageable);
+    List<Notification> findByUserIdAndReadAtIsNullAndIdLessThanOrderByIdDesc(Long userId, Long lastId, Pageable pageable);
+
+    // 커서 기반 — 읽음
+    List<Notification> findByUserIdAndReadAtIsNotNullOrderByIdDesc(Long userId, Pageable pageable);
+    List<Notification> findByUserIdAndReadAtIsNotNullAndIdLessThanOrderByIdDesc(Long userId, Long lastId, Pageable pageable);
 
     long countByUserIdAndReadAtIsNull(Long userId);
 

--- a/src/main/java/com/stockmanagement/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/stockmanagement/domain/notification/service/NotificationService.java
@@ -6,9 +6,9 @@ import com.stockmanagement.domain.notification.dto.NotificationResponse;
 import com.stockmanagement.domain.notification.entity.Notification;
 import com.stockmanagement.domain.notification.entity.NotificationType;
 import com.stockmanagement.domain.notification.repository.NotificationRepository;
+import com.stockmanagement.common.dto.CursorPage;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,21 +27,35 @@ public class NotificationService {
     private final NotificationRepository notificationRepository;
 
     /**
-     * 내 알림 목록을 조회한다.
+     * 내 알림 목록을 커서 기반으로 조회한다.
      *
      * @param userId 사용자 ID
      * @param read   null이면 전체, true이면 읽음만, false이면 미읽음만
+     * @param lastId 커서 (이전 페이지 마지막 ID), null이면 첫 페이지
+     * @param size   페이지 크기
      */
-    public Page<NotificationResponse> getNotifications(Long userId, Boolean read, Pageable pageable) {
-        Page<Notification> page;
+    public CursorPage<NotificationResponse> getNotifications(Long userId, Boolean read, Long lastId, int size) {
+        PageRequest limit = PageRequest.of(0, size + 1);
+        java.util.List<Notification> items;
+
         if (read == null) {
-            page = notificationRepository.findByUserIdOrderByCreatedAtDesc(userId, pageable);
+            items = lastId == null
+                    ? notificationRepository.findByUserIdOrderByIdDesc(userId, limit)
+                    : notificationRepository.findByUserIdAndIdLessThanOrderByIdDesc(userId, lastId, limit);
         } else if (read) {
-            page = notificationRepository.findByUserIdAndReadAtIsNotNullOrderByCreatedAtDesc(userId, pageable);
+            items = lastId == null
+                    ? notificationRepository.findByUserIdAndReadAtIsNotNullOrderByIdDesc(userId, limit)
+                    : notificationRepository.findByUserIdAndReadAtIsNotNullAndIdLessThanOrderByIdDesc(userId, lastId, limit);
         } else {
-            page = notificationRepository.findByUserIdAndReadAtIsNullOrderByCreatedAtDesc(userId, pageable);
+            items = lastId == null
+                    ? notificationRepository.findByUserIdAndReadAtIsNullOrderByIdDesc(userId, limit)
+                    : notificationRepository.findByUserIdAndReadAtIsNullAndIdLessThanOrderByIdDesc(userId, lastId, limit);
         }
-        return page.map(NotificationResponse::from);
+
+        return CursorPage.of(
+                items.stream().map(NotificationResponse::from).toList(),
+                size,
+                NotificationResponse::getId);
     }
 
     /** 알림 단건 읽음 처리. 소유권 검증 포함. */

--- a/src/main/java/com/stockmanagement/domain/order/controller/OrderController.java
+++ b/src/main/java/com/stockmanagement/domain/order/controller/OrderController.java
@@ -2,6 +2,7 @@ package com.stockmanagement.domain.order.controller;
 
 import com.stockmanagement.common.annotation.RequireEmailVerified;
 import com.stockmanagement.common.dto.ApiResponse;
+import com.stockmanagement.common.dto.CursorPage;
 import com.stockmanagement.common.ratelimit.RateLimit;
 import com.stockmanagement.common.security.CurrentUserId;
 import com.stockmanagement.common.security.SecurityUtils;
@@ -19,15 +20,14 @@ import com.stockmanagement.domain.order.service.OrderCommandService;
 import com.stockmanagement.domain.order.service.OrderDetailService;
 import com.stockmanagement.domain.order.service.OrderQueryService;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -38,6 +38,7 @@ import java.util.List;
  * <p>Base URL: {@code /api/orders}
  */
 @Tag(name = "주문", description = "주문 생성 · 조회 · 취소 · 상태 이력")
+@Validated
 @RestController
 @RequestMapping("/api/v1/orders")
 @RequiredArgsConstructor
@@ -87,18 +88,18 @@ public class OrderController {
         return ApiResponse.ok(orderDetailService.getDetail(id, userId, isAdmin));
     }
 
-    @Operation(summary = "주문 목록 조회 (필터 + 페이징)",
+    @Operation(summary = "주문 목록 조회 (필터 + 커서 페이징)",
                description = "status / startDate / endDate 필터 지원. ADMIN은 userId 파라미터로 특정 사용자 주문 조회 가능. USER는 본인 주문만 조회된다.")
     @GetMapping
-    public ApiResponse<Page<OrderResponse>> getList(
+    public ApiResponse<CursorPage<OrderResponse>> getList(
             @CurrentUserId(required = false) Long userId,
             Authentication authentication,
             @ModelAttribute OrderSearchRequest request,
-            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
-            Pageable pageable) {
+            @RequestParam(required = false) Long lastId,
+            @Min(1) @Max(100) @RequestParam(defaultValue = "20") int size) {
         boolean isAdmin = SecurityUtils.isAdmin(authentication);
         Long effectiveUserId = isAdmin ? null : userId;
-        return ApiResponse.ok(orderQueryService.getList(effectiveUserId, isAdmin, request, pageable));
+        return ApiResponse.ok(orderQueryService.getList(effectiveUserId, isAdmin, request, lastId, size));
     }
 
     @Operation(summary = "주문 취소", description = "PENDING 상태만 취소 가능. 재고 예약 해제(reserved--). ADMIN은 모든 주문 취소 가능.")

--- a/src/main/java/com/stockmanagement/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/stockmanagement/domain/order/repository/OrderRepository.java
@@ -54,6 +54,12 @@ public interface OrderRepository extends JpaRepository<Order, Long>, JpaSpecific
      */
     Page<Order> findByUserId(Long userId, Pageable pageable);
 
+    /** 커서 기반 조회 — 첫 페이지. */
+    List<Order> findByUserIdOrderByIdDesc(Long userId, Pageable pageable);
+
+    /** 커서 기반 조회 — 다음 페이지 (id < lastId). */
+    List<Order> findByUserIdAndIdLessThanOrderByIdDesc(Long userId, Long lastId, Pageable pageable);
+
     /** 여러 주문을 항목+상품 포함하여 한 번에 조회한다 (결제 목록 주문 요약용). */
     @Query("SELECT DISTINCT o FROM Order o LEFT JOIN FETCH o.items i LEFT JOIN FETCH i.product WHERE o.id IN :ids")
     List<Order> findByIdsWithItems(@Param("ids") List<Long> ids);

--- a/src/main/java/com/stockmanagement/domain/order/repository/OrderSpecification.java
+++ b/src/main/java/com/stockmanagement/domain/order/repository/OrderSpecification.java
@@ -35,8 +35,22 @@ public class OrderSpecification {
      * @param forceUserId null이면 request.userId 사용, non-null이면 강제 덮어쓰기
      */
     public static Specification<Order> of(OrderSearchRequest request, Long forceUserId) {
+        return of(request, forceUserId, null);
+    }
+
+    /**
+     * 검색 요청 + 강제 userId + 커서 기반 페이지네이션 Specification을 생성한다.
+     *
+     * @param lastId 커서 — null이면 첫 페이지, non-null이면 id < lastId 조건 추가
+     */
+    public static Specification<Order> of(OrderSearchRequest request, Long forceUserId, Long lastId) {
         return (root, query, cb) -> {
             List<Predicate> predicates = new ArrayList<>();
+
+            // 커서 조건 (id < lastId)
+            if (lastId != null) {
+                predicates.add(cb.lessThan(root.get("id"), lastId));
+            }
 
             // 주문 상태 필터
             if (request.getStatus() != null) {

--- a/src/main/java/com/stockmanagement/domain/order/service/OrderQueryService.java
+++ b/src/main/java/com/stockmanagement/domain/order/service/OrderQueryService.java
@@ -1,5 +1,6 @@
 package com.stockmanagement.domain.order.service;
 
+import com.stockmanagement.common.dto.CursorPage;
 import com.stockmanagement.common.exception.BusinessException;
 import com.stockmanagement.common.exception.ErrorCode;
 import com.stockmanagement.domain.coupon.dto.CouponValidateRequest;
@@ -26,7 +27,9 @@ import com.stockmanagement.domain.shipment.repository.ShipmentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -98,18 +101,23 @@ public class OrderQueryService {
      *   <li>USER: userId를 강제 적용 (request.userId 무시)
      * </ul>
      */
-    public Page<OrderResponse> getList(Long userId, boolean isAdmin,
-                                       OrderSearchRequest request, Pageable pageable) {
+    public CursorPage<OrderResponse> getList(Long userId, boolean isAdmin,
+                                              OrderSearchRequest request, Long lastId, int size) {
         Long forceUserId = isAdmin ? null : userId;
-        Page<Order> page = orderRepository.findAll(OrderSpecification.of(request, forceUserId), pageable);
+        PageRequest limit = PageRequest.of(0, size + 1, Sort.by(Sort.Direction.DESC, "id"));
+        List<Order> items = orderRepository.findAll(
+                OrderSpecification.of(request, forceUserId, lastId), limit).getContent();
 
         // 배송 상태 + 배송지 스냅샷 배치 조회 (N+1 방지)
-        List<Long> orderIds = page.map(Order::getId).toList();
+        List<Long> orderIds = items.stream().map(Order::getId).toList();
         Map<Long, ShipmentStatus> statusMap = shipmentRepository.findStatusMapByOrderIds(orderIds);
         Map<Long, OrderDeliverySnapshot> snapshotMap = deliverySnapshotRepository.findByOrderIdIn(orderIds)
                 .stream().collect(Collectors.toMap(OrderDeliverySnapshot::getOrderId, s -> s));
 
-        return page.map(o -> OrderResponse.from(o, null, statusMap.get(o.getId()), snapshotMap.get(o.getId())));
+        List<OrderResponse> responses = items.stream()
+                .map(o -> OrderResponse.from(o, null, statusMap.get(o.getId()), snapshotMap.get(o.getId())))
+                .toList();
+        return CursorPage.of(responses, size, OrderResponse::getId);
     }
 
     /**

--- a/src/main/java/com/stockmanagement/domain/point/controller/PointController.java
+++ b/src/main/java/com/stockmanagement/domain/point/controller/PointController.java
@@ -1,22 +1,27 @@
 package com.stockmanagement.domain.point.controller;
 
 import com.stockmanagement.common.dto.ApiResponse;
+import com.stockmanagement.common.dto.CursorPage;
 import com.stockmanagement.domain.point.dto.PointBalanceResponse;
 import com.stockmanagement.domain.point.dto.PointTransactionResponse;
 import com.stockmanagement.domain.point.service.PointService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Point", description = "포인트/적립금 API")
+@Validated
 @RestController
 @RequestMapping("/api/v1/points")
 @RequiredArgsConstructor
@@ -31,20 +36,22 @@ public class PointController {
         return ApiResponse.ok(pointService.getBalance(username));
     }
 
-    @Operation(summary = "포인트 변동 이력 조회 (최신순)")
+    @Operation(summary = "포인트 변동 이력 조회 (커서 기반, 최신순)")
     @GetMapping("/history")
-    public ApiResponse<Page<PointTransactionResponse>> getHistory(
+    public ApiResponse<CursorPage<PointTransactionResponse>> getHistory(
             @AuthenticationPrincipal String username,
-            @PageableDefault(size = 20) Pageable pageable) {
-        return ApiResponse.ok(pointService.getHistory(username, pageable));
+            @RequestParam(required = false) Long lastId,
+            @Min(1) @Max(100) @RequestParam(defaultValue = "20") int size) {
+        return ApiResponse.ok(pointService.getHistory(username, lastId, size));
     }
 
-    @Operation(summary = "적립 예정 포인트 조회 (배송 완료 전)")
+    @Operation(summary = "적립 예정 포인트 조회 (커서 기반, 배송 완료 전)")
     @GetMapping("/pending")
-    public ApiResponse<Page<PointTransactionResponse>> getPending(
+    public ApiResponse<CursorPage<PointTransactionResponse>> getPending(
             @AuthenticationPrincipal String username,
-            @PageableDefault(size = 20) Pageable pageable) {
-        return ApiResponse.ok(pointService.getPendingHistory(username, pageable));
+            @RequestParam(required = false) Long lastId,
+            @Min(1) @Max(100) @RequestParam(defaultValue = "20") int size) {
+        return ApiResponse.ok(pointService.getPendingHistory(username, lastId, size));
     }
 
     @Operation(summary = "만료 예정 포인트 조회")

--- a/src/main/java/com/stockmanagement/domain/point/repository/PointTransactionRepository.java
+++ b/src/main/java/com/stockmanagement/domain/point/repository/PointTransactionRepository.java
@@ -35,4 +35,12 @@ public interface PointTransactionRepository extends JpaRepository<PointTransacti
     /** 사용자의 만료 예정 CONFIRMED 포인트 조회 (만료일 가까운 순) */
     Page<PointTransaction> findByUserIdAndStatusAndExpiresAtBeforeOrderByExpiresAtAsc(
             Long userId, PointTransactionStatus status, LocalDateTime deadline, Pageable pageable);
+
+    // 커서 기반 — 전체 이력
+    List<PointTransaction> findByUserIdOrderByIdDesc(Long userId, Pageable pageable);
+    List<PointTransaction> findByUserIdAndIdLessThanOrderByIdDesc(Long userId, Long lastId, Pageable pageable);
+
+    // 커서 기반 — 상태 필터
+    List<PointTransaction> findByUserIdAndStatusOrderByIdDesc(Long userId, PointTransactionStatus status, Pageable pageable);
+    List<PointTransaction> findByUserIdAndStatusAndIdLessThanOrderByIdDesc(Long userId, PointTransactionStatus status, Long lastId, Pageable pageable);
 }

--- a/src/main/java/com/stockmanagement/domain/point/service/PointService.java
+++ b/src/main/java/com/stockmanagement/domain/point/service/PointService.java
@@ -18,8 +18,10 @@ import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import com.stockmanagement.common.dto.CursorPage;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -85,19 +87,30 @@ public class PointService {
         return PointBalanceResponse.of(user.getId(), balance);
     }
 
-    /** 포인트 변동 이력을 최신순 페이징 조회한다. */
-    public Page<PointTransactionResponse> getHistory(String username, Pageable pageable) {
+    /** 포인트 변동 이력을 커서 기반으로 조회한다. */
+    public CursorPage<PointTransactionResponse> getHistory(String username, Long lastId, int size) {
         User user = findUser(username);
-        return pointTransactionRepository.findByUserIdOrderByCreatedAtDesc(user.getId(), pageable)
-                .map(PointTransactionResponse::from);
+        PageRequest limit = PageRequest.of(0, size + 1);
+        var items = lastId == null
+                ? pointTransactionRepository.findByUserIdOrderByIdDesc(user.getId(), limit)
+                : pointTransactionRepository.findByUserIdAndIdLessThanOrderByIdDesc(user.getId(), lastId, limit);
+        return CursorPage.of(
+                items.stream().map(PointTransactionResponse::from).toList(),
+                size,
+                PointTransactionResponse::getId);
     }
 
-    /** 적립 예정 (PENDING) 포인트 이력을 최신순 페이징 조회한다. */
-    public Page<PointTransactionResponse> getPendingHistory(String username, Pageable pageable) {
+    /** 적립 예정 (PENDING) 포인트 이력을 커서 기반으로 조회한다. */
+    public CursorPage<PointTransactionResponse> getPendingHistory(String username, Long lastId, int size) {
         User user = findUser(username);
-        return pointTransactionRepository.findByUserIdAndStatusOrderByCreatedAtDesc(
-                        user.getId(), PointTransactionStatus.PENDING, pageable)
-                .map(PointTransactionResponse::from);
+        PageRequest limit = PageRequest.of(0, size + 1);
+        var items = lastId == null
+                ? pointTransactionRepository.findByUserIdAndStatusOrderByIdDesc(user.getId(), PointTransactionStatus.PENDING, limit)
+                : pointTransactionRepository.findByUserIdAndStatusAndIdLessThanOrderByIdDesc(user.getId(), PointTransactionStatus.PENDING, lastId, limit);
+        return CursorPage.of(
+                items.stream().map(PointTransactionResponse::from).toList(),
+                size,
+                PointTransactionResponse::getId);
     }
 
     /** 만료 예정 CONFIRMED 포인트를 만료일 가까운 순으로 페이징 조회한다. */

--- a/src/main/java/com/stockmanagement/domain/product/qna/controller/ProductQnaController.java
+++ b/src/main/java/com/stockmanagement/domain/product/qna/controller/ProductQnaController.java
@@ -1,6 +1,7 @@
 package com.stockmanagement.domain.product.qna.controller;
 
 import com.stockmanagement.common.dto.ApiResponse;
+import com.stockmanagement.common.dto.CursorPage;
 import com.stockmanagement.common.security.CurrentUserId;
 import com.stockmanagement.common.security.SecurityUtils;
 import com.stockmanagement.domain.product.qna.dto.QnaAnswerRequest;
@@ -10,13 +11,12 @@ import com.stockmanagement.domain.product.qna.service.ProductQnaService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 /**
@@ -30,6 +30,7 @@ import org.springframework.web.bind.annotation.*;
  * </pre>
  */
 @Tag(name = "상품 Q&A", description = "상품 질문·답변 관리")
+@Validated
 @RestController
 @RequestMapping("/api/v1/products/{productId}/qna")
 @RequiredArgsConstructor
@@ -39,13 +40,14 @@ public class ProductQnaController {
 
     @Operation(summary = "Q&A 목록 조회", description = "비밀글은 작성자 본인과 ADMIN에게만 원문 노출.")
     @GetMapping
-    public ApiResponse<Page<QnaResponse>> getList(
+    public ApiResponse<CursorPage<QnaResponse>> getList(
             @PathVariable Long productId,
-            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+            @RequestParam(required = false) Long lastId,
+            @Min(1) @Max(100) @RequestParam(defaultValue = "20") int size,
             @CurrentUserId(required = false) Long userId,
             Authentication authentication) {
         boolean isAdmin = SecurityUtils.isAdmin(authentication);
-        return ApiResponse.ok(qnaService.getList(productId, pageable, userId, isAdmin));
+        return ApiResponse.ok(qnaService.getList(productId, lastId, size, userId, isAdmin));
     }
 
     @Operation(summary = "질문 작성", description = "구매 여부 무관, 인증된 사용자만 작성 가능.")

--- a/src/main/java/com/stockmanagement/domain/product/qna/repository/ProductQnaRepository.java
+++ b/src/main/java/com/stockmanagement/domain/product/qna/repository/ProductQnaRepository.java
@@ -5,7 +5,15 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ProductQnaRepository extends JpaRepository<ProductQna, Long> {
 
     Page<ProductQna> findByProductId(Long productId, Pageable pageable);
+
+    /** 커서 기반 조회 — 첫 페이지. */
+    List<ProductQna> findByProductIdOrderByIdDesc(Long productId, Pageable pageable);
+
+    /** 커서 기반 조회 — 다음 페이지 (id < lastId). */
+    List<ProductQna> findByProductIdAndIdLessThanOrderByIdDesc(Long productId, Long lastId, Pageable pageable);
 }

--- a/src/main/java/com/stockmanagement/domain/product/qna/service/ProductQnaService.java
+++ b/src/main/java/com/stockmanagement/domain/product/qna/service/ProductQnaService.java
@@ -1,5 +1,6 @@
 package com.stockmanagement.domain.product.qna.service;
 
+import com.stockmanagement.common.dto.CursorPage;
 import com.stockmanagement.common.exception.BusinessException;
 import com.stockmanagement.common.exception.ErrorCode;
 import com.stockmanagement.domain.product.qna.dto.QnaAnswerRequest;
@@ -11,8 +12,7 @@ import com.stockmanagement.domain.product.repository.ProductRepository;
 import com.stockmanagement.domain.user.entity.User;
 import com.stockmanagement.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,22 +30,24 @@ public class ProductQnaService {
     private final ProductRepository productRepository;
     private final UserRepository userRepository;
 
-    /** Q&A 목록 조회 (비밀글 마스킹 포함) */
-    public Page<QnaResponse> getList(Long productId, Pageable pageable, Long currentUserId, boolean isAdmin) {
+    /** Q&A 목록 조회 (비밀글 마스킹 포함, 커서 기반) */
+    public CursorPage<QnaResponse> getList(Long productId, Long lastId, int size, Long currentUserId, boolean isAdmin) {
         validateProductExists(productId);
-        Page<ProductQna> qnas = qnaRepository.findByProductId(productId, pageable);
+        PageRequest limit = PageRequest.of(0, size + 1);
+        List<ProductQna> items = lastId == null
+                ? qnaRepository.findByProductIdOrderByIdDesc(productId, limit)
+                : qnaRepository.findByProductIdAndIdLessThanOrderByIdDesc(productId, lastId, limit);
 
-        List<Long> userIds = qnas.getContent().stream()
+        List<Long> userIds = items.stream()
                 .map(ProductQna::getUserId)
                 .distinct()
                 .toList();
         Map<Long, String> usernameMap = buildUsernameMap(userIds);
 
-        return qnas.map(q -> QnaResponse.from(
-                q,
-                usernameMap.get(q.getUserId()),
-                currentUserId,
-                isAdmin));
+        List<QnaResponse> responses = items.stream()
+                .map(q -> QnaResponse.from(q, usernameMap.get(q.getUserId()), currentUserId, isAdmin))
+                .toList();
+        return CursorPage.of(responses, size, QnaResponse::getId);
     }
 
     /** 질문 작성 */

--- a/src/main/java/com/stockmanagement/domain/product/review/controller/ReviewController.java
+++ b/src/main/java/com/stockmanagement/domain/product/review/controller/ReviewController.java
@@ -1,6 +1,7 @@
 package com.stockmanagement.domain.product.review.controller;
 
 import com.stockmanagement.common.dto.ApiResponse;
+import com.stockmanagement.common.dto.CursorPage;
 import com.stockmanagement.common.security.CurrentUserId;
 import com.stockmanagement.domain.product.review.dto.RatingStatsResponse;
 import com.stockmanagement.domain.product.review.dto.ReviewCreateRequest;
@@ -10,15 +11,15 @@ import com.stockmanagement.domain.product.review.service.ReviewService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Review", description = "상품 리뷰 API")
+@Validated
 @RestController
 @RequestMapping("/api/v1/products/{productId}/reviews")
 @RequiredArgsConstructor
@@ -36,15 +37,15 @@ public class ReviewController {
         return ApiResponse.ok(reviewService.create(productId, userId, request));
     }
 
-    @Operation(summary = "상품 리뷰 목록 조회",
-               description = "sort: createdAt,desc(기본) | rating,desc | rating,asc\n\n" +
-                       "rating: 1~5 별점 필터 (null이면 전체)")
+    @Operation(summary = "상품 리뷰 목록 조회 (커서 기반)",
+               description = "rating: 1~5 별점 필터 (null이면 전체)")
     @GetMapping
-    public ApiResponse<Page<ReviewResponse>> getList(
+    public ApiResponse<CursorPage<ReviewResponse>> getList(
             @PathVariable Long productId,
             @RequestParam(required = false) Integer rating,
-            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        return ApiResponse.ok(reviewService.getList(productId, pageable, rating));
+            @RequestParam(required = false) Long lastId,
+            @Min(1) @Max(100) @RequestParam(defaultValue = "20") int size) {
+        return ApiResponse.ok(reviewService.getList(productId, lastId, size, rating));
     }
 
     @Operation(summary = "리뷰 별점 분포 통계",

--- a/src/main/java/com/stockmanagement/domain/product/review/repository/ReviewRepository.java
+++ b/src/main/java/com/stockmanagement/domain/product/review/repository/ReviewRepository.java
@@ -65,4 +65,16 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     /** 상품의 별점별 리뷰 수 분포를 조회한다. Object[0]=rating(Integer), Object[1]=count(Long). */
     @Query("SELECT r.rating, COUNT(r) FROM Review r WHERE r.productId = :productId GROUP BY r.rating")
     List<Object[]> findRatingDistributionByProductId(@Param("productId") Long productId);
+
+    // 커서 기반 — 상품 리뷰
+    List<Review> findByProductIdOrderByIdDesc(Long productId, Pageable pageable);
+    List<Review> findByProductIdAndIdLessThanOrderByIdDesc(Long productId, Long lastId, Pageable pageable);
+    List<Review> findByProductIdAndRatingOrderByIdDesc(Long productId, int rating, Pageable pageable);
+    List<Review> findByProductIdAndRatingAndIdLessThanOrderByIdDesc(Long productId, int rating, Long lastId, Pageable pageable);
+
+    // 커서 기반 — 사용자 리뷰
+    List<Review> findByUserIdOrderByIdDesc(Long userId, Pageable pageable);
+    List<Review> findByUserIdAndIdLessThanOrderByIdDesc(Long userId, Long lastId, Pageable pageable);
+    List<Review> findByUserIdAndRatingOrderByIdDesc(Long userId, int rating, Pageable pageable);
+    List<Review> findByUserIdAndRatingAndIdLessThanOrderByIdDesc(Long userId, int rating, Long lastId, Pageable pageable);
 }

--- a/src/main/java/com/stockmanagement/domain/product/review/service/ReviewService.java
+++ b/src/main/java/com/stockmanagement/domain/product/review/service/ReviewService.java
@@ -12,9 +12,11 @@ import com.stockmanagement.domain.product.review.entity.Review;
 import com.stockmanagement.domain.product.review.repository.ReviewRepository;
 import com.stockmanagement.domain.user.entity.User;
 import com.stockmanagement.domain.user.repository.UserRepository;
+import com.stockmanagement.common.dto.CursorPage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -72,23 +74,45 @@ public class ReviewService {
      * Pageable의 sort로 정렬을 지원한다 (기본: createdAt desc).
      * 작성자 username을 마스킹하여 포함한다.
      */
-    public Page<ReviewResponse> getList(Long productId, Pageable pageable, Integer rating) {
+    public CursorPage<ReviewResponse> getList(Long productId, Long lastId, int size, Integer rating) {
         if (!productRepository.existsById(productId)) {
             throw new BusinessException(ErrorCode.PRODUCT_NOT_FOUND);
         }
-        Page<Review> reviews = (rating != null)
-                ? reviewRepository.findByProductIdAndRating(productId, rating, pageable)
-                : reviewRepository.findByProductId(productId, pageable);
-        Map<Long, String> usernameMap = buildUsernameMap(reviews.map(Review::getUserId).toList());
-        return reviews.map(r -> ReviewResponse.from(r, usernameMap.getOrDefault(r.getUserId(), "[탈퇴사용자]")));
+        PageRequest limit = PageRequest.of(0, size + 1);
+        List<Review> reviews;
+        if (rating != null) {
+            reviews = lastId == null
+                    ? reviewRepository.findByProductIdAndRatingOrderByIdDesc(productId, rating, limit)
+                    : reviewRepository.findByProductIdAndRatingAndIdLessThanOrderByIdDesc(productId, rating, lastId, limit);
+        } else {
+            reviews = lastId == null
+                    ? reviewRepository.findByProductIdOrderByIdDesc(productId, limit)
+                    : reviewRepository.findByProductIdAndIdLessThanOrderByIdDesc(productId, lastId, limit);
+        }
+        Map<Long, String> usernameMap = buildUsernameMap(reviews.stream().map(Review::getUserId).toList());
+        List<ReviewResponse> responses = reviews.stream()
+                .map(r -> ReviewResponse.from(r, usernameMap.getOrDefault(r.getUserId(), "[탈퇴사용자]")))
+                .toList();
+        return CursorPage.of(responses, size, ReviewResponse::getId);
     }
 
-    /** 특정 사용자의 리뷰 목록을 페이징 조회한다. 별점 필터 지원. */
-    public Page<ReviewResponse> getMyReviews(Long userId, Pageable pageable, Integer rating) {
-        Page<Review> reviews = (rating != null)
-                ? reviewRepository.findByUserIdAndRating(userId, rating, pageable)
-                : reviewRepository.findByUserId(userId, pageable);
-        return reviews.map(ReviewResponse::from);
+    /** 특정 사용자의 리뷰 목록을 커서 기반으로 조회한다. 별점 필터 지원. */
+    public CursorPage<ReviewResponse> getMyReviews(Long userId, Long lastId, int size, Integer rating) {
+        PageRequest limit = PageRequest.of(0, size + 1);
+        List<Review> reviews;
+        if (rating != null) {
+            reviews = lastId == null
+                    ? reviewRepository.findByUserIdAndRatingOrderByIdDesc(userId, rating, limit)
+                    : reviewRepository.findByUserIdAndRatingAndIdLessThanOrderByIdDesc(userId, rating, lastId, limit);
+        } else {
+            reviews = lastId == null
+                    ? reviewRepository.findByUserIdOrderByIdDesc(userId, limit)
+                    : reviewRepository.findByUserIdAndIdLessThanOrderByIdDesc(userId, lastId, limit);
+        }
+        return CursorPage.of(
+                reviews.stream().map(ReviewResponse::from).toList(),
+                size,
+                ReviewResponse::getId);
     }
 
     /**

--- a/src/main/java/com/stockmanagement/domain/product/wishlist/controller/WishlistController.java
+++ b/src/main/java/com/stockmanagement/domain/product/wishlist/controller/WishlistController.java
@@ -1,20 +1,21 @@
 package com.stockmanagement.domain.product.wishlist.controller;
 
 import com.stockmanagement.common.dto.ApiResponse;
+import com.stockmanagement.common.dto.CursorPage;
 import com.stockmanagement.common.security.CurrentUserId;
 import com.stockmanagement.domain.product.wishlist.dto.WishlistResponse;
 import com.stockmanagement.domain.product.wishlist.service.WishlistService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Wishlist", description = "위시리스트 API")
+@Validated
 @RestController
 @RequestMapping("/api/v1/wishlist")
 @RequiredArgsConstructor
@@ -46,11 +47,12 @@ public class WishlistController {
         return ApiResponse.ok(java.util.Map.of("wishlisted", wishlisted));
     }
 
-    @Operation(summary = "내 위시리스트 목록 조회 (페이지네이션)")
+    @Operation(summary = "내 위시리스트 목록 조회 (커서 기반)")
     @GetMapping
-    public ApiResponse<Page<WishlistResponse>> getList(
+    public ApiResponse<CursorPage<WishlistResponse>> getList(
             @CurrentUserId Long userId,
-            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        return ApiResponse.ok(wishlistService.getList(userId, pageable));
+            @RequestParam(required = false) Long lastId,
+            @Min(1) @Max(100) @RequestParam(defaultValue = "20") int size) {
+        return ApiResponse.ok(wishlistService.getList(userId, lastId, size));
     }
 }

--- a/src/main/java/com/stockmanagement/domain/product/wishlist/repository/WishlistRepository.java
+++ b/src/main/java/com/stockmanagement/domain/product/wishlist/repository/WishlistRepository.java
@@ -40,6 +40,17 @@ public interface WishlistRepository extends JpaRepository<WishlistItem, Long> {
                     "(SELECT 1 FROM Product p WHERE p.id = w.productId)")
     Page<WishlistItem> findByUserIdWithExistingProduct(@Param("userId") Long userId, Pageable pageable);
 
+    /** 커서 기반 조회 — 첫 페이지. 존재하는 상품만 반환한다. */
+    @Query("SELECT w FROM WishlistItem w WHERE w.userId = :userId AND EXISTS " +
+            "(SELECT 1 FROM Product p WHERE p.id = w.productId) ORDER BY w.id DESC")
+    List<WishlistItem> findByUserIdWithExistingProductCursor(@Param("userId") Long userId, Pageable pageable);
+
+    /** 커서 기반 조회 — 다음 페이지 (id < lastId). 존재하는 상품만 반환한다. */
+    @Query("SELECT w FROM WishlistItem w WHERE w.userId = :userId AND w.id < :lastId AND EXISTS " +
+            "(SELECT 1 FROM Product p WHERE p.id = w.productId) ORDER BY w.id DESC")
+    List<WishlistItem> findByUserIdWithExistingProductCursorAfter(@Param("userId") Long userId,
+                                                                  @Param("lastId") Long lastId, Pageable pageable);
+
     /** 회원 탈퇴 시 사용자의 위시리스트 전체를 일괄 삭제한다. */
     @Modifying
     @Query("DELETE FROM WishlistItem w WHERE w.userId = :userId")

--- a/src/main/java/com/stockmanagement/domain/product/wishlist/service/WishlistService.java
+++ b/src/main/java/com/stockmanagement/domain/product/wishlist/service/WishlistService.java
@@ -11,9 +11,9 @@ import com.stockmanagement.domain.product.repository.ProductRepository;
 import com.stockmanagement.domain.product.wishlist.dto.WishlistResponse;
 import com.stockmanagement.domain.product.wishlist.entity.WishlistItem;
 import com.stockmanagement.domain.product.wishlist.repository.WishlistRepository;
+import com.stockmanagement.common.dto.CursorPage;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -79,19 +79,22 @@ public class WishlistService {
     }
 
     /**
-     * 사용자의 위시리스트 목록을 페이징 조회한다.
+     * 사용자의 위시리스트 목록을 커서 기반으로 조회한다.
      *
      * <p>userId는 JWT claim에서 추출한 값을 컨트롤러에서 전달받아 DB users 조회를 생략한다.
      */
-    public Page<WishlistResponse> getList(Long userId, Pageable pageable) {
-        // DB 레벨에서 존재하는 상품만 조회 — totalElements 정확도 보장
-        Page<WishlistItem> page = wishlistRepository.findByUserIdWithExistingProduct(userId, pageable);
-        if (page.isEmpty()) {
-            return page.map(item -> null); // 빈 페이지 반환
+    public CursorPage<WishlistResponse> getList(Long userId, Long lastId, int size) {
+        PageRequest limit = PageRequest.of(0, size + 1);
+        var items = lastId == null
+                ? wishlistRepository.findByUserIdWithExistingProductCursor(userId, limit)
+                : wishlistRepository.findByUserIdWithExistingProductCursorAfter(userId, lastId, limit);
+
+        if (items.isEmpty()) {
+            return CursorPage.of(List.of(), size, WishlistResponse::getId);
         }
 
         // N+1 방지: 상품 + 재고를 한 번에 배치 조회
-        List<Long> productIds = page.map(WishlistItem::getProductId).toList();
+        List<Long> productIds = items.stream().map(WishlistItem::getProductId).toList();
         int threshold = systemSettingService.getLowStockThreshold();
         Map<Long, Product> productMap = productRepository.findAllById(productIds).stream()
                 .collect(Collectors.toMap(Product::getId, Function.identity()));
@@ -100,12 +103,14 @@ public class WishlistService {
                         i -> i.getVariant().getProduct().getId(),
                         Collectors.summingInt(Inventory::getAvailable)));
 
-        return page.map(item -> {
+        List<WishlistResponse> responses = items.stream().map(item -> {
             int avail = availableMap.getOrDefault(item.getProductId(), 0);
             return WishlistResponse.of(
                     item,
                     productMap.get(item.getProductId()),
                     StockStatus.of(avail, threshold));
-        });
+        }).toList();
+
+        return CursorPage.of(responses, size, WishlistResponse::getId);
     }
 }

--- a/src/main/java/com/stockmanagement/domain/refund/controller/RefundController.java
+++ b/src/main/java/com/stockmanagement/domain/refund/controller/RefundController.java
@@ -1,6 +1,7 @@
 package com.stockmanagement.domain.refund.controller;
 
 import com.stockmanagement.common.dto.ApiResponse;
+import com.stockmanagement.common.dto.CursorPage;
 import com.stockmanagement.common.security.CurrentUserId;
 import com.stockmanagement.common.security.SecurityUtils;
 import com.stockmanagement.domain.refund.dto.RefundRequest;
@@ -9,18 +10,18 @@ import com.stockmanagement.domain.refund.service.RefundService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @Tag(name = "Refund", description = "환불 API")
+@Validated
 @RestController
 @RequestMapping("/api/v1/refunds")
 @RequiredArgsConstructor
@@ -37,12 +38,13 @@ public class RefundController {
         return ApiResponse.ok(refundService.requestRefund(request, userId));
     }
 
-    @Operation(summary = "내 환불 목록", description = "현재 로그인 사용자의 환불 내역을 최신순으로 페이징 조회한다.")
+    @Operation(summary = "내 환불 목록", description = "현재 로그인 사용자의 환불 내역을 최신순으로 커서 기반 조회한다.")
     @GetMapping("/my")
-    public ApiResponse<Page<RefundResponse>> getMyRefunds(
+    public ApiResponse<CursorPage<RefundResponse>> getMyRefunds(
             @CurrentUserId Long userId,
-            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        return ApiResponse.ok(refundService.getMyRefunds(userId, pageable));
+            @RequestParam(required = false) Long lastId,
+            @Min(1) @Max(100) @RequestParam(defaultValue = "20") int size) {
+        return ApiResponse.ok(refundService.getMyRefunds(userId, lastId, size));
     }
 
     @Operation(summary = "환불 단건 조회", description = "ADMIN은 모든 환불 조회 가능. USER는 본인 주문의 환불만 가능.")

--- a/src/main/java/com/stockmanagement/domain/refund/repository/RefundRepository.java
+++ b/src/main/java/com/stockmanagement/domain/refund/repository/RefundRepository.java
@@ -21,4 +21,10 @@ public interface RefundRepository extends JpaRepository<Refund, Long> {
 
     /** 특정 사용자의 환불 목록을 최신순으로 페이징 조회한다. */
     Page<Refund> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
+
+    /** 커서 기반 조회 — 첫 페이지. */
+    List<Refund> findByUserIdOrderByIdDesc(Long userId, Pageable pageable);
+
+    /** 커서 기반 조회 — 다음 페이지 (id < lastId). */
+    List<Refund> findByUserIdAndIdLessThanOrderByIdDesc(Long userId, Long lastId, Pageable pageable);
 }

--- a/src/main/java/com/stockmanagement/domain/refund/service/RefundService.java
+++ b/src/main/java/com/stockmanagement/domain/refund/service/RefundService.java
@@ -15,11 +15,11 @@ import com.stockmanagement.domain.refund.dto.RefundResponse;
 import com.stockmanagement.domain.refund.entity.Refund;
 import com.stockmanagement.domain.refund.entity.RefundStatus;
 import com.stockmanagement.domain.refund.repository.RefundRepository;
+import com.stockmanagement.common.dto.CursorPage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -131,10 +131,16 @@ public class RefundService {
         return RefundResponse.from(refund);
     }
 
-    /** 현재 인증 사용자의 환불 목록을 최신순으로 페이징 조회한다. */
-    public Page<RefundResponse> getMyRefunds(Long userId, Pageable pageable) {
-        return refundRepository.findByUserIdOrderByCreatedAtDesc(userId, pageable)
-                .map(RefundResponse::from);
+    /** 현재 인증 사용자의 환불 목록을 커서 기반으로 조회한다. */
+    public CursorPage<RefundResponse> getMyRefunds(Long userId, Long lastId, int size) {
+        PageRequest limit = PageRequest.of(0, size + 1);
+        var items = lastId == null
+                ? refundRepository.findByUserIdOrderByIdDesc(userId, limit)
+                : refundRepository.findByUserIdAndIdLessThanOrderByIdDesc(userId, lastId, limit);
+        return CursorPage.of(
+                items.stream().map(RefundResponse::from).toList(),
+                size,
+                RefundResponse::getId);
     }
 
     /** 결제 ID로 환불 목록을 조회한다. 부분 취소 시 다건 반환. 본인 또는 ADMIN만 가능. */

--- a/src/main/java/com/stockmanagement/domain/shipment/controller/ShipmentController.java
+++ b/src/main/java/com/stockmanagement/domain/shipment/controller/ShipmentController.java
@@ -1,6 +1,7 @@
 package com.stockmanagement.domain.shipment.controller;
 
 import com.stockmanagement.common.dto.ApiResponse;
+import com.stockmanagement.common.dto.CursorPage;
 import com.stockmanagement.common.security.CurrentUserId;
 import com.stockmanagement.common.security.SecurityUtils;
 import com.stockmanagement.domain.shipment.dto.ReturnRequestDto;
@@ -10,13 +11,12 @@ import com.stockmanagement.domain.shipment.service.ShipmentService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 /**
@@ -36,6 +36,7 @@ import org.springframework.web.bind.annotation.*;
  * 외부 API로 노출하지 않는다.
  */
 @Tag(name = "배송", description = "배송 조회 · 출고 · 완료 · 반품 (상태 전이)")
+@Validated
 @RestController
 @RequestMapping("/api/v1/shipments")
 @RequiredArgsConstructor
@@ -43,12 +44,13 @@ public class ShipmentController {
 
     private final ShipmentService shipmentService;
 
-    @Operation(summary = "내 배송 목록 조회", description = "로그인한 사용자의 배송 목록을 최신순으로 반환한다.")
+    @Operation(summary = "내 배송 목록 조회", description = "로그인한 사용자의 배송 목록을 커서 기반으로 반환한다.")
     @GetMapping("/my")
-    public ApiResponse<Page<ShipmentResponse>> getMyShipments(
+    public ApiResponse<CursorPage<ShipmentResponse>> getMyShipments(
             @CurrentUserId Long userId,
-            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        return ApiResponse.ok(shipmentService.getMyShipments(userId, pageable));
+            @RequestParam(required = false) Long lastId,
+            @Min(1) @Max(100) @RequestParam(defaultValue = "20") int size) {
+        return ApiResponse.ok(shipmentService.getMyShipments(userId, lastId, size));
     }
 
     @Operation(summary = "주문별 배송 조회", description = "본인 주문의 배송 정보만 조회 가능. ADMIN은 전체 조회 가능.")

--- a/src/main/java/com/stockmanagement/domain/shipment/repository/ShipmentRepository.java
+++ b/src/main/java/com/stockmanagement/domain/shipment/repository/ShipmentRepository.java
@@ -34,4 +34,12 @@ public interface ShipmentRepository extends JpaRepository<Shipment, Long> {
     /** 특정 사용자의 배송 목록을 최신순 페이징 조회한다. */
     @Query("SELECT s FROM Shipment s WHERE s.orderId IN (SELECT o.id FROM Order o WHERE o.userId = :userId) ORDER BY s.createdAt DESC")
     Page<Shipment> findByUserId(@Param("userId") Long userId, Pageable pageable);
+
+    /** 커서 기반 조회 — 첫 페이지. */
+    @Query("SELECT s FROM Shipment s WHERE s.orderId IN (SELECT o.id FROM Order o WHERE o.userId = :userId) ORDER BY s.id DESC")
+    List<Shipment> findByUserIdCursor(@Param("userId") Long userId, Pageable pageable);
+
+    /** 커서 기반 조회 — 다음 페이지 (id < lastId). */
+    @Query("SELECT s FROM Shipment s WHERE s.id < :lastId AND s.orderId IN (SELECT o.id FROM Order o WHERE o.userId = :userId) ORDER BY s.id DESC")
+    List<Shipment> findByUserIdCursorAfter(@Param("userId") Long userId, @Param("lastId") Long lastId, Pageable pageable);
 }

--- a/src/main/java/com/stockmanagement/domain/shipment/service/ShipmentService.java
+++ b/src/main/java/com/stockmanagement/domain/shipment/service/ShipmentService.java
@@ -14,9 +14,9 @@ import com.stockmanagement.domain.shipment.entity.Shipment;
 import com.stockmanagement.common.outbox.OutboxEventStore;
 import com.stockmanagement.domain.shipment.repository.ShipmentRepository;
 import com.stockmanagement.domain.user.repository.UserRepository;
+import com.stockmanagement.common.dto.CursorPage;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -96,14 +96,21 @@ public class ShipmentService {
     }
 
     /**
-     * 로그인한 사용자의 배송 목록을 최신순 페이징 조회한다.
+     * 로그인한 사용자의 배송 목록을 커서 기반으로 조회한다.
      *
-     * @param userId   요청자 ID (JWT claim 기반)
-     * @param pageable 페이지 요청
+     * @param userId 요청자 ID (JWT claim 기반)
+     * @param lastId 커서 (이전 페이지 마지막 ID), null이면 첫 페이지
+     * @param size   페이지 크기
      */
-    public Page<ShipmentResponse> getMyShipments(Long userId, Pageable pageable) {
-        return shipmentRepository.findByUserId(userId, pageable)
-                .map(ShipmentResponse::from);
+    public CursorPage<ShipmentResponse> getMyShipments(Long userId, Long lastId, int size) {
+        PageRequest limit = PageRequest.of(0, size + 1);
+        var items = lastId == null
+                ? shipmentRepository.findByUserIdCursor(userId, limit)
+                : shipmentRepository.findByUserIdCursorAfter(userId, lastId, limit);
+        return CursorPage.of(
+                items.stream().map(ShipmentResponse::from).toList(),
+                size,
+                ShipmentResponse::getId);
     }
 
     /**

--- a/src/main/java/com/stockmanagement/domain/user/controller/UserController.java
+++ b/src/main/java/com/stockmanagement/domain/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.stockmanagement.domain.user.controller;
 
 import com.stockmanagement.common.dto.ApiResponse;
+import com.stockmanagement.common.dto.CursorPage;
 import com.stockmanagement.common.security.CurrentUserId;
 import com.stockmanagement.domain.order.dto.OrderResponse;
 import com.stockmanagement.domain.product.dto.ProductResponse;
@@ -15,13 +16,12 @@ import com.stockmanagement.domain.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import java.util.List;
 import org.springframework.web.bind.annotation.*;
 
@@ -35,6 +35,7 @@ import org.springframework.web.bind.annotation.*;
  * </pre>
  */
 @Tag(name = "사용자", description = "내 정보 조회 · 내 주문·리뷰 목록 — JWT 인증 필요")
+@Validated
 @RestController
 @RequestMapping("/api/v1/users")
 @RequiredArgsConstructor
@@ -79,24 +80,24 @@ public class UserController {
         userService.changePassword(username, request, accessToken);
     }
 
-    @Operation(summary = "내 주문 목록 (페이징)", description = "기본: 최신순, 20건.")
+    @Operation(summary = "내 주문 목록 (커서 기반)", description = "기본: 최신순, 20건.")
     @GetMapping("/me/orders")
-    public ApiResponse<Page<OrderResponse>> getMyOrders(
+    public ApiResponse<CursorPage<OrderResponse>> getMyOrders(
             @AuthenticationPrincipal String username,
-            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
-            Pageable pageable) {
-        return ApiResponse.ok(userService.getMyOrders(username, pageable));
+            @RequestParam(required = false) Long lastId,
+            @Min(1) @Max(100) @RequestParam(defaultValue = "20") int size) {
+        return ApiResponse.ok(userService.getMyOrders(username, lastId, size));
     }
 
-    @Operation(summary = "내 리뷰 목록 (페이징)",
-               description = "별점 필터 지원 (?rating=1~5). sort 파라미터로 정렬 지정 (createdAt DESC 기본).")
+    @Operation(summary = "내 리뷰 목록 (커서 기반)",
+               description = "별점 필터 지원 (?rating=1~5).")
     @GetMapping("/me/reviews")
-    public ApiResponse<Page<ReviewResponse>> getMyReviews(
+    public ApiResponse<CursorPage<ReviewResponse>> getMyReviews(
             @CurrentUserId Long userId,
             @RequestParam(required = false) Integer rating,
-            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
-            Pageable pageable) {
-        return ApiResponse.ok(reviewService.getMyReviews(userId, pageable, rating));
+            @RequestParam(required = false) Long lastId,
+            @Min(1) @Max(100) @RequestParam(defaultValue = "20") int size) {
+        return ApiResponse.ok(reviewService.getMyReviews(userId, lastId, size, rating));
     }
 
     @Operation(summary = "최근 본 상품 기록", description = "상품 조회 시 자동 호출. Redis ZSet에 저장.")

--- a/src/main/java/com/stockmanagement/domain/user/service/UserService.java
+++ b/src/main/java/com/stockmanagement/domain/user/service/UserService.java
@@ -35,7 +35,9 @@ import com.stockmanagement.common.security.JwtTokenProvider;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.lang.Nullable;
+import com.stockmanagement.common.dto.CursorPage;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -270,23 +272,29 @@ public class UserService {
         jwtBlacklist.revoke(accessToken);
     }
 
-    /** 현재 인증된 사용자의 주문 목록 페이징 조회. hasReview + shipmentStatus 정보 포함. */
-    public Page<OrderResponse> getMyOrders(String username, Pageable pageable) {
+    /** 현재 인증된 사용자의 주문 목록 커서 기반 조회. hasReview + shipmentStatus 정보 포함. */
+    public CursorPage<OrderResponse> getMyOrders(String username, Long lastId, int size) {
         User user = userRepository.findByUsername(username)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
-        Page<Order> orders = orderRepository.findByUserId(user.getId(), pageable);
-        // 페이지 내 전체 상품 ID를 한 번에 조회 (N+1 방지)
-        List<Long> allProductIds = orders.getContent().stream()
+        PageRequest limit = PageRequest.of(0, size + 1);
+        List<Order> items = lastId == null
+                ? orderRepository.findByUserIdOrderByIdDesc(user.getId(), limit)
+                : orderRepository.findByUserIdAndIdLessThanOrderByIdDesc(user.getId(), lastId, limit);
+        // 목록 내 전체 상품 ID를 한 번에 조회 (N+1 방지)
+        List<Long> allProductIds = items.stream()
                 .flatMap(o -> o.getItems().stream().map(i -> i.getProduct().getId()))
                 .collect(Collectors.toList());
         Set<Long> reviewedIds = allProductIds.isEmpty()
                 ? Set.of()
                 : new HashSet<>(reviewRepository.findReviewedProductIdsByUserId(user.getId(), allProductIds));
         // 배송 상태 배치 조회 (N+1 방지)
-        List<Long> orderIds = orders.map(Order::getId).toList();
+        List<Long> orderIds = items.stream().map(Order::getId).toList();
         Map<Long, com.stockmanagement.domain.shipment.entity.ShipmentStatus> statusMap =
                 shipmentRepository.findStatusMapByOrderIds(orderIds);
-        return orders.map(o -> OrderResponse.from(o, reviewedIds, statusMap.get(o.getId())));
+        List<OrderResponse> responses = items.stream()
+                .map(o -> OrderResponse.from(o, reviewedIds, statusMap.get(o.getId())))
+                .toList();
+        return CursorPage.of(responses, size, OrderResponse::getId);
     }
 
     /**

--- a/src/test/java/com/stockmanagement/domain/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/notification/controller/NotificationControllerTest.java
@@ -1,6 +1,7 @@
 package com.stockmanagement.domain.notification.controller;
 
 import com.stockmanagement.common.config.SecurityConfig;
+import com.stockmanagement.common.dto.CursorPage;
 import com.stockmanagement.common.security.JwtBlacklist;
 import com.stockmanagement.common.security.JwtTokenProvider;
 import com.stockmanagement.domain.notification.dto.NotificationResponse;
@@ -14,16 +15,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -59,8 +57,8 @@ class NotificationControllerTest {
                     .read(false)
                     .createdAt(LocalDateTime.now())
                     .build();
-            given(notificationService.getNotifications(any(), any(), any(Pageable.class)))
-                    .willReturn(new PageImpl<>(List.of(response)));
+            given(notificationService.getNotifications(any(), any(), any(), anyInt()))
+                    .willReturn(CursorPage.of(List.of(response), 20, NotificationResponse::getId));
 
             mockMvc.perform(get("/api/v1/notifications"))
                     .andExpect(status().isOk())

--- a/src/test/java/com/stockmanagement/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/notification/service/NotificationServiceTest.java
@@ -1,5 +1,6 @@
 package com.stockmanagement.domain.notification.service;
 
+import com.stockmanagement.common.dto.CursorPage;
 import com.stockmanagement.common.exception.BusinessException;
 import com.stockmanagement.common.exception.ErrorCode;
 import com.stockmanagement.domain.notification.dto.NotificationResponse;
@@ -13,10 +14,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
@@ -55,27 +52,25 @@ class NotificationServiceTest {
         @Test
         @DisplayName("read=null — 전체 알림을 반환한다")
         void returnsAll() {
-            Pageable pageable = PageRequest.of(0, 20);
             Notification n = createNotification(1L, 1L);
-            given(notificationRepository.findByUserIdOrderByCreatedAtDesc(1L, pageable))
-                    .willReturn(new PageImpl<>(List.of(n)));
+            given(notificationRepository.findByUserIdOrderByIdDesc(any(), any()))
+                    .willReturn(List.of(n));
 
-            Page<NotificationResponse> result = notificationService.getNotifications(1L, null, pageable);
+            CursorPage<NotificationResponse> result = notificationService.getNotifications(1L, null, null, 20);
 
-            assertThat(result.getTotalElements()).isEqualTo(1);
+            assertThat(result.getContent()).hasSize(1);
             assertThat(result.getContent().get(0).getTitle()).isEqualTo("주문 접수");
         }
 
         @Test
         @DisplayName("read=false — 미읽음 알림만 반환한다")
         void returnsUnread() {
-            Pageable pageable = PageRequest.of(0, 20);
-            given(notificationRepository.findByUserIdAndReadAtIsNullOrderByCreatedAtDesc(1L, pageable))
-                    .willReturn(new PageImpl<>(List.of()));
+            given(notificationRepository.findByUserIdAndReadAtIsNullOrderByIdDesc(any(), any()))
+                    .willReturn(List.of());
 
-            Page<NotificationResponse> result = notificationService.getNotifications(1L, false, pageable);
+            CursorPage<NotificationResponse> result = notificationService.getNotifications(1L, false, null, 20);
 
-            assertThat(result.getTotalElements()).isEqualTo(0);
+            assertThat(result.getContent()).isEmpty();
         }
     }
 

--- a/src/test/java/com/stockmanagement/domain/order/controller/OrderControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/order/controller/OrderControllerTest.java
@@ -1,6 +1,7 @@
 package com.stockmanagement.domain.order.controller;
 
 import com.stockmanagement.common.config.SecurityConfig;
+import com.stockmanagement.common.dto.CursorPage;
 import com.stockmanagement.common.exception.BusinessException;
 import com.stockmanagement.common.exception.ErrorCode;
 import com.stockmanagement.domain.order.dto.OrderResponse;
@@ -19,8 +20,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
@@ -181,8 +180,8 @@ class OrderControllerTest {
         @WithMockUser
         @DisplayName("인증된 사용자 — 주문 목록 페이징 조회 → 200")
         void returnsList() throws Exception {
-            given(orderQueryService.getList(any(), anyBoolean(), any(), any(Pageable.class)))
-                    .willReturn(new PageImpl<>(List.of()));
+            given(orderQueryService.getList(any(), anyBoolean(), any(), any(), anyInt()))
+                    .willReturn(CursorPage.of(List.of(), 20, OrderResponse::getId));
 
             mockMvc.perform(get("/api/v1/orders"))
                     .andExpect(status().isOk())

--- a/src/test/java/com/stockmanagement/domain/order/service/OrderQueryServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/order/service/OrderQueryServiceTest.java
@@ -1,5 +1,6 @@
 package com.stockmanagement.domain.order.service;
 
+import com.stockmanagement.common.dto.CursorPage;
 import com.stockmanagement.common.exception.BusinessException;
 import com.stockmanagement.common.exception.ErrorCode;
 import com.stockmanagement.domain.admin.setting.service.SystemSettingService;
@@ -25,9 +26,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -148,26 +147,24 @@ class OrderQueryServiceTest {
         @Test
         @DisplayName("ADMIN — 필터 없이 전체 주문 반환")
         void admin_returnsAllOrders() {
-            Pageable pageable = PageRequest.of(0, 10);
             given(orderRepository.findAll(any(org.springframework.data.jpa.domain.Specification.class), any(Pageable.class)))
-                    .willReturn(new PageImpl<>(List.of(order), pageable, 1));
+                    .willReturn(new PageImpl<>(List.of(order)));
 
-            Page<OrderResponse> result = orderQueryService.getList(null, true, new OrderSearchRequest(), pageable);
+            CursorPage<OrderResponse> result = orderQueryService.getList(null, true, new OrderSearchRequest(), null, 10);
 
-            assertThat(result.getTotalElements()).isEqualTo(1);
+            assertThat(result.getContent()).hasSize(1);
             assertThat(result.getContent().get(0).getIdempotencyKey()).isEqualTo("idem-key-001");
         }
 
         @Test
         @DisplayName("USER — 컨트롤러에서 전달된 userId로 강제 필터링")
         void user_filtersOwnOrdersOnly() {
-            Pageable pageable = PageRequest.of(0, 10);
             given(orderRepository.findAll(any(org.springframework.data.jpa.domain.Specification.class), any(Pageable.class)))
-                    .willReturn(new PageImpl<>(List.of(order), pageable, 1));
+                    .willReturn(new PageImpl<>(List.of(order)));
 
-            Page<OrderResponse> result = orderQueryService.getList(1L, false, new OrderSearchRequest(), pageable);
+            CursorPage<OrderResponse> result = orderQueryService.getList(1L, false, new OrderSearchRequest(), null, 10);
 
-            assertThat(result.getTotalElements()).isEqualTo(1);
+            assertThat(result.getContent()).hasSize(1);
         }
     }
 }

--- a/src/test/java/com/stockmanagement/domain/point/controller/PointControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/point/controller/PointControllerTest.java
@@ -1,6 +1,7 @@
 package com.stockmanagement.domain.point.controller;
 
 import com.stockmanagement.common.config.SecurityConfig;
+import com.stockmanagement.common.dto.CursorPage;
 import com.stockmanagement.common.security.JwtBlacklist;
 import com.stockmanagement.domain.user.service.UserService;
 import com.stockmanagement.domain.point.dto.PointBalanceResponse;
@@ -14,16 +15,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
@@ -80,8 +78,8 @@ class PointControllerTest {
         @Test
         @DisplayName("인증된 사용자 — 이력 조회 → 200")
         void returnsHistory() throws Exception {
-            given(pointService.getHistory(anyString(), any(Pageable.class)))
-                    .willReturn(new PageImpl<>(List.of(mock(PointTransactionResponse.class))));
+            given(pointService.getHistory(anyString(), any(), anyInt()))
+                    .willReturn(CursorPage.of(List.of(mock(PointTransactionResponse.class)), 20, PointTransactionResponse::getId));
 
             mockMvc.perform(get("/api/v1/points/history").with(authentication(USER_AUTH)))
                     .andExpect(status().isOk())

--- a/src/test/java/com/stockmanagement/domain/product/qna/controller/ProductQnaControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/product/qna/controller/ProductQnaControllerTest.java
@@ -1,6 +1,7 @@
 package com.stockmanagement.domain.product.qna.controller;
 
 import com.stockmanagement.common.config.SecurityConfig;
+import com.stockmanagement.common.dto.CursorPage;
 import com.stockmanagement.common.security.EmailVerificationTokenStore;
 import com.stockmanagement.common.security.JwtBlacklist;
 import com.stockmanagement.common.security.JwtTokenProvider;
@@ -15,8 +16,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -79,8 +78,8 @@ class ProductQnaControllerTest {
         @Test
         @DisplayName("비로그인 조회 → 200")
         void getListWithoutAuth() throws Exception {
-            given(qnaService.getList(anyLong(), any(Pageable.class), isNull(), eq(false)))
-                    .willReturn(new PageImpl<>(List.of(sampleResponse())));
+            given(qnaService.getList(anyLong(), any(), anyInt(), isNull(), eq(false)))
+                    .willReturn(CursorPage.of(List.of(sampleResponse()), 20, QnaResponse::getId));
 
             mockMvc.perform(get("/api/v1/products/1/qna"))
                     .andExpect(status().isOk())

--- a/src/test/java/com/stockmanagement/domain/product/qna/service/ProductQnaServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/product/qna/service/ProductQnaServiceTest.java
@@ -1,5 +1,6 @@
 package com.stockmanagement.domain.product.qna.service;
 
+import com.stockmanagement.common.dto.CursorPage;
 import com.stockmanagement.common.exception.BusinessException;
 import com.stockmanagement.common.exception.ErrorCode;
 import com.stockmanagement.domain.product.qna.dto.QnaAnswerRequest;
@@ -18,10 +19,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
@@ -115,34 +112,32 @@ class ProductQnaServiceTest {
     class GetList {
 
         @Test
-        @DisplayName("정상 조회 — 페이지 반환")
+        @DisplayName("정상 조회 — 커서 페이지 반환")
         void returnsPaged() {
-            Pageable pageable = PageRequest.of(0, 20);
             ProductQna qna = createQna(1L, 1L, 10L, "문의합니다", false);
             given(productRepository.existsById(1L)).willReturn(true);
-            given(qnaRepository.findByProductId(1L, pageable))
-                    .willReturn(new PageImpl<>(List.of(qna), pageable, 1));
+            given(qnaRepository.findByProductIdOrderByIdDesc(any(), any()))
+                    .willReturn(List.of(qna));
             given(userRepository.findAllById(List.of(10L)))
                     .willReturn(List.of(createUser(10L, "buyer")));
 
-            Page<QnaResponse> result = qnaService.getList(1L, pageable, null, false);
+            CursorPage<QnaResponse> result = qnaService.getList(1L, null, 20, null, false);
 
-            assertThat(result.getTotalElements()).isEqualTo(1);
+            assertThat(result.getContent()).hasSize(1);
             assertThat(result.getContent().get(0).getContent()).isEqualTo("문의합니다");
         }
 
         @Test
         @DisplayName("비밀글 — 타인이면 마스킹 처리")
         void masksSecretForOthers() {
-            Pageable pageable = PageRequest.of(0, 20);
             ProductQna qna = createQna(1L, 1L, 10L, "비밀 내용", true);
             given(productRepository.existsById(1L)).willReturn(true);
-            given(qnaRepository.findByProductId(1L, pageable))
-                    .willReturn(new PageImpl<>(List.of(qna), pageable, 1));
+            given(qnaRepository.findByProductIdOrderByIdDesc(any(), any()))
+                    .willReturn(List.of(qna));
             given(userRepository.findAllById(List.of(10L)))
                     .willReturn(List.of(createUser(10L, "buyer")));
 
-            Page<QnaResponse> result = qnaService.getList(1L, pageable, 99L, false);
+            CursorPage<QnaResponse> result = qnaService.getList(1L, null, 20, 99L, false);
 
             assertThat(result.getContent().get(0).getContent()).isEqualTo("비밀글입니다");
         }
@@ -150,15 +145,14 @@ class ProductQnaServiceTest {
         @Test
         @DisplayName("비밀글 — 작성자 본인이면 원문 노출")
         void showsSecretToAuthor() {
-            Pageable pageable = PageRequest.of(0, 20);
             ProductQna qna = createQna(1L, 1L, 10L, "비밀 내용", true);
             given(productRepository.existsById(1L)).willReturn(true);
-            given(qnaRepository.findByProductId(1L, pageable))
-                    .willReturn(new PageImpl<>(List.of(qna), pageable, 1));
+            given(qnaRepository.findByProductIdOrderByIdDesc(any(), any()))
+                    .willReturn(List.of(qna));
             given(userRepository.findAllById(List.of(10L)))
                     .willReturn(List.of(createUser(10L, "buyer")));
 
-            Page<QnaResponse> result = qnaService.getList(1L, pageable, 10L, false);
+            CursorPage<QnaResponse> result = qnaService.getList(1L, null, 20, 10L, false);
 
             assertThat(result.getContent().get(0).getContent()).isEqualTo("비밀 내용");
         }
@@ -166,15 +160,14 @@ class ProductQnaServiceTest {
         @Test
         @DisplayName("비밀글 — ADMIN이면 원문 노출")
         void showsSecretToAdmin() {
-            Pageable pageable = PageRequest.of(0, 20);
             ProductQna qna = createQna(1L, 1L, 10L, "비밀 내용", true);
             given(productRepository.existsById(1L)).willReturn(true);
-            given(qnaRepository.findByProductId(1L, pageable))
-                    .willReturn(new PageImpl<>(List.of(qna), pageable, 1));
+            given(qnaRepository.findByProductIdOrderByIdDesc(any(), any()))
+                    .willReturn(List.of(qna));
             given(userRepository.findAllById(List.of(10L)))
                     .willReturn(List.of(createUser(10L, "buyer")));
 
-            Page<QnaResponse> result = qnaService.getList(1L, pageable, 99L, true);
+            CursorPage<QnaResponse> result = qnaService.getList(1L, null, 20, 99L, true);
 
             assertThat(result.getContent().get(0).getContent()).isEqualTo("비밀 내용");
         }

--- a/src/test/java/com/stockmanagement/domain/product/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/product/review/controller/ReviewControllerTest.java
@@ -1,6 +1,7 @@
 package com.stockmanagement.domain.product.review.controller;
 
 import com.stockmanagement.common.config.SecurityConfig;
+import com.stockmanagement.common.dto.CursorPage;
 import com.stockmanagement.common.exception.BusinessException;
 import com.stockmanagement.common.exception.ErrorCode;
 import com.stockmanagement.common.security.JwtBlacklist;
@@ -17,8 +18,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -26,9 +25,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
@@ -125,8 +122,8 @@ class ReviewControllerTest {
         @Test
         @DisplayName("비로그인 사용자 — 리뷰 목록 조회 → 200")
         void publicGetsList() throws Exception {
-            given(reviewService.getList(anyLong(), any(Pageable.class), any()))
-                    .willReturn(new PageImpl<>(List.of(mock(ReviewResponse.class))));
+            given(reviewService.getList(anyLong(), any(), anyInt(), any()))
+                    .willReturn(CursorPage.of(List.of(mock(ReviewResponse.class)), 20, ReviewResponse::getId));
 
             mockMvc.perform(get("/api/v1/products/1/reviews"))
                     .andExpect(status().isOk())

--- a/src/test/java/com/stockmanagement/domain/product/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/product/review/service/ReviewServiceTest.java
@@ -1,5 +1,6 @@
 package com.stockmanagement.domain.product.review.service;
 
+import com.stockmanagement.common.dto.CursorPage;
 import com.stockmanagement.common.exception.BusinessException;
 import com.stockmanagement.common.exception.ErrorCode;
 import com.stockmanagement.domain.order.repository.OrderRepository;
@@ -17,9 +18,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
@@ -112,15 +110,15 @@ class ReviewServiceTest {
     class GetList {
 
         @Test
-        @DisplayName("정상 조회 → 페이지 반환")
+        @DisplayName("정상 조회 → 커서 페이지 반환")
         void success() {
             given(productRepository.existsById(1L)).willReturn(true);
             Review r = Review.builder().productId(1L).userId(2L).rating(4).title("보통").content("그냥 그래요").build();
             ReflectionTestUtils.setField(r, "id", 5L);
-            given(reviewRepository.findByProductId(any(), any(Pageable.class)))
-                    .willReturn(new PageImpl<>(List.of(r)));
+            given(reviewRepository.findByProductIdOrderByIdDesc(any(), any()))
+                    .willReturn(List.of(r));
 
-            Page<ReviewResponse> page = reviewService.getList(1L, Pageable.unpaged(), null);
+            CursorPage<ReviewResponse> page = reviewService.getList(1L, null, 20, null);
 
             assertThat(page.getContent()).hasSize(1);
             assertThat(page.getContent().get(0).getRating()).isEqualTo(4);

--- a/src/test/java/com/stockmanagement/domain/product/wishlist/controller/WishlistControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/product/wishlist/controller/WishlistControllerTest.java
@@ -20,13 +20,11 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.web.servlet.MockMvc;
 
-import org.springframework.data.domain.PageImpl;
+import com.stockmanagement.common.dto.CursorPage;
 
 import java.util.List;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
@@ -120,8 +118,8 @@ class WishlistControllerTest {
         @Test
         @DisplayName("인증된 사용자 — 위시리스트 조회 → 200")
         void returnsList() throws Exception {
-            given(wishlistService.getList(anyLong(), any()))
-                    .willReturn(new PageImpl<>(List.of(mock(WishlistResponse.class))));
+            given(wishlistService.getList(anyLong(), any(), anyInt()))
+                    .willReturn(CursorPage.of(List.of(mock(WishlistResponse.class)), 20, WishlistResponse::getId));
 
             mockMvc.perform(get("/api/v1/wishlist").with(authentication(USER_AUTH)))
                     .andExpect(status().isOk())

--- a/src/test/java/com/stockmanagement/domain/product/wishlist/service/WishlistServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/product/wishlist/service/WishlistServiceTest.java
@@ -18,9 +18,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import org.springframework.data.domain.PageImpl;
+import com.stockmanagement.common.dto.CursorPage;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -28,7 +27,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -113,21 +112,20 @@ class WishlistServiceTest {
     }
 
     @Nested
-    @DisplayName("getList() — 위시리스트 페이징 조회")
+    @DisplayName("getList() — 위시리스트 커서 기반 조회")
     class GetList {
 
         @Test
-        @DisplayName("목록 반환")
+        @DisplayName("첫 페이지 목록 반환")
         void success() {
             WishlistItem item = mockItem(5L, 1L, 10L);
             Product product = mockProduct(10L);
-            Pageable pageable = PageRequest.of(0, 20);
-            given(wishlistRepository.findByUserIdWithExistingProduct(1L, pageable))
-                    .willReturn(new PageImpl<>(List.of(item)));
+            given(wishlistRepository.findByUserIdWithExistingProductCursor(eq(1L), any()))
+                    .willReturn(List.of(item));
             given(productRepository.findAllById(List.of(10L))).willReturn(List.of(product));
             given(inventoryRepository.findAllByProductIdIn(List.of(10L))).willReturn(List.of());
 
-            var page = wishlistService.getList(1L, pageable);
+            CursorPage<WishlistResponse> page = wishlistService.getList(1L, null, 20);
 
             assertThat(page.getContent()).hasSize(1);
             assertThat(page.getContent().get(0).getProductName()).isEqualTo("상품A");

--- a/src/test/java/com/stockmanagement/domain/shipment/controller/ShipmentControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/shipment/controller/ShipmentControllerTest.java
@@ -17,7 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
-import org.springframework.data.domain.PageImpl;
+import com.stockmanagement.common.dto.CursorPage;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
@@ -55,8 +55,8 @@ class ShipmentControllerTest {
         @DisplayName("인증된 사용자 — 내 배송 목록 → 200")
         void returnsMyShipments() throws Exception {
             given(userService.resolveUserId(any())).willReturn(1L);
-            given(shipmentService.getMyShipments(anyLong(), any()))
-                    .willReturn(new PageImpl<>(List.of(mock(ShipmentResponse.class))));
+            given(shipmentService.getMyShipments(anyLong(), any(), anyInt()))
+                    .willReturn(CursorPage.of(List.of(mock(ShipmentResponse.class)), 20, ShipmentResponse::getId));
 
             mockMvc.perform(get("/api/v1/shipments/my"))
                     .andExpect(status().isOk())

--- a/src/test/java/com/stockmanagement/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/user/controller/UserControllerTest.java
@@ -1,6 +1,7 @@
 package com.stockmanagement.domain.user.controller;
 
 import com.stockmanagement.common.config.SecurityConfig;
+import com.stockmanagement.common.dto.CursorPage;
 import com.stockmanagement.domain.order.dto.OrderResponse;
 import com.stockmanagement.domain.user.dto.UserResponse;
 import com.stockmanagement.domain.user.entity.UserRole;
@@ -15,17 +16,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
@@ -131,8 +128,8 @@ class UserControllerTest {
         @Test
         @DisplayName("인증된 사용자 — 내 주문 목록 페이징 조회 → 200")
         void returnsMyOrders() throws Exception {
-            given(userService.getMyOrders(eq("testuser"), any(Pageable.class)))
-                    .willReturn(new PageImpl<>(List.of()));
+            given(userService.getMyOrders(eq("testuser"), any(), anyInt()))
+                    .willReturn(CursorPage.of(List.of(), 20, OrderResponse::getId));
 
             mockMvc.perform(get("/api/v1/users/me/orders")
                             .with(authentication(userAuth("testuser"))))

--- a/src/test/java/com/stockmanagement/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/user/service/UserServiceTest.java
@@ -37,10 +37,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
+import com.stockmanagement.common.dto.CursorPage;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.List;
@@ -326,18 +323,17 @@ class UserServiceTest {
     class GetMyOrders {
 
         @Test
-        @DisplayName("인증된 사용자의 주문 목록을 페이징하여 반환한다")
+        @DisplayName("인증된 사용자의 주문 목록을 커서 기반으로 반환한다")
         void returnsPagedOrders() {
-            Pageable pageable = PageRequest.of(0, 10);
             given(userRepository.findByUsername("testuser")).willReturn(Optional.of(user));
             // user.getId()는 미영속 상태라 null이므로 any() 매처 사용
-            given(orderRepository.findByUserId(any(), eq(pageable)))
-                    .willReturn(new PageImpl<>(List.of(), pageable, 0));
+            given(orderRepository.findByUserIdOrderByIdDesc(any(), any()))
+                    .willReturn(List.of());
 
-            Page<OrderResponse> result = userService.getMyOrders("testuser", pageable);
+            CursorPage<OrderResponse> result = userService.getMyOrders("testuser", null, 10);
 
-            assertThat(result).isEmpty();
-            verify(orderRepository).findByUserId(any(), eq(pageable));
+            assertThat(result.getContent()).isEmpty();
+            verify(orderRepository).findByUserIdOrderByIdDesc(any(), any());
         }
 
         @Test
@@ -345,7 +341,7 @@ class UserServiceTest {
         void throwsWhenUserNotFound() {
             given(userRepository.findByUsername("ghost")).willReturn(Optional.empty());
 
-            assertThatThrownBy(() -> userService.getMyOrders("ghost", PageRequest.of(0, 10)))
+            assertThatThrownBy(() -> userService.getMyOrders("ghost", null, 10))
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                             .isEqualTo(ErrorCode.USER_NOT_FOUND));

--- a/src/test/java/com/stockmanagement/integration/OrderFilterIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/OrderFilterIntegrationTest.java
@@ -86,7 +86,7 @@ class OrderFilterIntegrationTest extends AbstractIntegrationTest {
         mockMvc.perform(get("/api/v1/orders")
                         .header("Authorization", "Bearer " + userToken1))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.totalElements").value(2))
+                .andExpect(jsonPath("$.data.content.length()").value(2))
                 .andExpect(jsonPath("$.data.content[0].userId").value(userId1));
     }
 
@@ -101,7 +101,7 @@ class OrderFilterIntegrationTest extends AbstractIntegrationTest {
                         .header("Authorization", "Bearer " + userToken1)
                         .param("userId", String.valueOf(userId2)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.totalElements").value(1))
+                .andExpect(jsonPath("$.data.content.length()").value(1))
                 .andExpect(jsonPath("$.data.content[0].userId").value(userId1));
     }
 
@@ -122,7 +122,7 @@ class OrderFilterIntegrationTest extends AbstractIntegrationTest {
                         .header("Authorization", "Bearer " + userToken1)
                         .param("status", "PENDING"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.totalElements").value(1))
+                .andExpect(jsonPath("$.data.content.length()").value(1))
                 .andExpect(jsonPath("$.data.content[0].status").value("PENDING"));
     }
 
@@ -140,7 +140,7 @@ class OrderFilterIntegrationTest extends AbstractIntegrationTest {
                         .header("Authorization", "Bearer " + userToken1)
                         .param("status", "CANCELLED"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.totalElements").value(1))
+                .andExpect(jsonPath("$.data.content.length()").value(1))
                 .andExpect(jsonPath("$.data.content[0].status").value("CANCELLED"));
     }
 
@@ -156,7 +156,7 @@ class OrderFilterIntegrationTest extends AbstractIntegrationTest {
                         .header("Authorization", "Bearer " + adminToken)
                         .param("userId", String.valueOf(userId1)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.totalElements").value(1))
+                .andExpect(jsonPath("$.data.content.length()").value(1))
                 .andExpect(jsonPath("$.data.content[0].userId").value(userId1));
     }
 
@@ -169,7 +169,7 @@ class OrderFilterIntegrationTest extends AbstractIntegrationTest {
         mockMvc.perform(get("/api/v1/orders")
                         .header("Authorization", "Bearer " + adminToken))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.totalElements").value(2));
+                .andExpect(jsonPath("$.data.content.length()").value(2));
     }
 
     @Test
@@ -188,7 +188,7 @@ class OrderFilterIntegrationTest extends AbstractIntegrationTest {
                         .param("userId", String.valueOf(userId1))
                         .param("status", "PENDING"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.totalElements").value(1))
+                .andExpect(jsonPath("$.data.content.length()").value(1))
                 .andExpect(jsonPath("$.data.content[0].status").value("PENDING"));
     }
 
@@ -206,7 +206,7 @@ class OrderFilterIntegrationTest extends AbstractIntegrationTest {
                         .param("startDate", today)
                         .param("endDate", today))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.totalElements").value(1));
+                .andExpect(jsonPath("$.data.content.length()").value(1));
     }
 
     @Test
@@ -220,6 +220,6 @@ class OrderFilterIntegrationTest extends AbstractIntegrationTest {
                         .header("Authorization", "Bearer " + userToken1)
                         .param("endDate", yesterday))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.totalElements").value(0));
+                .andExpect(jsonPath("$.data.content.length()").value(0));
     }
 }

--- a/src/test/java/com/stockmanagement/integration/PointIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/PointIntegrationTest.java
@@ -80,7 +80,7 @@ class PointIntegrationTest extends AbstractIntegrationTest {
                         .header("Authorization", "Bearer " + userToken))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.content").isArray())
-                .andExpect(jsonPath("$.data.totalElements").value(0));
+                .andExpect(jsonPath("$.data.content.length()").value(0));
     }
 
     @Test

--- a/src/test/java/com/stockmanagement/integration/ReviewIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/ReviewIntegrationTest.java
@@ -169,7 +169,7 @@ class ReviewIntegrationTest extends AbstractIntegrationTest {
         // 삭제 후 목록 비어 있음 확인
         mockMvc.perform(get("/api/v1/products/" + productId + "/reviews"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.totalElements").value(0));
+                .andExpect(jsonPath("$.data.content.length()").value(0));
     }
 
     @Test

--- a/src/test/java/com/stockmanagement/integration/UserIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/UserIntegrationTest.java
@@ -33,7 +33,7 @@ class UserIntegrationTest extends AbstractIntegrationTest {
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.data.content").isArray())
-                    .andExpect(jsonPath("$.data.totalElements").value(0));
+                    .andExpect(jsonPath("$.data.content.length()").value(0));
         }
 
         @Test

--- a/src/test/java/com/stockmanagement/integration/WishlistIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/WishlistIntegrationTest.java
@@ -93,7 +93,7 @@ class WishlistIntegrationTest extends AbstractIntegrationTest {
                         .header("Authorization", "Bearer " + userToken))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.content").isArray())
-                .andExpect(jsonPath("$.data.totalElements").value(0));
+                .andExpect(jsonPath("$.data.content.length()").value(0));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- 사용자 대상 12개 엔드포인트를 `LIMIT/OFFSET` → `WHERE id < lastId ORDER BY id DESC` 커서 방식으로 전환
- 페이지 번호 증가에 따른 O(N) 스캔 → O(1) 접근으로 성능 개선
- 기존 `CursorPage<T>` (common/dto/) 및 InventoryService 패턴 재사용

## 변경 범위

### 전환 대상 (12개 엔드포인트)
| 도메인 | 엔드포인트 |
|--------|-----------|
| Refund | `GET /refunds/my` |
| Shipment | `GET /shipments/my` |
| Wishlist | `GET /wishlist` |
| Notification | `GET /notifications` |
| Point | `GET /points/history`, `GET /points/pending` |
| Review | `GET /products/{id}/reviews`, `GET /users/me/reviews` |
| QnA | `GET /products/{id}/qna` |
| Coupon | `GET /coupons/public` |
| Order | `GET /orders`, `GET /users/me/orders` |

### 유지 (offset)
- 관리자·상품 검색 (총 개수·페이지 점프 필요)
- `GET /points/expiring-soon` (`expiresAt ASC` 정렬, ID 커서와 비호환)

### 변경 패턴
- **Repository**: 커서 쿼리 2개 추가 (첫 페이지 + `id < lastId`)
- **Service**: `Page<T>` → `CursorPage<T>`, `PageRequest.of(0, size+1)` 패턴
- **Controller**: `Pageable` → `@RequestParam lastId/size`, `@Validated`
- **OrderSpecification**: 3-arg `of(request, forceUserId, lastId)` 오버로드 추가

### 파일 변경
- 소스: 30개 파일 (10개 도메인 × Repository/Service/Controller)
- 테스트: 19개 파일 (단위 + 통합 테스트)

## Test plan
- [x] `./gradlew test` 전체 통과 (BUILD SUCCESSFUL)
- [x] 단위 테스트: CursorPage 모킹 및 새 시그니처 반영
- [x] 통합 테스트: `$.data.totalElements` → `$.data.content.length()` 전환

Closes #15