### PR TITLE
perf: @CurrentUserId 전환으로 불필요한 findByUsername 제거

### DIFF
--- a/src/main/java/com/stockmanagement/domain/point/controller/PointController.java
+++ b/src/main/java/com/stockmanagement/domain/point/controller/PointController.java
@@ -2,6 +2,7 @@ package com.stockmanagement.domain.point.controller;
 
 import com.stockmanagement.common.dto.ApiResponse;
 import com.stockmanagement.common.dto.CursorPage;
+import com.stockmanagement.common.security.CurrentUserId;
 import com.stockmanagement.domain.point.dto.PointBalanceResponse;
 import com.stockmanagement.domain.point.dto.PointTransactionResponse;
 import com.stockmanagement.domain.point.service.PointService;
@@ -13,7 +14,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -32,34 +32,34 @@ public class PointController {
     @Operation(summary = "포인트 잔액 조회")
     @GetMapping("/balance")
     public ApiResponse<PointBalanceResponse> getBalance(
-            @AuthenticationPrincipal String username) {
-        return ApiResponse.ok(pointService.getBalance(username));
+            @CurrentUserId Long userId) {
+        return ApiResponse.ok(pointService.getBalance(userId));
     }
 
     @Operation(summary = "포인트 변동 이력 조회 (커서 기반, 최신순)")
     @GetMapping("/history")
     public ApiResponse<CursorPage<PointTransactionResponse>> getHistory(
-            @AuthenticationPrincipal String username,
+            @CurrentUserId Long userId,
             @RequestParam(required = false) Long lastId,
             @Min(1) @Max(100) @RequestParam(defaultValue = "20") int size) {
-        return ApiResponse.ok(pointService.getHistory(username, lastId, size));
+        return ApiResponse.ok(pointService.getHistory(userId, lastId, size));
     }
 
     @Operation(summary = "적립 예정 포인트 조회 (커서 기반, 배송 완료 전)")
     @GetMapping("/pending")
     public ApiResponse<CursorPage<PointTransactionResponse>> getPending(
-            @AuthenticationPrincipal String username,
+            @CurrentUserId Long userId,
             @RequestParam(required = false) Long lastId,
             @Min(1) @Max(100) @RequestParam(defaultValue = "20") int size) {
-        return ApiResponse.ok(pointService.getPendingHistory(username, lastId, size));
+        return ApiResponse.ok(pointService.getPendingHistory(userId, lastId, size));
     }
 
     @Operation(summary = "만료 예정 포인트 조회")
     @GetMapping("/expiring-soon")
     public ApiResponse<Page<PointTransactionResponse>> getExpiringSoon(
-            @AuthenticationPrincipal String username,
+            @CurrentUserId Long userId,
             @RequestParam(defaultValue = "30") int withinDays,
             @PageableDefault(size = 20) Pageable pageable) {
-        return ApiResponse.ok(pointService.getExpiringSoon(username, withinDays, pageable));
+        return ApiResponse.ok(pointService.getExpiringSoon(userId, withinDays, pageable));
     }
 }

--- a/src/main/java/com/stockmanagement/domain/point/service/PointService.java
+++ b/src/main/java/com/stockmanagement/domain/point/service/PointService.java
@@ -10,8 +10,6 @@ import com.stockmanagement.domain.point.entity.PointTransactionType;
 import com.stockmanagement.domain.point.entity.UserPoint;
 import com.stockmanagement.domain.point.repository.PointTransactionRepository;
 import com.stockmanagement.domain.point.repository.UserPointRepository;
-import com.stockmanagement.domain.user.entity.User;
-import com.stockmanagement.domain.user.repository.UserRepository;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.annotation.PostConstruct;
@@ -63,7 +61,6 @@ public class PointService {
 
     private final UserPointRepository userPointRepository;
     private final PointTransactionRepository pointTransactionRepository;
-    private final UserRepository userRepository;
     private final MeterRegistry meterRegistry;
 
     /** 적립금 부분 회수 발생 횟수 카운터 — 잔액 부족으로 전액 회수 불가 시 증가 */
@@ -79,21 +76,19 @@ public class PointService {
     // ===== 조회 =====
 
     /** 포인트 잔액을 조회한다. 포인트 계정이 없으면 0을 반환한다. */
-    public PointBalanceResponse getBalance(String username) {
-        User user = findUser(username);
-        long balance = userPointRepository.findByUserId(user.getId())
+    public PointBalanceResponse getBalance(Long userId) {
+        long balance = userPointRepository.findByUserId(userId)
                 .map(UserPoint::getBalance)
                 .orElse(0L);
-        return PointBalanceResponse.of(user.getId(), balance);
+        return PointBalanceResponse.of(userId, balance);
     }
 
     /** 포인트 변동 이력을 커서 기반으로 조회한다. */
-    public CursorPage<PointTransactionResponse> getHistory(String username, Long lastId, int size) {
-        User user = findUser(username);
+    public CursorPage<PointTransactionResponse> getHistory(Long userId, Long lastId, int size) {
         PageRequest limit = PageRequest.of(0, size + 1);
         var items = lastId == null
-                ? pointTransactionRepository.findByUserIdOrderByIdDesc(user.getId(), limit)
-                : pointTransactionRepository.findByUserIdAndIdLessThanOrderByIdDesc(user.getId(), lastId, limit);
+                ? pointTransactionRepository.findByUserIdOrderByIdDesc(userId, limit)
+                : pointTransactionRepository.findByUserIdAndIdLessThanOrderByIdDesc(userId, lastId, limit);
         return CursorPage.of(
                 items.stream().map(PointTransactionResponse::from).toList(),
                 size,
@@ -101,12 +96,11 @@ public class PointService {
     }
 
     /** 적립 예정 (PENDING) 포인트 이력을 커서 기반으로 조회한다. */
-    public CursorPage<PointTransactionResponse> getPendingHistory(String username, Long lastId, int size) {
-        User user = findUser(username);
+    public CursorPage<PointTransactionResponse> getPendingHistory(Long userId, Long lastId, int size) {
         PageRequest limit = PageRequest.of(0, size + 1);
         var items = lastId == null
-                ? pointTransactionRepository.findByUserIdAndStatusOrderByIdDesc(user.getId(), PointTransactionStatus.PENDING, limit)
-                : pointTransactionRepository.findByUserIdAndStatusAndIdLessThanOrderByIdDesc(user.getId(), PointTransactionStatus.PENDING, lastId, limit);
+                ? pointTransactionRepository.findByUserIdAndStatusOrderByIdDesc(userId, PointTransactionStatus.PENDING, limit)
+                : pointTransactionRepository.findByUserIdAndStatusAndIdLessThanOrderByIdDesc(userId, PointTransactionStatus.PENDING, lastId, limit);
         return CursorPage.of(
                 items.stream().map(PointTransactionResponse::from).toList(),
                 size,
@@ -114,11 +108,10 @@ public class PointService {
     }
 
     /** 만료 예정 CONFIRMED 포인트를 만료일 가까운 순으로 페이징 조회한다. */
-    public Page<PointTransactionResponse> getExpiringSoon(String username, int withinDays, Pageable pageable) {
-        User user = findUser(username);
+    public Page<PointTransactionResponse> getExpiringSoon(Long userId, int withinDays, Pageable pageable) {
         LocalDateTime deadline = LocalDateTime.now().plusDays(withinDays);
         return pointTransactionRepository.findByUserIdAndStatusAndExpiresAtBeforeOrderByExpiresAtAsc(
-                        user.getId(), PointTransactionStatus.CONFIRMED, deadline, pageable)
+                        userId, PointTransactionStatus.CONFIRMED, deadline, pageable)
                 .map(PointTransactionResponse::from);
     }
 
@@ -383,8 +376,4 @@ public class PointService {
                 });
     }
 
-    private User findUser(String username) {
-        return userRepository.findByUsername(username)
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
-    }
 }

--- a/src/main/java/com/stockmanagement/domain/shipment/controller/ShipmentController.java
+++ b/src/main/java/com/stockmanagement/domain/shipment/controller/ShipmentController.java
@@ -15,7 +15,6 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -57,10 +56,10 @@ public class ShipmentController {
     @GetMapping("/orders/{orderId}")
     public ApiResponse<ShipmentResponse> getByOrderId(
             @PathVariable Long orderId,
-            @AuthenticationPrincipal String username,
+            @CurrentUserId Long userId,
             Authentication authentication) {
         boolean isAdmin = SecurityUtils.isAdmin(authentication);
-        return ApiResponse.ok(shipmentService.getByOrderId(orderId, username, isAdmin));
+        return ApiResponse.ok(shipmentService.getByOrderId(orderId, userId, isAdmin));
     }
 
     @Operation(summary = "배송 출고 처리 (ADMIN)",

--- a/src/main/java/com/stockmanagement/domain/shipment/service/ShipmentService.java
+++ b/src/main/java/com/stockmanagement/domain/shipment/service/ShipmentService.java
@@ -13,12 +13,9 @@ import com.stockmanagement.domain.shipment.dto.ShipmentUpdateRequest;
 import com.stockmanagement.domain.shipment.entity.Shipment;
 import com.stockmanagement.common.outbox.OutboxEventStore;
 import com.stockmanagement.domain.shipment.repository.ShipmentRepository;
-import com.stockmanagement.domain.user.repository.UserRepository;
 import com.stockmanagement.common.dto.CursorPage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -44,7 +41,6 @@ public class ShipmentService {
 
     private final ShipmentRepository shipmentRepository;
     private final OrderRepository orderRepository;
-    private final UserRepository userRepository;
     private final OutboxEventStore outboxEventStore;
 
     /**
@@ -78,7 +74,7 @@ public class ShipmentService {
      *
      * @throws BusinessException 배송 정보가 없는 경우, 또는 소유자가 아닌 경우
      */
-    public ShipmentResponse getByOrderId(Long orderId, String username, boolean isAdmin) {
+    public ShipmentResponse getByOrderId(Long orderId, Long userId, boolean isAdmin) {
         Shipment shipment = shipmentRepository.findByOrderId(orderId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.SHIPMENT_NOT_FOUND));
 
@@ -86,7 +82,7 @@ public class ShipmentService {
             // userId 스칼라 프로젝션 — Order 전체 엔티티 로드 불필요
             Long orderUserId = orderRepository.findUserIdById(orderId)
                     .orElseThrow(() -> new BusinessException(ErrorCode.SHIPMENT_NOT_FOUND));
-            if (!orderUserId.equals(resolveUserId(username))) {
+            if (!orderUserId.equals(userId)) {
                 // 타인 배송 존재 여부 노출 방지 — ACCESS_DENIED 대신 NOT_FOUND 반환
                 throw new BusinessException(ErrorCode.SHIPMENT_NOT_FOUND);
             }
@@ -195,17 +191,6 @@ public class ShipmentService {
         Shipment shipment = findByOrderIdOrThrow(orderId);
         shipment.rejectReturn();
         return ShipmentResponse.from(shipment);
-    }
-
-    /** JWT details에서 userId를 꺼낸다. details가 없으면 DB fallback (구 토큰·테스트 환경 호환). */
-    private Long resolveUserId(String username) {
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        if (auth != null && auth.getDetails() instanceof Long userId) {
-            return userId;
-        }
-        return userRepository.findByUsername(username)
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND))
-                .getId();
     }
 
     private Shipment findByOrderIdOrThrow(Long orderId) {

--- a/src/main/java/com/stockmanagement/domain/user/controller/UserController.java
+++ b/src/main/java/com/stockmanagement/domain/user/controller/UserController.java
@@ -47,8 +47,8 @@ public class UserController {
 
     @Operation(summary = "내 정보 조회", description = "포인트 잔액(pointBalance) 포함.")
     @GetMapping("/me")
-    public ApiResponse<UserResponse> getMe(@AuthenticationPrincipal String username) {
-        return ApiResponse.ok(userService.getMe(username));
+    public ApiResponse<UserResponse> getMe(@CurrentUserId Long userId) {
+        return ApiResponse.ok(userService.getMe(userId));
     }
 
     @Operation(summary = "회원 탈퇴", description = "논리 삭제 처리. 탈퇴 후 동일 계정으로 로그인 불가.")
@@ -64,9 +64,9 @@ public class UserController {
     @Operation(summary = "프로필 수정", description = "이메일 변경. 중복 이메일이면 409.")
     @PatchMapping("/me")
     public ApiResponse<UserResponse> updateProfile(
-            @AuthenticationPrincipal String username,
+            @CurrentUserId Long userId,
             @Valid @RequestBody UpdateProfileRequest request) {
-        return ApiResponse.ok(userService.updateProfile(username, request));
+        return ApiResponse.ok(userService.updateProfile(userId, request));
     }
 
     @Operation(summary = "비밀번호 변경", description = "현재 비밀번호 확인 후 새 비밀번호로 변경. 기존 Access/Refresh Token 일괄 무효화.")
@@ -83,10 +83,10 @@ public class UserController {
     @Operation(summary = "내 주문 목록 (커서 기반)", description = "기본: 최신순, 20건.")
     @GetMapping("/me/orders")
     public ApiResponse<CursorPage<OrderResponse>> getMyOrders(
-            @AuthenticationPrincipal String username,
+            @CurrentUserId Long userId,
             @RequestParam(required = false) Long lastId,
             @Min(1) @Max(100) @RequestParam(defaultValue = "20") int size) {
-        return ApiResponse.ok(userService.getMyOrders(username, lastId, size));
+        return ApiResponse.ok(userService.getMyOrders(userId, lastId, size));
     }
 
     @Operation(summary = "내 리뷰 목록 (커서 기반)",

--- a/src/main/java/com/stockmanagement/domain/user/service/UserService.java
+++ b/src/main/java/com/stockmanagement/domain/user/service/UserService.java
@@ -198,10 +198,10 @@ public class UserService {
     }
 
     /** 현재 인증된 사용자 정보 조회 (포인트 잔액 포함). */
-    public UserResponse getMe(String username) {
-        User user = userRepository.findByUsername(username)
+    public UserResponse getMe(Long userId) {
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
-        Long pointBalance = userPointRepository.findByUserId(user.getId())
+        Long pointBalance = userPointRepository.findByUserId(userId)
                 .map(up -> up.getBalance()).orElse(null);
         return UserResponse.from(user, pointBalance);
     }
@@ -234,8 +234,8 @@ public class UserService {
 
     /** 프로필(이메일) 수정. 이메일 변경 시 중복 여부 검증. */
     @Transactional
-    public UserResponse updateProfile(String username, UpdateProfileRequest request) {
-        User user = userRepository.findByUsername(username)
+    public UserResponse updateProfile(Long userId, UpdateProfileRequest request) {
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
         if (request.getEmail() != null && !request.getEmail().equals(user.getEmail())) {
             if (userRepository.existsByEmail(request.getEmail())) {
@@ -273,20 +273,18 @@ public class UserService {
     }
 
     /** 현재 인증된 사용자의 주문 목록 커서 기반 조회. hasReview + shipmentStatus 정보 포함. */
-    public CursorPage<OrderResponse> getMyOrders(String username, Long lastId, int size) {
-        User user = userRepository.findByUsername(username)
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+    public CursorPage<OrderResponse> getMyOrders(Long userId, Long lastId, int size) {
         PageRequest limit = PageRequest.of(0, size + 1);
         List<Order> items = lastId == null
-                ? orderRepository.findByUserIdOrderByIdDesc(user.getId(), limit)
-                : orderRepository.findByUserIdAndIdLessThanOrderByIdDesc(user.getId(), lastId, limit);
+                ? orderRepository.findByUserIdOrderByIdDesc(userId, limit)
+                : orderRepository.findByUserIdAndIdLessThanOrderByIdDesc(userId, lastId, limit);
         // 목록 내 전체 상품 ID를 한 번에 조회 (N+1 방지)
         List<Long> allProductIds = items.stream()
                 .flatMap(o -> o.getItems().stream().map(i -> i.getProduct().getId()))
                 .collect(Collectors.toList());
         Set<Long> reviewedIds = allProductIds.isEmpty()
                 ? Set.of()
-                : new HashSet<>(reviewRepository.findReviewedProductIdsByUserId(user.getId(), allProductIds));
+                : new HashSet<>(reviewRepository.findReviewedProductIdsByUserId(userId, allProductIds));
         // 배송 상태 배치 조회 (N+1 방지)
         List<Long> orderIds = items.stream().map(Order::getId).toList();
         Map<Long, com.stockmanagement.domain.shipment.entity.ShipmentStatus> statusMap =

--- a/src/test/java/com/stockmanagement/domain/point/controller/PointControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/point/controller/PointControllerTest.java
@@ -54,7 +54,8 @@ class PointControllerTest {
         @Test
         @DisplayName("인증된 사용자 — 잔액 조회 → 200")
         void returnsBalance() throws Exception {
-            given(pointService.getBalance("user1")).willReturn(mock(PointBalanceResponse.class));
+            given(userService.resolveUserId(any())).willReturn(1L);
+            given(pointService.getBalance(any())).willReturn(mock(PointBalanceResponse.class));
 
             mockMvc.perform(get("/api/v1/points/balance").with(authentication(USER_AUTH)))
                     .andExpect(status().isOk())
@@ -78,7 +79,8 @@ class PointControllerTest {
         @Test
         @DisplayName("인증된 사용자 — 이력 조회 → 200")
         void returnsHistory() throws Exception {
-            given(pointService.getHistory(anyString(), any(), anyInt()))
+            given(userService.resolveUserId(any())).willReturn(1L);
+            given(pointService.getHistory(any(), any(), anyInt()))
                     .willReturn(CursorPage.of(List.of(mock(PointTransactionResponse.class)), 20, PointTransactionResponse::getId));
 
             mockMvc.perform(get("/api/v1/points/history").with(authentication(USER_AUTH)))

--- a/src/test/java/com/stockmanagement/domain/point/service/PointServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/point/service/PointServiceTest.java
@@ -9,8 +9,6 @@ import com.stockmanagement.domain.point.entity.PointTransactionType;
 import com.stockmanagement.domain.point.entity.UserPoint;
 import com.stockmanagement.domain.point.repository.PointTransactionRepository;
 import com.stockmanagement.domain.point.repository.UserPointRepository;
-import com.stockmanagement.domain.user.entity.User;
-import com.stockmanagement.domain.user.repository.UserRepository;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
@@ -39,7 +37,6 @@ class PointServiceTest {
 
     @Mock private UserPointRepository userPointRepository;
     @Mock private PointTransactionRepository pointTransactionRepository;
-    @Mock private UserRepository userRepository;
     @Spy  private MeterRegistry meterRegistry = new SimpleMeterRegistry();
 
     @InjectMocks private PointService pointService;
@@ -47,12 +44,6 @@ class PointServiceTest {
     @BeforeEach
     void setUp() {
         pointService.initMetrics();
-    }
-
-    private User mockUser(Long id, String username) {
-        User u = User.builder().username(username).password("pw").email("e@e.com").build();
-        ReflectionTestUtils.setField(u, "id", id);
-        return u;
     }
 
     private UserPoint mockUserPoint(Long userId, long balance) {
@@ -68,10 +59,9 @@ class PointServiceTest {
         @Test
         @DisplayName("포인트 계정 있음 → 잔액 반환")
         void withAccount() {
-            given(userRepository.findByUsername("user1")).willReturn(Optional.of(mockUser(1L, "user1")));
             given(userPointRepository.findByUserId(1L)).willReturn(Optional.of(mockUserPoint(1L, 5000)));
 
-            PointBalanceResponse response = pointService.getBalance("user1");
+            PointBalanceResponse response = pointService.getBalance(1L);
 
             assertThat(response.getBalance()).isEqualTo(5000);
         }
@@ -79,10 +69,9 @@ class PointServiceTest {
         @Test
         @DisplayName("포인트 계정 없음 → 0 반환")
         void withoutAccount() {
-            given(userRepository.findByUsername("user1")).willReturn(Optional.of(mockUser(1L, "user1")));
             given(userPointRepository.findByUserId(1L)).willReturn(Optional.empty());
 
-            PointBalanceResponse response = pointService.getBalance("user1");
+            PointBalanceResponse response = pointService.getBalance(1L);
 
             assertThat(response.getBalance()).isEqualTo(0);
         }

--- a/src/test/java/com/stockmanagement/domain/shipment/controller/ShipmentControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/shipment/controller/ShipmentControllerTest.java
@@ -81,6 +81,7 @@ class ShipmentControllerTest {
         @WithMockUser
         @DisplayName("인증된 사용자 — 배송 조회 → 200")
         void returnsShipment() throws Exception {
+            given(userService.resolveUserId(any())).willReturn(1L);
             given(shipmentService.getByOrderId(anyLong(), any(), anyBoolean())).willReturn(mock(ShipmentResponse.class));
 
             mockMvc.perform(get("/api/v1/shipments/orders/1"))
@@ -99,6 +100,7 @@ class ShipmentControllerTest {
         @WithMockUser
         @DisplayName("존재하지 않는 주문 → 404")
         void notFound() throws Exception {
+            given(userService.resolveUserId(any())).willReturn(1L);
             given(shipmentService.getByOrderId(anyLong(), any(), anyBoolean()))
                     .willThrow(new BusinessException(ErrorCode.ORDER_NOT_FOUND));
 

--- a/src/test/java/com/stockmanagement/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/user/controller/UserControllerTest.java
@@ -75,8 +75,9 @@ class UserControllerTest {
         @Test
         @DisplayName("인증된 사용자 — 내 정보 조회 → 200")
         void returnsMyInfo() throws Exception {
+            given(userService.resolveUserId(any())).willReturn(1L);
             UserResponse response = new UserResponse(1L, "testuser", "test@example.com", null, UserRole.USER, null, null);
-            given(userService.getMe("testuser")).willReturn(response);
+            given(userService.getMe(any())).willReturn(response);
 
             mockMvc.perform(get("/api/v1/users/me")
                             .with(authentication(userAuth("testuser"))))
@@ -128,7 +129,8 @@ class UserControllerTest {
         @Test
         @DisplayName("인증된 사용자 — 내 주문 목록 페이징 조회 → 200")
         void returnsMyOrders() throws Exception {
-            given(userService.getMyOrders(eq("testuser"), any(), anyInt()))
+            given(userService.resolveUserId(any())).willReturn(1L);
+            given(userService.getMyOrders(any(), any(), anyInt()))
                     .willReturn(CursorPage.of(List.of(), 20, OrderResponse::getId));
 
             mockMvc.perform(get("/api/v1/users/me/orders")

--- a/src/test/java/com/stockmanagement/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/user/service/UserServiceTest.java
@@ -296,9 +296,9 @@ class UserServiceTest {
         @Test
         @DisplayName("인증된 사용자 정보를 반환한다")
         void returnsUserResponse() {
-            given(userRepository.findByUsername("testuser")).willReturn(Optional.of(user));
+            given(userRepository.findById(1L)).willReturn(Optional.of(user));
 
-            UserResponse response = userService.getMe("testuser");
+            UserResponse response = userService.getMe(1L);
 
             assertThat(response.username()).isEqualTo("testuser");
             assertThat(response.email()).isEqualTo("test@example.com");
@@ -307,9 +307,9 @@ class UserServiceTest {
         @Test
         @DisplayName("사용자가 존재하지 않으면 USER_NOT_FOUND 예외 발생")
         void throwsWhenUserNotFound() {
-            given(userRepository.findByUsername("ghost")).willReturn(Optional.empty());
+            given(userRepository.findById(999L)).willReturn(Optional.empty());
 
-            assertThatThrownBy(() -> userService.getMe("ghost"))
+            assertThatThrownBy(() -> userService.getMe(999L))
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                             .isEqualTo(ErrorCode.USER_NOT_FOUND));
@@ -325,28 +325,13 @@ class UserServiceTest {
         @Test
         @DisplayName("인증된 사용자의 주문 목록을 커서 기반으로 반환한다")
         void returnsPagedOrders() {
-            given(userRepository.findByUsername("testuser")).willReturn(Optional.of(user));
-            // user.getId()는 미영속 상태라 null이므로 any() 매처 사용
             given(orderRepository.findByUserIdOrderByIdDesc(any(), any()))
                     .willReturn(List.of());
 
-            CursorPage<OrderResponse> result = userService.getMyOrders("testuser", null, 10);
+            CursorPage<OrderResponse> result = userService.getMyOrders(1L, null, 10);
 
             assertThat(result.getContent()).isEmpty();
             verify(orderRepository).findByUserIdOrderByIdDesc(any(), any());
-        }
-
-        @Test
-        @DisplayName("사용자가 존재하지 않으면 USER_NOT_FOUND 예외 발생")
-        void throwsWhenUserNotFound() {
-            given(userRepository.findByUsername("ghost")).willReturn(Optional.empty());
-
-            assertThatThrownBy(() -> userService.getMyOrders("ghost", null, 10))
-                    .isInstanceOf(BusinessException.class)
-                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
-                            .isEqualTo(ErrorCode.USER_NOT_FOUND));
-
-            verifyNoInteractions(orderRepository);
         }
     }
 


### PR DESCRIPTION
## Summary
- `PointController`(4곳), `ShipmentController`(1곳), `UserController`(3곳)에서 `@AuthenticationPrincipal String username` → `@CurrentUserId Long userId` 전환
- 서비스 레이어의 `userRepository.findByUsername()` 호출 제거 — 매 요청당 SELECT 1건 절감
- `PointService`에서 `UserRepository` 의존 제거, `ShipmentService`에서 `resolveUserId()` 및 `UserRepository` 의존 제거
- `deactivate`, `changePassword`는 username을 Redis key로 사용하므로 제외

## 변경 파일
- 소스 6개: PointController/Service, ShipmentController/Service, UserController/Service
- 테스트 5개: 위 컨트롤러/서비스 테스트 시그니처 반영

## Test plan
- [x] `./gradlew test` 전체 통과

Closes #192