### PR TITLE
feat: ES categoryId 필터 + 전체 재색인 관리자 API (#209, #210)

### DIFF
--- a/src/main/java/com/stockmanagement/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/stockmanagement/domain/admin/controller/AdminController.java
@@ -5,11 +5,13 @@ import com.stockmanagement.domain.admin.dto.AdminOrderResponse;
 import com.stockmanagement.domain.admin.dto.DashboardResponse;
 import com.stockmanagement.domain.admin.dto.LowStockThresholdRequest;
 import com.stockmanagement.domain.admin.dto.LowStockThresholdResponse;
+import com.stockmanagement.domain.admin.dto.ReindexResponse;
 import com.stockmanagement.domain.admin.dto.RoleUpdateRequest;
 import com.stockmanagement.domain.admin.dto.ShippingPolicyRequest;
 import com.stockmanagement.domain.admin.dto.ShippingPolicyResponse;
 import com.stockmanagement.domain.admin.service.AdminService;
 import com.stockmanagement.domain.admin.setting.service.SystemSettingService;
+import com.stockmanagement.domain.product.service.ProductSearchService;
 import com.stockmanagement.domain.inventory.dto.DailyInventorySnapshotResponse;
 import com.stockmanagement.domain.order.dto.DailyOrderStatsResponse;
 import com.stockmanagement.domain.order.entity.OrderStatus;
@@ -50,6 +52,15 @@ public class AdminController {
 
     private final AdminService adminService;
     private final SystemSettingService systemSettingService;
+    private final ProductSearchService productSearchService;
+
+    @Operation(summary = "상품 검색 전체 재색인",
+            description = "ES 인덱스를 재생성하고 ACTIVE 상품 전체를 다시 색인한다. " +
+                    "매핑 변경·색인 유실·통계 stale 복구용. 재색인 중 검색 결과가 부분적일 수 있다.")
+    @PostMapping("/search/reindex")
+    public ApiResponse<ReindexResponse> reindexProducts() {
+        return ApiResponse.ok(new ReindexResponse(productSearchService.reindexAll()));
+    }
 
     @Operation(summary = "관리자 대시보드", description = "주문 통계, 매출(CONFIRMED 기준), 사용자 수, 저재고(available<10) 목록 반환.")
     @GetMapping("/dashboard")

--- a/src/main/java/com/stockmanagement/domain/admin/dto/ReindexResponse.java
+++ b/src/main/java/com/stockmanagement/domain/admin/dto/ReindexResponse.java
@@ -1,0 +1,13 @@
+package com.stockmanagement.domain.admin.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/** 상품 검색 전체 재색인 결과 응답. */
+@Getter
+@AllArgsConstructor
+public class ReindexResponse {
+
+    /** 색인된 상품 수 */
+    private final long indexedCount;
+}

--- a/src/main/java/com/stockmanagement/domain/order/repository/OrderItemRepository.java
+++ b/src/main/java/com/stockmanagement/domain/order/repository/OrderItemRepository.java
@@ -25,4 +25,12 @@ public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
            "AND oi.order.status IN (com.stockmanagement.domain.order.entity.OrderStatus.CONFIRMED, " +
            "com.stockmanagement.domain.order.entity.OrderStatus.CANCEL_IN_PROGRESS)")
     long sumSalesCountByProductId(@Param("productId") Long productId);
+
+    /** 결제 완료된 주문에서 상품별 누적 판매 수량 배치 조회 — [productId, sum] 배열 목록 (재색인용) */
+    @Query("SELECT oi.product.id, COALESCE(SUM(oi.quantity), 0) FROM OrderItem oi " +
+           "WHERE oi.product.id IN :productIds " +
+           "AND oi.order.status IN (com.stockmanagement.domain.order.entity.OrderStatus.CONFIRMED, " +
+           "com.stockmanagement.domain.order.entity.OrderStatus.CANCEL_IN_PROGRESS) " +
+           "GROUP BY oi.product.id")
+    List<Object[]> sumSalesCountByProductIdIn(@Param("productIds") List<Long> productIds);
 }

--- a/src/main/java/com/stockmanagement/domain/product/document/ProductDocument.java
+++ b/src/main/java/com/stockmanagement/domain/product/document/ProductDocument.java
@@ -51,6 +51,10 @@ public class ProductDocument {
     @Field(type = FieldType.Keyword)
     private String category;
 
+    /** 카테고리 ID — categoryId 필터(하위 카테고리 포함) 대상 */
+    @Field(type = FieldType.Long)
+    private Long categoryId;
+
     @Field(type = FieldType.Keyword)
     private String status;
 
@@ -80,6 +84,7 @@ public class ProductDocument {
                 .price(product.getPrice() != null ? product.getPrice().doubleValue() : 0)
                 .sku(product.getSku())
                 .category(product.getCategoryName())
+                .categoryId(product.getCategory() != null ? product.getCategory().getId() : null)
                 .status(product.getStatus() != null ? product.getStatus().name() : null)
                 .thumbnailUrl(product.getThumbnailUrl())
                 .createdAt(product.getCreatedAt())
@@ -101,6 +106,7 @@ public class ProductDocument {
                 .price(getPriceAsBigDecimal())
                 .sku(sku)
                 .category(category)
+                .categoryId(categoryId)
                 .thumbnailUrl(thumbnailUrl)
                 .status(status != null ? ProductStatus.valueOf(status) : null)
                 .createdAt(createdAt)

--- a/src/main/java/com/stockmanagement/domain/product/service/ProductSearchService.java
+++ b/src/main/java/com/stockmanagement/domain/product/service/ProductSearchService.java
@@ -1,29 +1,41 @@
 package com.stockmanagement.domain.product.service;
 
+import co.elastic.clients.elasticsearch._types.FieldValue;
 import co.elastic.clients.elasticsearch._types.SortOptions;
 import co.elastic.clients.elasticsearch._types.SortOrder;
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import com.stockmanagement.domain.order.repository.OrderItemRepository;
+import com.stockmanagement.domain.product.category.repository.CategoryRepository;
 import com.stockmanagement.domain.product.document.ProductDocument;
 import com.stockmanagement.domain.product.dto.ProductSearchRequest;
 import com.stockmanagement.domain.product.dto.ProductResponse;
 import com.stockmanagement.domain.product.entity.Product;
+import com.stockmanagement.domain.product.entity.ProductStatus;
+import com.stockmanagement.domain.product.repository.ProductRepository;
 import com.stockmanagement.domain.product.repository.ProductSearchRepository;
+import com.stockmanagement.domain.product.review.repository.ReviewRepository;
+import com.stockmanagement.domain.product.review.repository.ReviewStatsProjection;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.elasticsearch.client.elc.NativeQuery;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.IndexOperations;
 import org.springframework.data.elasticsearch.core.SearchHit;
 import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Elasticsearch 기반 상품 검색 서비스.
@@ -37,8 +49,15 @@ import java.util.Set;
 @RequiredArgsConstructor
 public class ProductSearchService {
 
+    /** 재색인 시 한 번에 색인하는 상품 수 — DB 조회·bulk 요청 크기의 균형 */
+    private static final int REINDEX_BATCH_SIZE = 500;
+
     private final ElasticsearchOperations elasticsearchOperations;
     private final ProductSearchRepository productSearchRepository;
+    private final CategoryRepository categoryRepository;
+    private final ProductRepository productRepository;
+    private final ReviewRepository reviewRepository;
+    private final OrderItemRepository orderItemRepository;
 
     /**
      * 동적 조건으로 상품을 검색한다.
@@ -78,6 +97,19 @@ public class ProductSearchService {
         // 카테고리 필터 (정확 일치)
         if (request.getCategory() != null && !request.getCategory().isBlank()) {
             boolQuery.filter(f -> f.term(t -> t.field("category").value(request.getCategory())));
+        }
+
+        // 카테고리 ID 필터 — includeChildren=true이면 하위 카테고리 포함
+        if (request.getCategoryId() != null) {
+            List<Long> categoryIds = new ArrayList<>();
+            categoryIds.add(request.getCategoryId());
+            if (request.isIncludeChildren()) {
+                categoryIds.addAll(categoryRepository.findChildIdsByParentId(request.getCategoryId()));
+            }
+            List<FieldValue> values = categoryIds.stream()
+                    .map(id -> FieldValue.of(id.longValue()))
+                    .toList();
+            boolQuery.filter(f -> f.terms(t -> t.field("categoryId").terms(ts -> ts.value(values))));
         }
 
         // 정렬 옵션
@@ -161,6 +193,63 @@ public class ProductSearchService {
             if (seen.size() >= size) break;
         }
         return new ArrayList<>(seen);
+    }
+
+    /**
+     * 전체 재색인 — 인덱스를 재생성하고 ACTIVE 상품 전체를 다시 색인한다 (ADMIN 전용).
+     *
+     * <p>ES 데이터 유실, 매핑 변경, 색인 stale 누적(리뷰/판매 통계, 카테고리명 변경) 복구용.
+     * 인덱스 삭제 후 배치 색인이 끝날 때까지 검색 결과가 부분적일 수 있다.
+     *
+     * <p>{@code @Transactional(readOnly = true)}: 배치 페이징 중 LAZY 카테고리 접근을 위해
+     * 영속성 컨텍스트를 메서드 전체에 유지한다.
+     *
+     * @return 색인된 상품 수
+     */
+    @Transactional(readOnly = true)
+    public long reindexAll() {
+        IndexOperations indexOps = elasticsearchOperations.indexOps(ProductDocument.class);
+        if (indexOps.exists()) {
+            indexOps.delete();
+        }
+        indexOps.createWithMapping();
+
+        long total = 0;
+        int page = 0;
+        Page<Product> products;
+        do {
+            products = productRepository.findByStatus(ProductStatus.ACTIVE,
+                    PageRequest.of(page, REINDEX_BATCH_SIZE, Sort.by("id")));
+            if (products.isEmpty()) {
+                break;
+            }
+            productSearchRepository.saveAll(buildDocuments(products.getContent()));
+            total += products.getNumberOfElements();
+            page++;
+        } while (products.hasNext());
+
+        indexOps.refresh();
+        log.info("[ES] 전체 재색인 완료: {}건", total);
+        return total;
+    }
+
+    /** 상품 배치에 리뷰·판매 통계를 배치 조회로 결합하여 ES 문서 목록을 생성한다. */
+    private List<ProductDocument> buildDocuments(List<Product> products) {
+        List<Long> ids = products.stream().map(Product::getId).toList();
+
+        Map<Long, Long> reviewCounts = reviewRepository.findReviewStatsByProductIdIn(ids).stream()
+                .collect(Collectors.toMap(
+                        ReviewStatsProjection::getProductId,
+                        ReviewStatsProjection::getReviewCount));
+
+        Map<Long, Long> salesCounts = orderItemRepository.sumSalesCountByProductIdIn(ids).stream()
+                .collect(Collectors.toMap(row -> (Long) row[0], row -> (Long) row[1]));
+
+        return products.stream()
+                .map(p -> ProductDocument.from(p,
+                        reviewCounts.getOrDefault(p.getId(), 0L),
+                        salesCounts.getOrDefault(p.getId(), 0L)))
+                .toList();
     }
 
     // ===== 내부 헬퍼 =====

--- a/src/test/java/com/stockmanagement/domain/admin/controller/AdminControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/admin/controller/AdminControllerTest.java
@@ -51,6 +51,33 @@ class AdminControllerTest {
     @MockBean private JwtTokenProvider jwtTokenProvider;
     @MockBean private JwtBlacklist jwtBlacklist;
     @MockBean private UserService userService;
+    @MockBean private com.stockmanagement.domain.product.service.ProductSearchService productSearchService;
+
+    // ===== POST /api/admin/search/reindex =====
+
+    @Nested
+    @DisplayName("POST /api/admin/search/reindex")
+    class Reindex {
+
+        @Test
+        @WithMockUser(roles = "ADMIN")
+        @DisplayName("ADMIN → 200, 색인 건수 반환")
+        void reindexAsAdmin() throws Exception {
+            given(productSearchService.reindexAll()).willReturn(42L);
+
+            mockMvc.perform(post("/api/v1/admin/search/reindex"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.indexedCount").value(42));
+        }
+
+        @Test
+        @WithMockUser(roles = "USER")
+        @DisplayName("USER → 403")
+        void reindexAsUserForbidden() throws Exception {
+            mockMvc.perform(post("/api/v1/admin/search/reindex"))
+                    .andExpect(status().isForbidden());
+        }
+    }
 
     // ===== GET /api/admin/dashboard =====
 

--- a/src/test/java/com/stockmanagement/integration/ProductSearchIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/ProductSearchIntegrationTest.java
@@ -161,6 +161,89 @@ class ProductSearchIntegrationTest extends AbstractIntegrationTest {
                 .andExpect(jsonPath("$.data.content[0].sku").value("TS-001"));
     }
 
+    // ===== 카테고리 ID 필터 — ES 경로 (#209) =====
+
+    @Test
+    @DisplayName("q + categoryId → 해당 카테고리 상품만 반환")
+    void search_byKeywordAndCategoryId() throws Exception {
+        createProduct("무선 마우스", "CID-001", 30000, "전자");
+        createProduct("무선 이어폰 파우치", "CID-002", 20000, "패션잡화");
+        long categoryId = getOrCreateCategory("전자");
+
+        // 수정 전에는 ES 경로에서 categoryId가 무시되어 2건이 반환됐다
+        mockMvc.perform(get("/api/v1/products")
+                        .param("q", "무선")
+                        .param("categoryId", String.valueOf(categoryId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalElements").value(1))
+                .andExpect(jsonPath("$.data.content[0].sku").value("CID-001"))
+                .andExpect(jsonPath("$.data.content[0].categoryId").value(categoryId));
+    }
+
+    @Test
+    @DisplayName("q + categoryId + includeChildren=true → 하위 카테고리 상품 포함")
+    void search_byKeywordAndCategoryId_includeChildren() throws Exception {
+        long parentId = getOrCreateCategory("가전");
+        String childBody = mockMvc.perform(post("/api/v1/categories")
+                        .header("Authorization", "Bearer " + adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(String.format("{\"name\":\"주방가전\",\"parentId\":%d}", parentId)))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        long childId = objectMapper.readTree(childBody).path("data").path("id").asLong();
+
+        createProduct("소형 냉장고", "IC-001", 300000, "가전");
+        createProduct("소형 전기포트", "IC-002", 40000, "주방가전");
+        // 다른 카테고리의 동일 키워드 상품 — 필터로 제외되어야 함
+        createProduct("소형 가방", "IC-003", 50000, "패션잡화");
+
+        mockMvc.perform(get("/api/v1/products")
+                        .param("q", "소형")
+                        .param("categoryId", String.valueOf(parentId))
+                        .param("includeChildren", "true"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalElements").value(2));
+
+        // includeChildren=false(기본) → 부모 카테고리 직속 상품만
+        mockMvc.perform(get("/api/v1/products")
+                        .param("q", "소형")
+                        .param("categoryId", String.valueOf(parentId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalElements").value(1))
+                .andExpect(jsonPath("$.data.content[0].sku").value("IC-001"));
+    }
+
+    // ===== 전체 재색인 (#210) =====
+
+    @Test
+    @DisplayName("색인 유실 후 관리자 재색인 → 검색 복구")
+    void reindex_restoresIndex() throws Exception {
+        createProduct("복구 노트북", "RI-001", 500000, "전자");
+        createProduct("복구 마우스", "RI-002", 30000, "전자");
+        long categoryId = getOrCreateCategory("전자");
+
+        // 색인 유실 시뮬레이션
+        productSearchRepository.deleteAll();
+        elasticsearchOperations.indexOps(ProductDocument.class).refresh();
+
+        mockMvc.perform(get("/api/v1/products").param("q", "복구"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalElements").value(0));
+
+        // 재색인 (ADMIN)
+        mockMvc.perform(post("/api/v1/admin/search/reindex")
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.indexedCount").value(2));
+
+        // 검색 복구 + 재생성된 매핑에서 categoryId 필터 동작 확인
+        mockMvc.perform(get("/api/v1/products")
+                        .param("q", "복구")
+                        .param("categoryId", String.valueOf(categoryId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalElements").value(2));
+    }
+
     // ===== 복합 필터 =====
 
     @Test


### PR DESCRIPTION
## 개요

ES 리뷰에서 나온 최우선 이슈 2건을 처리한다. 두 이슈는 짝으로 묶었다 — #209의 매핑 변경(categoryId 필드 추가)은 기존 문서 재색인이 필요하고, 그 수단이 #210이다.

## #209 — q+categoryId 조합 시 카테고리 필터 무시

- `ProductDocument`에 `categoryId`(Long) 필드 추가 + `from()`/`toProductResponse()` 반영 (ES 경로 응답의 categoryId null 문제도 해소)
- `ProductSearchService.search()`에 categoryId terms 필터 추가 — `includeChildren=true`이면 `findChildIdsByParentId`로 하위 카테고리 ID까지 포함
- `hasSearchCondition()`은 변경 없음 — categoryId 단독 조회는 기존대로 MySQL 경로

## #210 — 전체 재색인 관리자 API

- `POST /api/v1/admin/search/reindex` (ADMIN 전용 — `/api/v1/admin/**` 규칙으로 보호)
- `ProductSearchService.reindexAll()`: 인덱스 삭제 → `createWithMapping()`(@Setting/@Field 기반 재생성) → ACTIVE 상품 500건 단위 페이징 bulk 색인 → refresh
- 리뷰 통계는 기존 `findReviewStatsByProductIdIn`, 판매량은 신규 `sumSalesCountByProductIdIn` 배치 쿼리로 N+1 없이 조회
- `@Transactional(readOnly=true)`로 배치 순회 중 LAZY 카테고리 접근 보장
- 재색인 중 검색 결과가 부분적일 수 있음 (관리자 작업 특성상 허용, Swagger 문서에 명시)

## 테스트

- `ProductSearchIntegrationTest` +3: q+categoryId 필터(수정 전엔 2건 반환되던 케이스), includeChildren 하위 카테고리 포함/제외, 색인 유실 → 재색인 → 검색 복구
- `AdminControllerTest` +2: ADMIN 200 + 색인 건수 응답 / USER 403
- 전체 테스트 스위트 통과

## 배포 참고

배포 후 기존 문서에는 categoryId가 없으므로 `POST /api/v1/admin/search/reindex`를 1회 실행해야 categoryId 필터가 전체 상품에 적용된다.

Closes #209
Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)