### PR TITLE
fix: cancelItems 자기 호출로 인한 @Transactional 무효화 수정 (#200)

### DIFF
--- a/src/main/java/com/stockmanagement/domain/order/service/OrderCommandService.java
+++ b/src/main/java/com/stockmanagement/domain/order/service/OrderCommandService.java
@@ -12,7 +12,6 @@ import com.stockmanagement.domain.order.dto.OrderCreateRequest;
 import com.stockmanagement.domain.order.dto.OrderItemCancelRequest;
 import com.stockmanagement.domain.order.dto.OrderItemCancelResponse;
 import com.stockmanagement.domain.order.dto.OrderItemRequest;
-import com.stockmanagement.domain.order.dto.OrderItemResponse;
 import com.stockmanagement.domain.order.dto.OrderResponse;
 import com.stockmanagement.domain.order.entity.Order;
 import com.stockmanagement.domain.order.entity.OrderItem;
@@ -40,13 +39,11 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -71,6 +68,7 @@ public class OrderCommandService {
     private final OutboxEventStore outboxEventStore;
     private final DeliveryAddressService deliveryAddressService;
     private final OrderDeliverySnapshotRepository deliverySnapshotRepository;
+    private final OrderItemCancelTransactionHelper itemCancelTxHelper;
 
     /**
      * 주문을 생성한다 (내부 호출 전용 — 장바구니 결제 등).
@@ -283,133 +281,27 @@ public class OrderCommandService {
      *   <li>[No TX] Toss 부분 환불 API 호출
      *   <li>[Short TX] 아이템 CANCELLED 처리 + 재고 해제 + 포인트 반환 + 주문 상태 전이
      * </ol>
+     *
+     * <p>Short TX는 {@link OrderItemCancelTransactionHelper} 별도 빈으로 실행한다.
+     * 같은 클래스 내부 호출(self-invocation)은 프록시를 우회하여 {@code @Transactional}이
+     * 적용되지 않으므로 반드시 헬퍼를 경유해야 한다.
      */
     @DistributedLock(key = "'order-item-cancel:' + #orderId")
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public OrderItemCancelResponse cancelItems(Long orderId, Long userId, boolean isAdmin,
                                                OrderItemCancelRequest request) {
         // 1. Short TX: 검증 + 환불 금액 계산
-        CancelItemsContext ctx = validateAndPrepare(orderId, userId, isAdmin, request.getItemIds());
+        var ctx = itemCancelTxHelper.validateAndPrepare(orderId, userId, isAdmin, request.getItemIds());
 
         // 2. Toss 부분 환불 (DB 커넥션 미점유)
-        if (ctx.refundAmount.compareTo(BigDecimal.ZERO) > 0) {
-            paymentService.cancelPartialForItems(orderId, ctx.refundAmount, request.getReason());
+        if (ctx.refundAmount().compareTo(BigDecimal.ZERO) > 0) {
+            paymentService.cancelPartialForItems(orderId, ctx.refundAmount(), request.getReason());
         }
 
         // 3. Short TX: 아이템 취소 + 재고 해제 + 포인트 반환 + 주문 상태 전이
-        return applyItemCancel(orderId, request.getItemIds(), request.getReason(),
-                ctx.refundAmount, ctx.pointsToRefund);
+        return itemCancelTxHelper.applyItemCancel(orderId, request.getItemIds(), request.getReason(),
+                ctx.refundAmount(), ctx.pointsToRefund());
     }
-
-    /**
-     * [Short TX] 부분 취소 검증 + 환불 금액 계산.
-     */
-    @Transactional
-    CancelItemsContext validateAndPrepare(Long orderId, Long userId, boolean isAdmin,
-                                          List<Long> itemIds) {
-        Order order = orderRepository.findByIdWithItemsForUpdate(orderId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
-
-        validateOrderOwnership(order, userId, isAdmin);
-
-        // CONFIRMED 또는 PARTIAL_CANCELLED 상태만 부분 취소 가능
-        if (order.getStatus() != OrderStatus.CONFIRMED
-                && order.getStatus() != OrderStatus.PARTIAL_CANCELLED) {
-            throw new BusinessException(ErrorCode.INVALID_ORDER_STATUS);
-        }
-
-        // 요청 아이템 검증
-        Set<Long> requestedIds = new HashSet<>(itemIds);
-        Map<Long, OrderItem> itemMap = order.getItems().stream()
-                .collect(Collectors.toMap(OrderItem::getId, i -> i));
-
-        List<OrderItem> targetItems = new ArrayList<>();
-        for (Long itemId : requestedIds) {
-            OrderItem item = itemMap.get(itemId);
-            if (item == null) {
-                throw new BusinessException(ErrorCode.ORDER_ITEM_NOT_FOUND);
-            }
-            if (!item.isActive()) {
-                throw new BusinessException(ErrorCode.ORDER_ITEM_ALREADY_CANCELLED);
-            }
-            targetItems.add(item);
-        }
-
-        // 환불 금액 계산 (비례 안분)
-        BigDecimal cancelledSubtotal = targetItems.stream()
-                .map(OrderItem::getSubtotal)
-                .reduce(BigDecimal.ZERO, BigDecimal::add);
-
-        BigDecimal cancelRatio = cancelledSubtotal.divide(
-                order.getTotalAmount(), 10, RoundingMode.DOWN);
-
-        BigDecimal proportionalDiscount = order.getDiscountAmount()
-                .multiply(cancelRatio).setScale(0, RoundingMode.DOWN);
-
-        long proportionalPoints = BigDecimal.valueOf(order.getUsedPoints())
-                .multiply(cancelRatio).setScale(0, RoundingMode.DOWN).longValue();
-
-        BigDecimal refundAmount = cancelledSubtotal
-                .subtract(proportionalDiscount)
-                .subtract(BigDecimal.valueOf(proportionalPoints))
-                .max(BigDecimal.ZERO);
-
-        return new CancelItemsContext(refundAmount, proportionalPoints);
-    }
-
-    /**
-     * [Short TX] 아이템 취소 + 재고 해제 + 포인트 반환 + 주문 상태 전이.
-     */
-    @Transactional
-    @CacheEvict(cacheNames = "orders", key = "#orderId")
-    OrderItemCancelResponse applyItemCancel(Long orderId, List<Long> itemIds, String reason,
-                                            BigDecimal refundAmount, long pointsToRefund) {
-        Order order = orderRepository.findByIdWithItemsForUpdate(orderId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
-
-        OrderStatus previousStatus = order.getStatus();
-        Set<Long> requestedIds = new HashSet<>(itemIds);
-
-        // 아이템 취소 + 재고 해제
-        List<OrderItemResponse> cancelledResponses = new ArrayList<>();
-        for (OrderItem item : order.getItems()) {
-            if (requestedIds.contains(item.getId()) && item.isActive()) {
-                item.cancel();
-                inventoryService.releaseAllocation(item.getVariant().getId(), item.getQuantity());
-                cancelledResponses.add(OrderItemResponse.from(item));
-            }
-        }
-
-        // 비례 포인트 반환
-        if (pointsToRefund > 0) {
-            pointService.refundPartial(order.getUserId(), orderId, pointsToRefund);
-        }
-
-        // 주문 상태 전이
-        order.partialCancel(reason);
-
-        // 모든 아이템 취소 → 쿠폰 반환 + EARN 포인트 처리
-        if (order.isAllItemsCancelled()) {
-            couponService.releaseCoupon(orderId);
-            pointService.expirePending(orderId);
-        }
-
-        recordHistory(orderId, previousStatus, order.getStatus(),
-                "partial-cancel:items=" + itemIds);
-        outboxEventStore.save(new OrderCancelledEvent(
-                orderId, order.getUserId(), "PARTIAL_ITEM_CANCELLED"));
-
-        return OrderItemCancelResponse.builder()
-                .orderId(orderId)
-                .orderStatus(order.getStatus().name())
-                .refundAmount(refundAmount)
-                .refundedPoints(pointsToRefund)
-                .cancelledItems(cancelledResponses)
-                .build();
-    }
-
-    /** 부분 취소 검증 결과 컨텍스트. */
-    record CancelItemsContext(BigDecimal refundAmount, long pointsToRefund) {}
 
     /**
      * 회원 탈퇴 시 사용자의 모든 PENDING 주문을 강제 취소한다.

--- a/src/main/java/com/stockmanagement/domain/order/service/OrderItemCancelTransactionHelper.java
+++ b/src/main/java/com/stockmanagement/domain/order/service/OrderItemCancelTransactionHelper.java
@@ -1,0 +1,188 @@
+package com.stockmanagement.domain.order.service;
+
+import com.stockmanagement.common.exception.BusinessException;
+import com.stockmanagement.common.exception.ErrorCode;
+import com.stockmanagement.common.event.OrderCancelledEvent;
+import com.stockmanagement.common.outbox.OutboxEventStore;
+import com.stockmanagement.domain.coupon.service.CouponService;
+import com.stockmanagement.domain.inventory.service.InventoryService;
+import com.stockmanagement.domain.order.dto.OrderItemCancelResponse;
+import com.stockmanagement.domain.order.dto.OrderItemResponse;
+import com.stockmanagement.domain.order.entity.Order;
+import com.stockmanagement.domain.order.entity.OrderItem;
+import com.stockmanagement.domain.order.entity.OrderStatus;
+import com.stockmanagement.domain.order.entity.OrderStatusHistory;
+import com.stockmanagement.domain.order.repository.OrderRepository;
+import com.stockmanagement.domain.order.repository.OrderStatusHistoryRepository;
+import com.stockmanagement.domain.point.service.PointService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * 주문 아이템 부분 취소의 DB 연산을 단기 트랜잭션으로 분리하는 헬퍼.
+ *
+ * <p>{@link OrderCommandService#cancelItems}는 Toss 부분 환불(외부 HTTP)을 사이에 두고
+ * 검증([Short TX])과 적용([Short TX])을 실행한다. 같은 클래스 내부 호출(self-invocation)은
+ * 프록시를 우회하여 {@code @Transactional}이 적용되지 않으므로 별도 빈으로 분리한다.
+ * ({@code PaymentTransactionHelper}와 동일한 패턴)
+ */
+@Service
+@RequiredArgsConstructor
+class OrderItemCancelTransactionHelper {
+
+    private final OrderRepository orderRepository;
+    private final InventoryService inventoryService;
+    private final OrderStatusHistoryRepository historyRepository;
+    private final CouponService couponService;
+    private final PointService pointService;
+    private final OutboxEventStore outboxEventStore;
+
+    /** 부분 취소 검증 결과 컨텍스트. */
+    record CancelItemsContext(BigDecimal refundAmount, long pointsToRefund) {}
+
+    /**
+     * [Short TX] 부분 취소 검증 + 환불 금액 계산.
+     */
+    @Transactional
+    CancelItemsContext validateAndPrepare(Long orderId, Long userId, boolean isAdmin,
+                                          List<Long> itemIds) {
+        Order order = orderRepository.findByIdWithItemsForUpdate(orderId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
+
+        validateOrderOwnership(order, userId, isAdmin);
+
+        // CONFIRMED 또는 PARTIAL_CANCELLED 상태만 부분 취소 가능
+        if (order.getStatus() != OrderStatus.CONFIRMED
+                && order.getStatus() != OrderStatus.PARTIAL_CANCELLED) {
+            throw new BusinessException(ErrorCode.INVALID_ORDER_STATUS);
+        }
+
+        // 요청 아이템 검증
+        Set<Long> requestedIds = new HashSet<>(itemIds);
+        Map<Long, OrderItem> itemMap = order.getItems().stream()
+                .collect(Collectors.toMap(OrderItem::getId, i -> i));
+
+        List<OrderItem> targetItems = new ArrayList<>();
+        for (Long itemId : requestedIds) {
+            OrderItem item = itemMap.get(itemId);
+            if (item == null) {
+                throw new BusinessException(ErrorCode.ORDER_ITEM_NOT_FOUND);
+            }
+            if (!item.isActive()) {
+                throw new BusinessException(ErrorCode.ORDER_ITEM_ALREADY_CANCELLED);
+            }
+            targetItems.add(item);
+        }
+
+        // 환불 금액 계산 (비례 안분)
+        BigDecimal cancelledSubtotal = targetItems.stream()
+                .map(OrderItem::getSubtotal)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        BigDecimal cancelRatio = cancelledSubtotal.divide(
+                order.getTotalAmount(), 10, RoundingMode.DOWN);
+
+        BigDecimal proportionalDiscount = order.getDiscountAmount()
+                .multiply(cancelRatio).setScale(0, RoundingMode.DOWN);
+
+        long proportionalPoints = BigDecimal.valueOf(order.getUsedPoints())
+                .multiply(cancelRatio).setScale(0, RoundingMode.DOWN).longValue();
+
+        BigDecimal refundAmount = cancelledSubtotal
+                .subtract(proportionalDiscount)
+                .subtract(BigDecimal.valueOf(proportionalPoints))
+                .max(BigDecimal.ZERO);
+
+        return new CancelItemsContext(refundAmount, proportionalPoints);
+    }
+
+    /**
+     * [Short TX] 아이템 취소 + 재고 해제 + 포인트 반환 + 주문 상태 전이.
+     */
+    @Transactional
+    @CacheEvict(cacheNames = "orders", key = "#orderId")
+    OrderItemCancelResponse applyItemCancel(Long orderId, List<Long> itemIds, String reason,
+                                            BigDecimal refundAmount, long pointsToRefund) {
+        Order order = orderRepository.findByIdWithItemsForUpdate(orderId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
+
+        OrderStatus previousStatus = order.getStatus();
+        Set<Long> requestedIds = new HashSet<>(itemIds);
+
+        // 아이템 취소 + 재고 해제
+        List<OrderItemResponse> cancelledResponses = new ArrayList<>();
+        for (OrderItem item : order.getItems()) {
+            if (requestedIds.contains(item.getId()) && item.isActive()) {
+                item.cancel();
+                inventoryService.releaseAllocation(item.getVariant().getId(), item.getQuantity());
+                cancelledResponses.add(OrderItemResponse.from(item));
+            }
+        }
+
+        // 비례 포인트 반환
+        if (pointsToRefund > 0) {
+            pointService.refundPartial(order.getUserId(), orderId, pointsToRefund);
+        }
+
+        // 주문 상태 전이
+        order.partialCancel(reason);
+
+        // 모든 아이템 취소 → 쿠폰 반환 + EARN 포인트 처리
+        if (order.isAllItemsCancelled()) {
+            couponService.releaseCoupon(orderId);
+            pointService.expirePending(orderId);
+        }
+
+        recordHistory(orderId, previousStatus, order.getStatus(),
+                "partial-cancel:items=" + itemIds);
+        outboxEventStore.save(new OrderCancelledEvent(
+                orderId, order.getUserId(), "PARTIAL_ITEM_CANCELLED"));
+
+        return OrderItemCancelResponse.builder()
+                .orderId(orderId)
+                .orderStatus(order.getStatus().name())
+                .refundAmount(refundAmount)
+                .refundedPoints(pointsToRefund)
+                .cancelledItems(cancelledResponses)
+                .build();
+    }
+
+    private void validateOrderOwnership(Order order, Long userId, boolean isAdmin) {
+        if (!isAdmin && !order.getUserId().equals(userId)) {
+            throw new BusinessException(ErrorCode.ORDER_ACCESS_DENIED);
+        }
+    }
+
+    private String currentUser() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated() || "anonymousUser".equals(auth.getPrincipal())) {
+            return "system";
+        }
+        return auth.getName();
+    }
+
+    private void recordHistory(Long orderId, OrderStatus from, OrderStatus to, String note) {
+        historyRepository.save(
+                OrderStatusHistory.builder()
+                        .orderId(orderId)
+                        .fromStatus(from)
+                        .toStatus(to)
+                        .changedBy(currentUser())
+                        .note(note)
+                        .build()
+        );
+    }
+}

--- a/src/test/java/com/stockmanagement/integration/OrderItemCancelIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/OrderItemCancelIntegrationTest.java
@@ -1,0 +1,234 @@
+package com.stockmanagement.integration;
+
+import com.stockmanagement.domain.payment.infrastructure.TossPaymentsClient;
+import com.stockmanagement.domain.payment.infrastructure.TossWebhookVerifier;
+import com.stockmanagement.domain.payment.infrastructure.dto.TossConfirmResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 주문 아이템 부분 취소 통합 테스트.
+ *
+ * <p>cancelItems()는 분산 락 + Toss 부분 환불(외부 HTTP)을 사이에 둔 Short TX 2개로 구성된다.
+ * 회귀 검증 대상 (#200): Short TX가 프록시를 경유하지 않으면(self-invocation)
+ * 아이템 취소·주문 상태 전이가 DB에 영속화되지 않아 동일 아이템 재취소로
+ * Toss 중복 환불·재고 이중 해제가 가능해진다.
+ *
+ * <p>TossPaymentsClient(외부 API)는 {@link MockBean}으로 대체한다.
+ */
+@DisplayName("주문 아이템 부분 취소 통합 테스트")
+class OrderItemCancelIntegrationTest extends AbstractIntegrationTest {
+
+    @MockBean TossPaymentsClient tossPaymentsClient;
+    @MockBean TossWebhookVerifier tossWebhookVerifier;
+
+    @Test
+    @DisplayName("부분 취소 → 상태 영속화 + 재고 해제, 동일 아이템 재취소 409, 전체 취소 시 CANCELLED")
+    void partialCancel_persistsState_andRejectsDoubleCancel() throws Exception {
+        // ===== 준비: 상품 2개 등록 + 입고 =====
+        String adminToken = createAdminAndLogin("admin_ic1", "adminpass1!", "aic1@test.com");
+        String userToken = signupAndLogin("buyer_ic1", "Password1!", "bic1@test.com");
+        long userId = userRepository.findByUsername("buyer_ic1").orElseThrow().getId();
+
+        TestProduct productA = createProductWithStock(adminToken, "ITEM-CXL-A", 10_000, 10);
+        TestProduct productB = createProductWithStock(adminToken, "ITEM-CXL-B", 5_000, 10);
+        long variantA = productA.variantId();
+        long variantB = productB.variantId();
+
+        // ===== 주문 생성 (A x1 + B x2 = 20000) =====
+        String orderBody = mockMvc.perform(post("/api/v1/orders")
+                        .header("Authorization", "Bearer " + userToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(String.format(
+                                "{\"userId\":%d,\"idempotencyKey\":\"item-cancel-001\",\"items\":[" +
+                                "{\"productId\":%d,\"variantId\":%d,\"quantity\":1,\"unitPrice\":10000}," +
+                                "{\"productId\":%d,\"variantId\":%d,\"quantity\":2,\"unitPrice\":5000}]}",
+                                userId, productA.productId(), variantA, productB.productId(), variantB)))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        long orderId = objectMapper.readTree(orderBody).path("data").path("id").asLong();
+
+        // ===== 결제 확정 (Toss confirm mock) → CONFIRMED =====
+        confirmPayment(userToken, orderId, 20_000);
+
+        long itemA = findItemIdByVariant(userToken, orderId, variantA);
+        long itemB = findItemIdByVariant(userToken, orderId, variantB);
+
+        // 확정 후 재고: A allocated=1 (available 9)
+        assertInventory(adminToken, variantA, 1, 9);
+
+        // ===== 1차 부분 취소 (아이템 A) → PARTIAL_CANCELLED =====
+        mockMvc.perform(post("/api/v1/orders/" + orderId + "/items/cancel")
+                        .header("Authorization", "Bearer " + userToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(String.format("{\"itemIds\":[%d],\"reason\":\"단순 변심\"}", itemA)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.orderStatus").value("PARTIAL_CANCELLED"))
+                .andExpect(jsonPath("$.data.refundAmount").value(10000));
+
+        // 상태 영속화 검증 — 주문 PARTIAL_CANCELLED, 아이템 A만 CANCELLED (#200 회귀 핵심)
+        mockMvc.perform(get("/api/v1/orders/" + orderId)
+                        .header("Authorization", "Bearer " + userToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value("PARTIAL_CANCELLED"))
+                .andExpect(jsonPath("$.data.items[?(@.id == " + itemA + ")].status").value("CANCELLED"))
+                .andExpect(jsonPath("$.data.items[?(@.id == " + itemB + ")].status").value("ACTIVE"));
+
+        // 재고 해제 검증 — A allocated 0, available 복원
+        assertInventory(adminToken, variantA, 0, 10);
+
+        // ===== 동일 아이템 재취소 → 409, Toss 재환불 없음 =====
+        mockMvc.perform(post("/api/v1/orders/" + orderId + "/items/cancel")
+                        .header("Authorization", "Bearer " + userToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(String.format("{\"itemIds\":[%d]}", itemA)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.success").value(false));
+
+        // Toss 부분 환불은 1차 취소 때 1회만 호출되어야 한다 (중복 환불 방지)
+        then(tossPaymentsClient).should(times(1)).cancel(any(), any());
+
+        // 재고 이중 해제 없음
+        assertInventory(adminToken, variantA, 0, 10);
+
+        // ===== 남은 아이템 B 취소 → 전체 CANCELLED =====
+        mockMvc.perform(post("/api/v1/orders/" + orderId + "/items/cancel")
+                        .header("Authorization", "Bearer " + userToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(String.format("{\"itemIds\":[%d]}", itemB)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.orderStatus").value("CANCELLED"))
+                .andExpect(jsonPath("$.data.refundAmount").value(10000));
+
+        mockMvc.perform(get("/api/v1/orders/" + orderId)
+                        .header("Authorization", "Bearer " + userToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value("CANCELLED"));
+
+        assertInventory(adminToken, variantB, 0, 10);
+    }
+
+    @Test
+    @DisplayName("PENDING 주문 부분 취소 시도 → 409")
+    void partialCancel_pendingOrder_409() throws Exception {
+        String adminToken = createAdminAndLogin("admin_ic2", "adminpass2!", "aic2@test.com");
+        String userToken = signupAndLogin("buyer_ic2", "Password1!", "bic2@test.com");
+        long userId = userRepository.findByUsername("buyer_ic2").orElseThrow().getId();
+
+        TestProduct product = createProductWithStock(adminToken, "ITEM-CXL-C", 3_000, 5);
+        long variantId = product.variantId();
+
+        String orderBody = mockMvc.perform(post("/api/v1/orders")
+                        .header("Authorization", "Bearer " + userToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(String.format(
+                                "{\"userId\":%d,\"idempotencyKey\":\"item-cancel-002\",\"items\":[" +
+                                "{\"productId\":%d,\"variantId\":%d,\"quantity\":1,\"unitPrice\":3000}]}",
+                                userId, product.productId(), variantId)))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        long orderId = objectMapper.readTree(orderBody).path("data").path("id").asLong();
+        long itemId = findItemIdByVariant(userToken, orderId, variantId);
+
+        // 결제 전(PENDING) 부분 취소 불가
+        mockMvc.perform(post("/api/v1/orders/" + orderId + "/items/cancel")
+                        .header("Authorization", "Bearer " + userToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(String.format("{\"itemIds\":[%d]}", itemId)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.success").value(false));
+    }
+
+    // ===== 헬퍼 =====
+
+    /** 테스트용 상품 식별자 홀더. */
+    private record TestProduct(long productId, long variantId) {}
+
+    /** 상품 등록 + 입고 후 productId·기본 variantId를 반환한다. */
+    private TestProduct createProductWithStock(String adminToken, String sku, int price, int quantity) throws Exception {
+        String productBody = mockMvc.perform(post("/api/v1/products")
+                        .header("Authorization", "Bearer " + adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(String.format(
+                                "{\"name\":\"%s\",\"sku\":\"%s\",\"price\":%d}", sku, sku, price)))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        long productId = objectMapper.readTree(productBody).path("data").path("id").asLong();
+        long variantId = getDefaultVariantId(productId);
+
+        mockMvc.perform(post("/api/v1/inventory/variants/" + variantId + "/receive")
+                        .header("Authorization", "Bearer " + adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(String.format("{\"quantity\":%d}", quantity)))
+                .andExpect(status().isOk());
+        return new TestProduct(productId, variantId);
+    }
+
+    /** prepare → Toss confirm(mock) → confirm 호출로 주문을 CONFIRMED 상태로 만든다. */
+    private void confirmPayment(String userToken, long orderId, int amount) throws Exception {
+        String prepareBody = mockMvc.perform(post("/api/v1/payments/prepare")
+                        .header("Authorization", "Bearer " + userToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(String.format("{\"orderId\":%d,\"amount\":%d}", orderId, amount)))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        String tossOrderId = objectMapper.readTree(prepareBody).path("data").path("tossOrderId").asText();
+
+        TossConfirmResponse tossResponse = new TossConfirmResponse();
+        setField(tossResponse, "paymentKey", "pk-item-cancel-" + orderId);
+        setField(tossResponse, "status", "DONE");
+        setField(tossResponse, "method", "카드");
+        setField(tossResponse, "requestedAt", "2026-01-01T00:00:00+09:00");
+        setField(tossResponse, "approvedAt", "2026-01-01T00:00:01+09:00");
+        given(tossPaymentsClient.confirm(any())).willReturn(tossResponse);
+
+        mockMvc.perform(post("/api/v1/payments/confirm")
+                        .header("Authorization", "Bearer " + userToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(String.format(
+                                "{\"paymentKey\":\"pk-item-cancel-%d\",\"tossOrderId\":\"%s\",\"amount\":%d}",
+                                orderId, tossOrderId, amount)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value("DONE"));
+    }
+
+    /** 주문 조회 응답에서 variantId에 해당하는 아이템 ID를 찾는다. */
+    private long findItemIdByVariant(String userToken, long orderId, long variantId) throws Exception {
+        String body = mockMvc.perform(get("/api/v1/orders/" + orderId)
+                        .header("Authorization", "Bearer " + userToken))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        for (var item : objectMapper.readTree(body).path("data").path("items")) {
+            if (item.path("variantId").asLong() == variantId) {
+                return item.path("id").asLong();
+            }
+        }
+        throw new AssertionError("variantId=" + variantId + " 아이템을 주문에서 찾을 수 없음");
+    }
+
+    /** 재고의 allocated·available 값을 검증한다. */
+    private void assertInventory(String adminToken, long variantId, int allocated, int available) throws Exception {
+        mockMvc.perform(get("/api/v1/inventory/variants/" + variantId)
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.allocated").value(allocated))
+                .andExpect(jsonPath("$.data.available").value(available));
+    }
+
+    private void setField(Object target, String fieldName, Object value) throws Exception {
+        java.lang.reflect.Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+}


### PR DESCRIPTION
## 개요

`OrderCommandService.cancelItems()`가 `@Transactional(NOT_SUPPORTED)` 상태에서 같은 클래스의 `validateAndPrepare()`·`applyItemCancel()`을 `this`로 직접 호출하여, 프록시 우회(self-invocation)로 두 메서드의 `@Transactional`·`@CacheEvict`가 적용되지 않던 문제를 수정한다.

`spring.jpa.open-in-view=false` 환경에서 실제 영향:

- `findByIdWithItemsForUpdate`의 `FOR UPDATE` 락이 리포지토리 단기 TX 종료 시 즉시 해제
- 반환된 Order/OrderItem은 detached → `item.cancel()`, `order.partialCancel()` 변경이 **DB에 저장되지 않음**
- 재고 해제·포인트 반환·이력·아웃박스는 각자 프록시 TX로 커밋 → **정합성 붕괴**
- 동일 아이템 재취소가 검증을 통과 → **Toss 중복 환불 + 재고 이중 해제 반복 가능**

## 변경 내용

- `OrderItemCancelTransactionHelper` 신설 — `validateAndPrepare`/`applyItemCancel`을 별도 빈의 Short TX로 이동 (`PaymentTransactionHelper`와 동일 패턴)
- `OrderCommandService.cancelItems()`는 헬퍼 경유로 오케스트레이션만 수행 (분산 락 + Toss 호출 위치 불변)
- 로직 변경 없음 — 메서드 본문은 그대로 이동

## 테스트

- `OrderItemCancelIntegrationTest` 신규 (기존 커버리지 0건):
  - 부분 취소 → 주문 `PARTIAL_CANCELLED`·아이템 `CANCELLED` **영속화** 검증 (#200 회귀 핵심)
  - 재고 `allocated` 해제 검증
  - 동일 아이템 재취소 → 409 + **Toss 재환불 호출 없음**(`times(1)`) + 재고 이중 해제 없음
  - 남은 아이템 전체 취소 → `CANCELLED` 전이
  - PENDING 주문 부분 취소 → 409
- 전체 테스트 통과 (`./gradlew test` BUILD SUCCESSFUL)

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)