### PR TITLE
fix: 재고 락 획득 순서 통일 (#202) dev 반영

### DIFF
--- a/src/main/java/com/stockmanagement/domain/order/entity/Order.java
+++ b/src/main/java/com/stockmanagement/domain/order/entity/Order.java
@@ -15,6 +15,7 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 /**
@@ -262,6 +263,18 @@ public class Order {
     /** ACTIVE 상태인 아이템만 반환한다. */
     public List<OrderItem> getActiveItems() {
         return items.stream().filter(OrderItem::isActive).toList();
+    }
+
+    /**
+     * variantId 오름차순으로 정렬된 아이템을 반환한다.
+     *
+     * <p>재고 비관적 락을 다건으로 획득하는 모든 경로(예약·확정·해제)는
+     * 반드시 이 순서를 사용해야 한다 — 획득 순서가 다르면 동시 요청 간 데드락이 발생할 수 있다.
+     */
+    public List<OrderItem> getItemsSortedByVariant() {
+        return items.stream()
+                .sorted(Comparator.comparing(i -> i.getVariant().getId()))
+                .toList();
     }
 
     /**

--- a/src/main/java/com/stockmanagement/domain/order/service/OrderCommandService.java
+++ b/src/main/java/com/stockmanagement/domain/order/service/OrderCommandService.java
@@ -185,9 +185,9 @@ public class OrderCommandService {
         }
 
         // 6. 재고 예약 (variantId 오름차순 — 데드락 방지)
-        savedOrder.getItems().stream()
-                .sorted(java.util.Comparator.comparing(i -> i.getVariant().getId()))
-                .forEach(item -> inventoryService.reserve(item.getVariant().getId(), item.getQuantity()));
+        for (OrderItem item : savedOrder.getItemsSortedByVariant()) {
+            inventoryService.reserve(item.getVariant().getId(), item.getQuantity());
+        }
 
         // 7. 쿠폰 적용
         if (request.getCouponCode() != null && !request.getCouponCode().isBlank()) {
@@ -232,7 +232,8 @@ public class OrderCommandService {
         OrderStatus previousStatus = order.getStatus();
         order.cancel(reason);
 
-        for (OrderItem item : order.getItems()) {
+        // variantId 오름차순 — 재고 락 획득 순서 통일 (데드락 방지)
+        for (OrderItem item : order.getItemsSortedByVariant()) {
             inventoryService.releaseReservation(item.getVariant().getId(), item.getQuantity());
         }
 
@@ -256,7 +257,8 @@ public class OrderCommandService {
         OrderStatus previousStatus = order.getStatus();
         order.cancel(null);
 
-        for (OrderItem item : order.getItems()) {
+        // variantId 오름차순 — 재고 락 획득 순서 통일 (데드락 방지)
+        for (OrderItem item : order.getItemsSortedByVariant()) {
             inventoryService.releaseReservation(item.getVariant().getId(), item.getQuantity());
         }
 

--- a/src/main/java/com/stockmanagement/domain/order/service/OrderItemCancelTransactionHelper.java
+++ b/src/main/java/com/stockmanagement/domain/order/service/OrderItemCancelTransactionHelper.java
@@ -122,9 +122,9 @@ class OrderItemCancelTransactionHelper {
         OrderStatus previousStatus = order.getStatus();
         Set<Long> requestedIds = new HashSet<>(itemIds);
 
-        // 아이템 취소 + 재고 해제
+        // 아이템 취소 + 재고 해제 (variantId 오름차순 — 재고 락 획득 순서 통일, 데드락 방지)
         List<OrderItemResponse> cancelledResponses = new ArrayList<>();
-        for (OrderItem item : order.getItems()) {
+        for (OrderItem item : order.getItemsSortedByVariant()) {
             if (requestedIds.contains(item.getId()) && item.isActive()) {
                 item.cancel();
                 inventoryService.releaseAllocation(item.getVariant().getId(), item.getQuantity());

--- a/src/main/java/com/stockmanagement/domain/order/service/OrderPaymentService.java
+++ b/src/main/java/com/stockmanagement/domain/order/service/OrderPaymentService.java
@@ -54,7 +54,8 @@ public class OrderPaymentService {
         OrderStatus previousStatus = order.getStatus();
         order.confirm();
 
-        for (OrderItem item : order.getItems()) {
+        // variantId 오름차순 — 재고 락 획득 순서 통일 (데드락 방지)
+        for (OrderItem item : order.getItemsSortedByVariant()) {
             inventoryService.confirmAllocation(item.getVariant().getId(), item.getQuantity());
         }
 
@@ -79,8 +80,11 @@ public class OrderPaymentService {
         order.refund();
 
         // ACTIVE 아이템만 재고 해제 — 부분 취소로 이미 CANCELLED된 아이템은 건너뜀
-        for (OrderItem item : order.getActiveItems()) {
-            inventoryService.releaseAllocation(item.getVariant().getId(), item.getQuantity());
+        // variantId 오름차순 — 재고 락 획득 순서 통일 (데드락 방지)
+        for (OrderItem item : order.getItemsSortedByVariant()) {
+            if (item.isActive()) {
+                inventoryService.releaseAllocation(item.getVariant().getId(), item.getQuantity());
+            }
         }
 
         couponService.releaseCoupon(order.getId());
@@ -108,7 +112,8 @@ public class OrderPaymentService {
         OrderStatus previousStatus = order.getStatus();
         order.cancelByWebhook(reason);
 
-        for (OrderItem item : order.getItems()) {
+        // variantId 오름차순 — 재고 락 획득 순서 통일 (데드락 방지)
+        for (OrderItem item : order.getItemsSortedByVariant()) {
             inventoryService.releaseReservation(item.getVariant().getId(), item.getQuantity());
         }
 

--- a/src/test/java/com/stockmanagement/domain/order/entity/OrderTest.java
+++ b/src/test/java/com/stockmanagement/domain/order/entity/OrderTest.java
@@ -1,0 +1,46 @@
+package com.stockmanagement.domain.order.entity;
+
+import com.stockmanagement.domain.product.entity.ProductVariant;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@DisplayName("Order 엔티티 단위 테스트")
+class OrderTest {
+
+    @Test
+    @DisplayName("getItemsSortedByVariant()는 variantId 오름차순으로 반환한다 — 재고 락 획득 순서 통일")
+    void getItemsSortedByVariant_returnsAscendingVariantIdOrder() {
+        Order order = Order.builder()
+                .userId(1L)
+                .totalAmount(BigDecimal.valueOf(10_000))
+                .idempotencyKey("sort-test-001")
+                .build();
+
+        // 삽입 순서: variantId 3 → 1 → 2
+        order.addItem(itemWithVariantId(3L));
+        order.addItem(itemWithVariantId(1L));
+        order.addItem(itemWithVariantId(2L));
+
+        assertThat(order.getItemsSortedByVariant())
+                .extracting(i -> i.getVariant().getId())
+                .containsExactly(1L, 2L, 3L);
+        // 원본 items 순서는 변경되지 않는다
+        assertThat(order.getItems())
+                .extracting(i -> i.getVariant().getId())
+                .containsExactly(3L, 1L, 2L);
+    }
+
+    private OrderItem itemWithVariantId(Long variantId) {
+        ProductVariant variant = mock(ProductVariant.class);
+        given(variant.getId()).willReturn(variantId);
+        OrderItem item = mock(OrderItem.class);
+        given(item.getVariant()).willReturn(variant);
+        return item;
+    }
+}


### PR DESCRIPTION
## 개요

PR #206(#202 수정)이 스택 base였던 `fix/order-item-cancel-self-invocation` 브랜치로 머지되어 dev에 반영되지 않았다 (#204는 그 이전에 dev로 머지됨). 해당 브랜치에 남아 있는 #202 변경분을 dev로 가져온다.

## 내용

PR #206과 동일 — `Order.getItemsSortedByVariant()` 신설 및 다건 재고 락 경로 7곳 정렬 적용. 상세는 #206 참고.

Refs #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)