### PR TITLE
fix: reserve() 저재고 경보 기준값 계산 오류 수정 (#201)

### DIFF
--- a/src/main/java/com/stockmanagement/domain/inventory/service/InventoryService.java
+++ b/src/main/java/com/stockmanagement/domain/inventory/service/InventoryService.java
@@ -189,7 +189,7 @@ public class InventoryService {
     @CacheEvict(cacheNames = "inventory", key = "#variantId")
     public void reserve(Long variantId, int quantity) {
         Inventory inventory = findByVariantIdWithLock(variantId);
-        int availableBefore = inventory.getAvailable() + quantity; // reserve 전 가용 재고
+        int availableBefore = inventory.getAvailable(); // reserve 전 가용 재고
         inventory.reserve(quantity);
         recordTransaction(inventory, InventoryTransactionType.RESERVE, quantity);
 

--- a/src/test/java/com/stockmanagement/domain/inventory/service/InventoryServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/inventory/service/InventoryServiceTest.java
@@ -245,6 +245,31 @@ class InventoryServiceTest {
         }
 
         @Test
+        @DisplayName("가용 재고가 임계값을 하향 돌파하면 LowStockEvent를 발행한다")
+        void publishesLowStockEventOnThresholdCrossing() {
+            // onHand=15, reserved=3 → available=12 (임계값 10 이상)
+            Inventory inventory = Inventory.builder().variant(variant).build();
+            inventory.receive(15);
+            inventory.reserve(3);
+            given(inventoryRepository.findByVariantIdWithLock(1L)).willReturn(Optional.of(inventory));
+
+            inventoryService.reserve(1L, 5); // available 12 → 7 (임계값 하향 돌파)
+
+            verify(eventPublisher).publishEvent(any(com.stockmanagement.common.event.LowStockEvent.class));
+        }
+
+        @Test
+        @DisplayName("이미 임계값 미만인 재고는 LowStockEvent를 재발행하지 않는다")
+        void doesNotRepublishLowStockEventWhenAlreadyBelowThreshold() {
+            Inventory inventory = inventoryWithStock(); // available=7 (임계값 10 미만)
+            given(inventoryRepository.findByVariantIdWithLock(1L)).willReturn(Optional.of(inventory));
+
+            inventoryService.reserve(1L, 5); // available 7 → 2 (이미 미만 → 중복 경보 없음)
+
+            verify(eventPublisher, never()).publishEvent(any(com.stockmanagement.common.event.LowStockEvent.class));
+        }
+
+        @Test
         @DisplayName("가용 재고 부족 시 InsufficientStockException이 전파된다")
         void propagatesInsufficientStockException() {
             Inventory inventory = inventoryWithStock(); // available=7


### PR DESCRIPTION
## 개요

`InventoryService.reserve()`에서 저재고 경보 기준값(`availableBefore`)이 `reserve()` 호출 **전**에 계산되는데도 `+ quantity`를 더해 기준값이 부풀려지던 버그를 수정한다.

## 문제

```java
int availableBefore = inventory.getAvailable() + quantity; // 이 시점 getAvailable()이 이미 'reserve 전' 값
inventory.reserve(quantity);
```

임계값 하향 돌파 감지 조건이 `availableBefore >= threshold && after < threshold`인데, 기준값이 `quantity`만큼 부풀려져 **이미 임계값 미만인 재고에서도 주문마다 LowStockEvent가 재발행**됐다 (관리자 중복 경보 메일).

예: threshold=10, available=7(이미 미만), quantity=5 → before가 12로 계산되어 이벤트 재발행.

## 변경

- `+ quantity` 제거 (한 줄)
- 회귀 테스트 2건 추가:
  - 임계값 하향 돌파(12→7) 시 `LowStockEvent` 발행
  - 이미 임계값 미만(7→2)이면 재발행 없음 — 수정 전 코드에서는 실패하는 테스트

## 테스트

`InventoryServiceTest` 전체 통과.

Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)