### PR TITLE
release: 코드 리뷰 후속 수정 반영 (#200, #201, #202)

### DIFF
--- a/src/main/java/com/stockmanagement/domain/inventory/service/InventoryService.java
+++ b/src/main/java/com/stockmanagement/domain/inventory/service/InventoryService.java
@@ -189,7 +189,7 @@ public class InventoryService {
     @CacheEvict(cacheNames = "inventory", key = "#variantId")
     public void reserve(Long variantId, int quantity) {
         Inventory inventory = findByVariantIdWithLock(variantId);
-        int availableBefore = inventory.getAvailable() + quantity; // reserve 전 가용 재고
+        int availableBefore = inventory.getAvailable(); // reserve 전 가용 재고
         inventory.reserve(quantity);
         recordTransaction(inventory, InventoryTransactionType.RESERVE, quantity);
 

--- a/src/main/java/com/stockmanagement/domain/order/entity/Order.java
+++ b/src/main/java/com/stockmanagement/domain/order/entity/Order.java
@@ -15,6 +15,7 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 /**
@@ -262,6 +263,18 @@ public class Order {
     /** ACTIVE 상태인 아이템만 반환한다. */
     public List<OrderItem> getActiveItems() {
         return items.stream().filter(OrderItem::isActive).toList();
+    }
+
+    /**
+     * variantId 오름차순으로 정렬된 아이템을 반환한다.
+     *
+     * <p>재고 비관적 락을 다건으로 획득하는 모든 경로(예약·확정·해제)는
+     * 반드시 이 순서를 사용해야 한다 — 획득 순서가 다르면 동시 요청 간 데드락이 발생할 수 있다.
+     */
+    public List<OrderItem> getItemsSortedByVariant() {
+        return items.stream()
+                .sorted(Comparator.comparing(i -> i.getVariant().getId()))
+                .toList();
     }
 
     /**

--- a/src/main/java/com/stockmanagement/domain/order/service/OrderCommandService.java
+++ b/src/main/java/com/stockmanagement/domain/order/service/OrderCommandService.java
@@ -12,7 +12,6 @@ import com.stockmanagement.domain.order.dto.OrderCreateRequest;
 import com.stockmanagement.domain.order.dto.OrderItemCancelRequest;
 import com.stockmanagement.domain.order.dto.OrderItemCancelResponse;
 import com.stockmanagement.domain.order.dto.OrderItemRequest;
-import com.stockmanagement.domain.order.dto.OrderItemResponse;
 import com.stockmanagement.domain.order.dto.OrderResponse;
 import com.stockmanagement.domain.order.entity.Order;
 import com.stockmanagement.domain.order.entity.OrderItem;
@@ -40,13 +39,11 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -71,6 +68,7 @@ public class OrderCommandService {
     private final OutboxEventStore outboxEventStore;
     private final DeliveryAddressService deliveryAddressService;
     private final OrderDeliverySnapshotRepository deliverySnapshotRepository;
+    private final OrderItemCancelTransactionHelper itemCancelTxHelper;
 
     /**
      * 주문을 생성한다 (내부 호출 전용 — 장바구니 결제 등).
@@ -283,133 +281,27 @@ public class OrderCommandService {
      *   <li>[No TX] Toss 부분 환불 API 호출
      *   <li>[Short TX] 아이템 CANCELLED 처리 + 재고 해제 + 포인트 반환 + 주문 상태 전이
      * </ol>
+     *
+     * <p>Short TX는 {@link OrderItemCancelTransactionHelper} 별도 빈으로 실행한다.
+     * 같은 클래스 내부 호출(self-invocation)은 프록시를 우회하여 {@code @Transactional}이
+     * 적용되지 않으므로 반드시 헬퍼를 경유해야 한다.
      */
     @DistributedLock(key = "'order-item-cancel:' + #orderId")
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public OrderItemCancelResponse cancelItems(Long orderId, Long userId, boolean isAdmin,
                                                OrderItemCancelRequest request) {
         // 1. Short TX: 검증 + 환불 금액 계산
-        CancelItemsContext ctx = validateAndPrepare(orderId, userId, isAdmin, request.getItemIds());
+        var ctx = itemCancelTxHelper.validateAndPrepare(orderId, userId, isAdmin, request.getItemIds());
 
         // 2. Toss 부분 환불 (DB 커넥션 미점유)
-        if (ctx.refundAmount.compareTo(BigDecimal.ZERO) > 0) {
-            paymentService.cancelPartialForItems(orderId, ctx.refundAmount, request.getReason());
+        if (ctx.refundAmount().compareTo(BigDecimal.ZERO) > 0) {
+            paymentService.cancelPartialForItems(orderId, ctx.refundAmount(), request.getReason());
         }
 
         // 3. Short TX: 아이템 취소 + 재고 해제 + 포인트 반환 + 주문 상태 전이
-        return applyItemCancel(orderId, request.getItemIds(), request.getReason(),
-                ctx.refundAmount, ctx.pointsToRefund);
+        return itemCancelTxHelper.applyItemCancel(orderId, request.getItemIds(), request.getReason(),
+                ctx.refundAmount(), ctx.pointsToRefund());
     }
-
-    /**
-     * [Short TX] 부분 취소 검증 + 환불 금액 계산.
-     */
-    @Transactional
-    CancelItemsContext validateAndPrepare(Long orderId, Long userId, boolean isAdmin,
-                                          List<Long> itemIds) {
-        Order order = orderRepository.findByIdWithItemsForUpdate(orderId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
-
-        validateOrderOwnership(order, userId, isAdmin);
-
-        // CONFIRMED 또는 PARTIAL_CANCELLED 상태만 부분 취소 가능
-        if (order.getStatus() != OrderStatus.CONFIRMED
-                && order.getStatus() != OrderStatus.PARTIAL_CANCELLED) {
-            throw new BusinessException(ErrorCode.INVALID_ORDER_STATUS);
-        }
-
-        // 요청 아이템 검증
-        Set<Long> requestedIds = new HashSet<>(itemIds);
-        Map<Long, OrderItem> itemMap = order.getItems().stream()
-                .collect(Collectors.toMap(OrderItem::getId, i -> i));
-
-        List<OrderItem> targetItems = new ArrayList<>();
-        for (Long itemId : requestedIds) {
-            OrderItem item = itemMap.get(itemId);
-            if (item == null) {
-                throw new BusinessException(ErrorCode.ORDER_ITEM_NOT_FOUND);
-            }
-            if (!item.isActive()) {
-                throw new BusinessException(ErrorCode.ORDER_ITEM_ALREADY_CANCELLED);
-            }
-            targetItems.add(item);
-        }
-
-        // 환불 금액 계산 (비례 안분)
-        BigDecimal cancelledSubtotal = targetItems.stream()
-                .map(OrderItem::getSubtotal)
-                .reduce(BigDecimal.ZERO, BigDecimal::add);
-
-        BigDecimal cancelRatio = cancelledSubtotal.divide(
-                order.getTotalAmount(), 10, RoundingMode.DOWN);
-
-        BigDecimal proportionalDiscount = order.getDiscountAmount()
-                .multiply(cancelRatio).setScale(0, RoundingMode.DOWN);
-
-        long proportionalPoints = BigDecimal.valueOf(order.getUsedPoints())
-                .multiply(cancelRatio).setScale(0, RoundingMode.DOWN).longValue();
-
-        BigDecimal refundAmount = cancelledSubtotal
-                .subtract(proportionalDiscount)
-                .subtract(BigDecimal.valueOf(proportionalPoints))
-                .max(BigDecimal.ZERO);
-
-        return new CancelItemsContext(refundAmount, proportionalPoints);
-    }
-
-    /**
-     * [Short TX] 아이템 취소 + 재고 해제 + 포인트 반환 + 주문 상태 전이.
-     */
-    @Transactional
-    @CacheEvict(cacheNames = "orders", key = "#orderId")
-    OrderItemCancelResponse applyItemCancel(Long orderId, List<Long> itemIds, String reason,
-                                            BigDecimal refundAmount, long pointsToRefund) {
-        Order order = orderRepository.findByIdWithItemsForUpdate(orderId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
-
-        OrderStatus previousStatus = order.getStatus();
-        Set<Long> requestedIds = new HashSet<>(itemIds);
-
-        // 아이템 취소 + 재고 해제
-        List<OrderItemResponse> cancelledResponses = new ArrayList<>();
-        for (OrderItem item : order.getItems()) {
-            if (requestedIds.contains(item.getId()) && item.isActive()) {
-                item.cancel();
-                inventoryService.releaseAllocation(item.getVariant().getId(), item.getQuantity());
-                cancelledResponses.add(OrderItemResponse.from(item));
-            }
-        }
-
-        // 비례 포인트 반환
-        if (pointsToRefund > 0) {
-            pointService.refundPartial(order.getUserId(), orderId, pointsToRefund);
-        }
-
-        // 주문 상태 전이
-        order.partialCancel(reason);
-
-        // 모든 아이템 취소 → 쿠폰 반환 + EARN 포인트 처리
-        if (order.isAllItemsCancelled()) {
-            couponService.releaseCoupon(orderId);
-            pointService.expirePending(orderId);
-        }
-
-        recordHistory(orderId, previousStatus, order.getStatus(),
-                "partial-cancel:items=" + itemIds);
-        outboxEventStore.save(new OrderCancelledEvent(
-                orderId, order.getUserId(), "PARTIAL_ITEM_CANCELLED"));
-
-        return OrderItemCancelResponse.builder()
-                .orderId(orderId)
-                .orderStatus(order.getStatus().name())
-                .refundAmount(refundAmount)
-                .refundedPoints(pointsToRefund)
-                .cancelledItems(cancelledResponses)
-                .build();
-    }
-
-    /** 부분 취소 검증 결과 컨텍스트. */
-    record CancelItemsContext(BigDecimal refundAmount, long pointsToRefund) {}
 
     /**
      * 회원 탈퇴 시 사용자의 모든 PENDING 주문을 강제 취소한다.

--- a/src/main/java/com/stockmanagement/domain/order/service/OrderCommandService.java
+++ b/src/main/java/com/stockmanagement/domain/order/service/OrderCommandService.java
@@ -185,9 +185,9 @@ public class OrderCommandService {
         }
 
         // 6. 재고 예약 (variantId 오름차순 — 데드락 방지)
-        savedOrder.getItems().stream()
-                .sorted(java.util.Comparator.comparing(i -> i.getVariant().getId()))
-                .forEach(item -> inventoryService.reserve(item.getVariant().getId(), item.getQuantity()));
+        for (OrderItem item : savedOrder.getItemsSortedByVariant()) {
+            inventoryService.reserve(item.getVariant().getId(), item.getQuantity());
+        }
 
         // 7. 쿠폰 적용
         if (request.getCouponCode() != null && !request.getCouponCode().isBlank()) {
@@ -232,7 +232,8 @@ public class OrderCommandService {
         OrderStatus previousStatus = order.getStatus();
         order.cancel(reason);
 
-        for (OrderItem item : order.getItems()) {
+        // variantId 오름차순 — 재고 락 획득 순서 통일 (데드락 방지)
+        for (OrderItem item : order.getItemsSortedByVariant()) {
             inventoryService.releaseReservation(item.getVariant().getId(), item.getQuantity());
         }
 
@@ -256,7 +257,8 @@ public class OrderCommandService {
         OrderStatus previousStatus = order.getStatus();
         order.cancel(null);
 
-        for (OrderItem item : order.getItems()) {
+        // variantId 오름차순 — 재고 락 획득 순서 통일 (데드락 방지)
+        for (OrderItem item : order.getItemsSortedByVariant()) {
             inventoryService.releaseReservation(item.getVariant().getId(), item.getQuantity());
         }
 

--- a/src/main/java/com/stockmanagement/domain/order/service/OrderItemCancelTransactionHelper.java
+++ b/src/main/java/com/stockmanagement/domain/order/service/OrderItemCancelTransactionHelper.java
@@ -1,0 +1,188 @@
+package com.stockmanagement.domain.order.service;
+
+import com.stockmanagement.common.exception.BusinessException;
+import com.stockmanagement.common.exception.ErrorCode;
+import com.stockmanagement.common.event.OrderCancelledEvent;
+import com.stockmanagement.common.outbox.OutboxEventStore;
+import com.stockmanagement.domain.coupon.service.CouponService;
+import com.stockmanagement.domain.inventory.service.InventoryService;
+import com.stockmanagement.domain.order.dto.OrderItemCancelResponse;
+import com.stockmanagement.domain.order.dto.OrderItemResponse;
+import com.stockmanagement.domain.order.entity.Order;
+import com.stockmanagement.domain.order.entity.OrderItem;
+import com.stockmanagement.domain.order.entity.OrderStatus;
+import com.stockmanagement.domain.order.entity.OrderStatusHistory;
+import com.stockmanagement.domain.order.repository.OrderRepository;
+import com.stockmanagement.domain.order.repository.OrderStatusHistoryRepository;
+import com.stockmanagement.domain.point.service.PointService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * 주문 아이템 부분 취소의 DB 연산을 단기 트랜잭션으로 분리하는 헬퍼.
+ *
+ * <p>{@link OrderCommandService#cancelItems}는 Toss 부분 환불(외부 HTTP)을 사이에 두고
+ * 검증([Short TX])과 적용([Short TX])을 실행한다. 같은 클래스 내부 호출(self-invocation)은
+ * 프록시를 우회하여 {@code @Transactional}이 적용되지 않으므로 별도 빈으로 분리한다.
+ * ({@code PaymentTransactionHelper}와 동일한 패턴)
+ */
+@Service
+@RequiredArgsConstructor
+class OrderItemCancelTransactionHelper {
+
+    private final OrderRepository orderRepository;
+    private final InventoryService inventoryService;
+    private final OrderStatusHistoryRepository historyRepository;
+    private final CouponService couponService;
+    private final PointService pointService;
+    private final OutboxEventStore outboxEventStore;
+
+    /** 부분 취소 검증 결과 컨텍스트. */
+    record CancelItemsContext(BigDecimal refundAmount, long pointsToRefund) {}
+
+    /**
+     * [Short TX] 부분 취소 검증 + 환불 금액 계산.
+     */
+    @Transactional
+    CancelItemsContext validateAndPrepare(Long orderId, Long userId, boolean isAdmin,
+                                          List<Long> itemIds) {
+        Order order = orderRepository.findByIdWithItemsForUpdate(orderId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
+
+        validateOrderOwnership(order, userId, isAdmin);
+
+        // CONFIRMED 또는 PARTIAL_CANCELLED 상태만 부분 취소 가능
+        if (order.getStatus() != OrderStatus.CONFIRMED
+                && order.getStatus() != OrderStatus.PARTIAL_CANCELLED) {
+            throw new BusinessException(ErrorCode.INVALID_ORDER_STATUS);
+        }
+
+        // 요청 아이템 검증
+        Set<Long> requestedIds = new HashSet<>(itemIds);
+        Map<Long, OrderItem> itemMap = order.getItems().stream()
+                .collect(Collectors.toMap(OrderItem::getId, i -> i));
+
+        List<OrderItem> targetItems = new ArrayList<>();
+        for (Long itemId : requestedIds) {
+            OrderItem item = itemMap.get(itemId);
+            if (item == null) {
+                throw new BusinessException(ErrorCode.ORDER_ITEM_NOT_FOUND);
+            }
+            if (!item.isActive()) {
+                throw new BusinessException(ErrorCode.ORDER_ITEM_ALREADY_CANCELLED);
+            }
+            targetItems.add(item);
+        }
+
+        // 환불 금액 계산 (비례 안분)
+        BigDecimal cancelledSubtotal = targetItems.stream()
+                .map(OrderItem::getSubtotal)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        BigDecimal cancelRatio = cancelledSubtotal.divide(
+                order.getTotalAmount(), 10, RoundingMode.DOWN);
+
+        BigDecimal proportionalDiscount = order.getDiscountAmount()
+                .multiply(cancelRatio).setScale(0, RoundingMode.DOWN);
+
+        long proportionalPoints = BigDecimal.valueOf(order.getUsedPoints())
+                .multiply(cancelRatio).setScale(0, RoundingMode.DOWN).longValue();
+
+        BigDecimal refundAmount = cancelledSubtotal
+                .subtract(proportionalDiscount)
+                .subtract(BigDecimal.valueOf(proportionalPoints))
+                .max(BigDecimal.ZERO);
+
+        return new CancelItemsContext(refundAmount, proportionalPoints);
+    }
+
+    /**
+     * [Short TX] 아이템 취소 + 재고 해제 + 포인트 반환 + 주문 상태 전이.
+     */
+    @Transactional
+    @CacheEvict(cacheNames = "orders", key = "#orderId")
+    OrderItemCancelResponse applyItemCancel(Long orderId, List<Long> itemIds, String reason,
+                                            BigDecimal refundAmount, long pointsToRefund) {
+        Order order = orderRepository.findByIdWithItemsForUpdate(orderId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
+
+        OrderStatus previousStatus = order.getStatus();
+        Set<Long> requestedIds = new HashSet<>(itemIds);
+
+        // 아이템 취소 + 재고 해제
+        List<OrderItemResponse> cancelledResponses = new ArrayList<>();
+        for (OrderItem item : order.getItems()) {
+            if (requestedIds.contains(item.getId()) && item.isActive()) {
+                item.cancel();
+                inventoryService.releaseAllocation(item.getVariant().getId(), item.getQuantity());
+                cancelledResponses.add(OrderItemResponse.from(item));
+            }
+        }
+
+        // 비례 포인트 반환
+        if (pointsToRefund > 0) {
+            pointService.refundPartial(order.getUserId(), orderId, pointsToRefund);
+        }
+
+        // 주문 상태 전이
+        order.partialCancel(reason);
+
+        // 모든 아이템 취소 → 쿠폰 반환 + EARN 포인트 처리
+        if (order.isAllItemsCancelled()) {
+            couponService.releaseCoupon(orderId);
+            pointService.expirePending(orderId);
+        }
+
+        recordHistory(orderId, previousStatus, order.getStatus(),
+                "partial-cancel:items=" + itemIds);
+        outboxEventStore.save(new OrderCancelledEvent(
+                orderId, order.getUserId(), "PARTIAL_ITEM_CANCELLED"));
+
+        return OrderItemCancelResponse.builder()
+                .orderId(orderId)
+                .orderStatus(order.getStatus().name())
+                .refundAmount(refundAmount)
+                .refundedPoints(pointsToRefund)
+                .cancelledItems(cancelledResponses)
+                .build();
+    }
+
+    private void validateOrderOwnership(Order order, Long userId, boolean isAdmin) {
+        if (!isAdmin && !order.getUserId().equals(userId)) {
+            throw new BusinessException(ErrorCode.ORDER_ACCESS_DENIED);
+        }
+    }
+
+    private String currentUser() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated() || "anonymousUser".equals(auth.getPrincipal())) {
+            return "system";
+        }
+        return auth.getName();
+    }
+
+    private void recordHistory(Long orderId, OrderStatus from, OrderStatus to, String note) {
+        historyRepository.save(
+                OrderStatusHistory.builder()
+                        .orderId(orderId)
+                        .fromStatus(from)
+                        .toStatus(to)
+                        .changedBy(currentUser())
+                        .note(note)
+                        .build()
+        );
+    }
+}

--- a/src/main/java/com/stockmanagement/domain/order/service/OrderItemCancelTransactionHelper.java
+++ b/src/main/java/com/stockmanagement/domain/order/service/OrderItemCancelTransactionHelper.java
@@ -122,9 +122,9 @@ class OrderItemCancelTransactionHelper {
         OrderStatus previousStatus = order.getStatus();
         Set<Long> requestedIds = new HashSet<>(itemIds);
 
-        // 아이템 취소 + 재고 해제
+        // 아이템 취소 + 재고 해제 (variantId 오름차순 — 재고 락 획득 순서 통일, 데드락 방지)
         List<OrderItemResponse> cancelledResponses = new ArrayList<>();
-        for (OrderItem item : order.getItems()) {
+        for (OrderItem item : order.getItemsSortedByVariant()) {
             if (requestedIds.contains(item.getId()) && item.isActive()) {
                 item.cancel();
                 inventoryService.releaseAllocation(item.getVariant().getId(), item.getQuantity());

--- a/src/main/java/com/stockmanagement/domain/order/service/OrderPaymentService.java
+++ b/src/main/java/com/stockmanagement/domain/order/service/OrderPaymentService.java
@@ -54,7 +54,8 @@ public class OrderPaymentService {
         OrderStatus previousStatus = order.getStatus();
         order.confirm();
 
-        for (OrderItem item : order.getItems()) {
+        // variantId 오름차순 — 재고 락 획득 순서 통일 (데드락 방지)
+        for (OrderItem item : order.getItemsSortedByVariant()) {
             inventoryService.confirmAllocation(item.getVariant().getId(), item.getQuantity());
         }
 
@@ -79,8 +80,11 @@ public class OrderPaymentService {
         order.refund();
 
         // ACTIVE 아이템만 재고 해제 — 부분 취소로 이미 CANCELLED된 아이템은 건너뜀
-        for (OrderItem item : order.getActiveItems()) {
-            inventoryService.releaseAllocation(item.getVariant().getId(), item.getQuantity());
+        // variantId 오름차순 — 재고 락 획득 순서 통일 (데드락 방지)
+        for (OrderItem item : order.getItemsSortedByVariant()) {
+            if (item.isActive()) {
+                inventoryService.releaseAllocation(item.getVariant().getId(), item.getQuantity());
+            }
         }
 
         couponService.releaseCoupon(order.getId());
@@ -108,7 +112,8 @@ public class OrderPaymentService {
         OrderStatus previousStatus = order.getStatus();
         order.cancelByWebhook(reason);
 
-        for (OrderItem item : order.getItems()) {
+        // variantId 오름차순 — 재고 락 획득 순서 통일 (데드락 방지)
+        for (OrderItem item : order.getItemsSortedByVariant()) {
             inventoryService.releaseReservation(item.getVariant().getId(), item.getQuantity());
         }
 

--- a/src/test/java/com/stockmanagement/domain/inventory/service/InventoryServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/inventory/service/InventoryServiceTest.java
@@ -245,6 +245,31 @@ class InventoryServiceTest {
         }
 
         @Test
+        @DisplayName("가용 재고가 임계값을 하향 돌파하면 LowStockEvent를 발행한다")
+        void publishesLowStockEventOnThresholdCrossing() {
+            // onHand=15, reserved=3 → available=12 (임계값 10 이상)
+            Inventory inventory = Inventory.builder().variant(variant).build();
+            inventory.receive(15);
+            inventory.reserve(3);
+            given(inventoryRepository.findByVariantIdWithLock(1L)).willReturn(Optional.of(inventory));
+
+            inventoryService.reserve(1L, 5); // available 12 → 7 (임계값 하향 돌파)
+
+            verify(eventPublisher).publishEvent(any(com.stockmanagement.common.event.LowStockEvent.class));
+        }
+
+        @Test
+        @DisplayName("이미 임계값 미만인 재고는 LowStockEvent를 재발행하지 않는다")
+        void doesNotRepublishLowStockEventWhenAlreadyBelowThreshold() {
+            Inventory inventory = inventoryWithStock(); // available=7 (임계값 10 미만)
+            given(inventoryRepository.findByVariantIdWithLock(1L)).willReturn(Optional.of(inventory));
+
+            inventoryService.reserve(1L, 5); // available 7 → 2 (이미 미만 → 중복 경보 없음)
+
+            verify(eventPublisher, never()).publishEvent(any(com.stockmanagement.common.event.LowStockEvent.class));
+        }
+
+        @Test
         @DisplayName("가용 재고 부족 시 InsufficientStockException이 전파된다")
         void propagatesInsufficientStockException() {
             Inventory inventory = inventoryWithStock(); // available=7

--- a/src/test/java/com/stockmanagement/domain/order/entity/OrderTest.java
+++ b/src/test/java/com/stockmanagement/domain/order/entity/OrderTest.java
@@ -1,0 +1,46 @@
+package com.stockmanagement.domain.order.entity;
+
+import com.stockmanagement.domain.product.entity.ProductVariant;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@DisplayName("Order 엔티티 단위 테스트")
+class OrderTest {
+
+    @Test
+    @DisplayName("getItemsSortedByVariant()는 variantId 오름차순으로 반환한다 — 재고 락 획득 순서 통일")
+    void getItemsSortedByVariant_returnsAscendingVariantIdOrder() {
+        Order order = Order.builder()
+                .userId(1L)
+                .totalAmount(BigDecimal.valueOf(10_000))
+                .idempotencyKey("sort-test-001")
+                .build();
+
+        // 삽입 순서: variantId 3 → 1 → 2
+        order.addItem(itemWithVariantId(3L));
+        order.addItem(itemWithVariantId(1L));
+        order.addItem(itemWithVariantId(2L));
+
+        assertThat(order.getItemsSortedByVariant())
+                .extracting(i -> i.getVariant().getId())
+                .containsExactly(1L, 2L, 3L);
+        // 원본 items 순서는 변경되지 않는다
+        assertThat(order.getItems())
+                .extracting(i -> i.getVariant().getId())
+                .containsExactly(3L, 1L, 2L);
+    }
+
+    private OrderItem itemWithVariantId(Long variantId) {
+        ProductVariant variant = mock(ProductVariant.class);
+        given(variant.getId()).willReturn(variantId);
+        OrderItem item = mock(OrderItem.class);
+        given(item.getVariant()).willReturn(variant);
+        return item;
+    }
+}

--- a/src/test/java/com/stockmanagement/integration/OrderItemCancelIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/OrderItemCancelIntegrationTest.java
@@ -1,0 +1,234 @@
+package com.stockmanagement.integration;
+
+import com.stockmanagement.domain.payment.infrastructure.TossPaymentsClient;
+import com.stockmanagement.domain.payment.infrastructure.TossWebhookVerifier;
+import com.stockmanagement.domain.payment.infrastructure.dto.TossConfirmResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 주문 아이템 부분 취소 통합 테스트.
+ *
+ * <p>cancelItems()는 분산 락 + Toss 부분 환불(외부 HTTP)을 사이에 둔 Short TX 2개로 구성된다.
+ * 회귀 검증 대상 (#200): Short TX가 프록시를 경유하지 않으면(self-invocation)
+ * 아이템 취소·주문 상태 전이가 DB에 영속화되지 않아 동일 아이템 재취소로
+ * Toss 중복 환불·재고 이중 해제가 가능해진다.
+ *
+ * <p>TossPaymentsClient(외부 API)는 {@link MockBean}으로 대체한다.
+ */
+@DisplayName("주문 아이템 부분 취소 통합 테스트")
+class OrderItemCancelIntegrationTest extends AbstractIntegrationTest {
+
+    @MockBean TossPaymentsClient tossPaymentsClient;
+    @MockBean TossWebhookVerifier tossWebhookVerifier;
+
+    @Test
+    @DisplayName("부분 취소 → 상태 영속화 + 재고 해제, 동일 아이템 재취소 409, 전체 취소 시 CANCELLED")
+    void partialCancel_persistsState_andRejectsDoubleCancel() throws Exception {
+        // ===== 준비: 상품 2개 등록 + 입고 =====
+        String adminToken = createAdminAndLogin("admin_ic1", "adminpass1!", "aic1@test.com");
+        String userToken = signupAndLogin("buyer_ic1", "Password1!", "bic1@test.com");
+        long userId = userRepository.findByUsername("buyer_ic1").orElseThrow().getId();
+
+        TestProduct productA = createProductWithStock(adminToken, "ITEM-CXL-A", 10_000, 10);
+        TestProduct productB = createProductWithStock(adminToken, "ITEM-CXL-B", 5_000, 10);
+        long variantA = productA.variantId();
+        long variantB = productB.variantId();
+
+        // ===== 주문 생성 (A x1 + B x2 = 20000) =====
+        String orderBody = mockMvc.perform(post("/api/v1/orders")
+                        .header("Authorization", "Bearer " + userToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(String.format(
+                                "{\"userId\":%d,\"idempotencyKey\":\"item-cancel-001\",\"items\":[" +
+                                "{\"productId\":%d,\"variantId\":%d,\"quantity\":1,\"unitPrice\":10000}," +
+                                "{\"productId\":%d,\"variantId\":%d,\"quantity\":2,\"unitPrice\":5000}]}",
+                                userId, productA.productId(), variantA, productB.productId(), variantB)))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        long orderId = objectMapper.readTree(orderBody).path("data").path("id").asLong();
+
+        // ===== 결제 확정 (Toss confirm mock) → CONFIRMED =====
+        confirmPayment(userToken, orderId, 20_000);
+
+        long itemA = findItemIdByVariant(userToken, orderId, variantA);
+        long itemB = findItemIdByVariant(userToken, orderId, variantB);
+
+        // 확정 후 재고: A allocated=1 (available 9)
+        assertInventory(adminToken, variantA, 1, 9);
+
+        // ===== 1차 부분 취소 (아이템 A) → PARTIAL_CANCELLED =====
+        mockMvc.perform(post("/api/v1/orders/" + orderId + "/items/cancel")
+                        .header("Authorization", "Bearer " + userToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(String.format("{\"itemIds\":[%d],\"reason\":\"단순 변심\"}", itemA)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.orderStatus").value("PARTIAL_CANCELLED"))
+                .andExpect(jsonPath("$.data.refundAmount").value(10000));
+
+        // 상태 영속화 검증 — 주문 PARTIAL_CANCELLED, 아이템 A만 CANCELLED (#200 회귀 핵심)
+        mockMvc.perform(get("/api/v1/orders/" + orderId)
+                        .header("Authorization", "Bearer " + userToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value("PARTIAL_CANCELLED"))
+                .andExpect(jsonPath("$.data.items[?(@.id == " + itemA + ")].status").value("CANCELLED"))
+                .andExpect(jsonPath("$.data.items[?(@.id == " + itemB + ")].status").value("ACTIVE"));
+
+        // 재고 해제 검증 — A allocated 0, available 복원
+        assertInventory(adminToken, variantA, 0, 10);
+
+        // ===== 동일 아이템 재취소 → 409, Toss 재환불 없음 =====
+        mockMvc.perform(post("/api/v1/orders/" + orderId + "/items/cancel")
+                        .header("Authorization", "Bearer " + userToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(String.format("{\"itemIds\":[%d]}", itemA)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.success").value(false));
+
+        // Toss 부분 환불은 1차 취소 때 1회만 호출되어야 한다 (중복 환불 방지)
+        then(tossPaymentsClient).should(times(1)).cancel(any(), any());
+
+        // 재고 이중 해제 없음
+        assertInventory(adminToken, variantA, 0, 10);
+
+        // ===== 남은 아이템 B 취소 → 전체 CANCELLED =====
+        mockMvc.perform(post("/api/v1/orders/" + orderId + "/items/cancel")
+                        .header("Authorization", "Bearer " + userToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(String.format("{\"itemIds\":[%d]}", itemB)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.orderStatus").value("CANCELLED"))
+                .andExpect(jsonPath("$.data.refundAmount").value(10000));
+
+        mockMvc.perform(get("/api/v1/orders/" + orderId)
+                        .header("Authorization", "Bearer " + userToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value("CANCELLED"));
+
+        assertInventory(adminToken, variantB, 0, 10);
+    }
+
+    @Test
+    @DisplayName("PENDING 주문 부분 취소 시도 → 409")
+    void partialCancel_pendingOrder_409() throws Exception {
+        String adminToken = createAdminAndLogin("admin_ic2", "adminpass2!", "aic2@test.com");
+        String userToken = signupAndLogin("buyer_ic2", "Password1!", "bic2@test.com");
+        long userId = userRepository.findByUsername("buyer_ic2").orElseThrow().getId();
+
+        TestProduct product = createProductWithStock(adminToken, "ITEM-CXL-C", 3_000, 5);
+        long variantId = product.variantId();
+
+        String orderBody = mockMvc.perform(post("/api/v1/orders")
+                        .header("Authorization", "Bearer " + userToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(String.format(
+                                "{\"userId\":%d,\"idempotencyKey\":\"item-cancel-002\",\"items\":[" +
+                                "{\"productId\":%d,\"variantId\":%d,\"quantity\":1,\"unitPrice\":3000}]}",
+                                userId, product.productId(), variantId)))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        long orderId = objectMapper.readTree(orderBody).path("data").path("id").asLong();
+        long itemId = findItemIdByVariant(userToken, orderId, variantId);
+
+        // 결제 전(PENDING) 부분 취소 불가
+        mockMvc.perform(post("/api/v1/orders/" + orderId + "/items/cancel")
+                        .header("Authorization", "Bearer " + userToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(String.format("{\"itemIds\":[%d]}", itemId)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.success").value(false));
+    }
+
+    // ===== 헬퍼 =====
+
+    /** 테스트용 상품 식별자 홀더. */
+    private record TestProduct(long productId, long variantId) {}
+
+    /** 상품 등록 + 입고 후 productId·기본 variantId를 반환한다. */
+    private TestProduct createProductWithStock(String adminToken, String sku, int price, int quantity) throws Exception {
+        String productBody = mockMvc.perform(post("/api/v1/products")
+                        .header("Authorization", "Bearer " + adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(String.format(
+                                "{\"name\":\"%s\",\"sku\":\"%s\",\"price\":%d}", sku, sku, price)))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        long productId = objectMapper.readTree(productBody).path("data").path("id").asLong();
+        long variantId = getDefaultVariantId(productId);
+
+        mockMvc.perform(post("/api/v1/inventory/variants/" + variantId + "/receive")
+                        .header("Authorization", "Bearer " + adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(String.format("{\"quantity\":%d}", quantity)))
+                .andExpect(status().isOk());
+        return new TestProduct(productId, variantId);
+    }
+
+    /** prepare → Toss confirm(mock) → confirm 호출로 주문을 CONFIRMED 상태로 만든다. */
+    private void confirmPayment(String userToken, long orderId, int amount) throws Exception {
+        String prepareBody = mockMvc.perform(post("/api/v1/payments/prepare")
+                        .header("Authorization", "Bearer " + userToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(String.format("{\"orderId\":%d,\"amount\":%d}", orderId, amount)))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        String tossOrderId = objectMapper.readTree(prepareBody).path("data").path("tossOrderId").asText();
+
+        TossConfirmResponse tossResponse = new TossConfirmResponse();
+        setField(tossResponse, "paymentKey", "pk-item-cancel-" + orderId);
+        setField(tossResponse, "status", "DONE");
+        setField(tossResponse, "method", "카드");
+        setField(tossResponse, "requestedAt", "2026-01-01T00:00:00+09:00");
+        setField(tossResponse, "approvedAt", "2026-01-01T00:00:01+09:00");
+        given(tossPaymentsClient.confirm(any())).willReturn(tossResponse);
+
+        mockMvc.perform(post("/api/v1/payments/confirm")
+                        .header("Authorization", "Bearer " + userToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(String.format(
+                                "{\"paymentKey\":\"pk-item-cancel-%d\",\"tossOrderId\":\"%s\",\"amount\":%d}",
+                                orderId, tossOrderId, amount)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value("DONE"));
+    }
+
+    /** 주문 조회 응답에서 variantId에 해당하는 아이템 ID를 찾는다. */
+    private long findItemIdByVariant(String userToken, long orderId, long variantId) throws Exception {
+        String body = mockMvc.perform(get("/api/v1/orders/" + orderId)
+                        .header("Authorization", "Bearer " + userToken))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        for (var item : objectMapper.readTree(body).path("data").path("items")) {
+            if (item.path("variantId").asLong() == variantId) {
+                return item.path("id").asLong();
+            }
+        }
+        throw new AssertionError("variantId=" + variantId + " 아이템을 주문에서 찾을 수 없음");
+    }
+
+    /** 재고의 allocated·available 값을 검증한다. */
+    private void assertInventory(String adminToken, long variantId, int allocated, int available) throws Exception {
+        mockMvc.perform(get("/api/v1/inventory/variants/" + variantId)
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.allocated").value(allocated))
+                .andExpect(jsonPath("$.data.available").value(available));
+    }
+
+    private void setField(Object target, String fieldName, Object value) throws Exception {
+        java.lang.reflect.Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+}


### PR DESCRIPTION
## 개요

2026-07 전체 코드 리뷰에서 발견된 이슈 수정분을 master에 반영한다.

## 포함 변경

- **#200 (Critical, PR #204)**: `cancelItems` self-invocation으로 `@Transactional` 미적용 → `OrderItemCancelTransactionHelper` 분리. 부분 취소 미영속화로 인한 Toss 중복 환불·재고 이중 해제 가능성 제거. 통합 테스트 신규.
- **#201 (PR #205)**: `reserve()` 저재고 경보 기준값 계산 오류 수정 — 임계값 미만 재고에서 `LowStockEvent` 중복 발행 방지.
- **#202 (PR #206, #207)**: 다건 재고 락 획득 순서를 `Order.getItemsSortedByVariant()`로 통일 (7개 경로) — 동시 확정/취소 간 데드락 방지.
- 문서 최신화 (README·API·DB·TODO·IMPROVEMENTS, Mermaid, flow-visualizer)

## 검증

머지된 dev에서 전체 테스트 스위트 통과 (`./gradlew test` BUILD SUCCESSFUL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)