### PR TITLE
fix: ES 클라이언트 타임아웃 설정 — 장애 시 fail-fast (#211)

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -49,6 +49,10 @@ spring.data.redis.port=6379
 
 # ===== Elasticsearch =====
 spring.elasticsearch.uris=http://localhost:9200
+# fail-fast: ES 장애 시 MySQL fallback이 있으므로 짧게 끊는다 (기본 socket 30s → 상품 쓰기/검색 블로킹 방지)
+# socket 5s: 재색인 bulk(500건) 요청 여유 포함
+spring.elasticsearch.connection-timeout=1s
+spring.elasticsearch.socket-timeout=5s
 
 # ===== Cache =====
 spring.cache.type=redis


### PR DESCRIPTION
## 개요

`spring.elasticsearch.uris`만 설정되어 있어 기본 타임아웃(socket 30초)이 적용되던 문제를 수정한다. ES가 행업하면 상품 등록/수정(AFTER_COMMIT 동기 색인)과 검색(MySQL fallback 진입 전)이 요청 스레드에서 최대 30초 블록됐다.

## 변경

```properties
spring.elasticsearch.connection-timeout=1s
spring.elasticsearch.socket-timeout=5s
```

- MySQL fallback이 있으므로 fail-fast가 올바른 정책
- socket 5s는 재색인(#210) bulk 500건 요청 여유를 포함해 이슈 제안값(3s)보다 소폭 상향

## 테스트

타임아웃 적용 상태로 `ProductSearchIntegrationTest`(Testcontainers ES) 전체 통과.

Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)