### PR TITLE
fix: ES 색인 실패 시 Outbox 재시도 (#212)

### DIFF
--- a/src/main/java/com/stockmanagement/common/event/ProductSyncEvent.java
+++ b/src/main/java/com/stockmanagement/common/event/ProductSyncEvent.java
@@ -1,5 +1,9 @@
 package com.stockmanagement.common.event;
 
+import com.stockmanagement.common.outbox.OutboxEventType;
+
+import java.util.Map;
+
 /**
  * 상품 Elasticsearch 동기화 이벤트.
  *
@@ -8,8 +12,11 @@ package com.stockmanagement.common.event;
  *
  * <p>트랜잭션 커밋 이후에 발행되도록 {@link ProductEventListener}에서
  * {@code @TransactionalEventListener(AFTER_COMMIT)}으로 처리한다.
+ *
+ * <p>동기 색인 실패 시에만 Outbox({@code PRODUCT_SYNC})에 저장되어
+ * 릴레이 스케줄러가 최대 5회 재시도한다.
  */
-public class ProductSyncEvent extends DomainEvent {
+public class ProductSyncEvent extends DomainEvent implements OutboxSupport {
 
     private final Long productId;
     private final boolean delete;
@@ -26,5 +33,15 @@ public class ProductSyncEvent extends DomainEvent {
 
     public boolean isDelete() {
         return delete;
+    }
+
+    @Override
+    public OutboxEventType outboxEventType() {
+        return OutboxEventType.PRODUCT_SYNC;
+    }
+
+    @Override
+    public Map<String, Object> toOutboxPayload() {
+        return Map.of("productId", productId, "delete", delete);
     }
 }

--- a/src/main/java/com/stockmanagement/common/outbox/OutboxEventProcessor.java
+++ b/src/main/java/com/stockmanagement/common/outbox/OutboxEventProcessor.java
@@ -9,6 +9,7 @@ import com.stockmanagement.common.event.ShipmentDeliveredEvent;
 import com.stockmanagement.common.event.ShipmentReturnedEvent;
 import com.stockmanagement.common.event.ShipmentShippedEvent;
 import com.stockmanagement.domain.point.service.PointService;
+import com.stockmanagement.domain.product.service.ProductIndexSynchronizer;
 import com.stockmanagement.domain.shipment.service.ShipmentService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -46,6 +47,7 @@ class OutboxEventProcessor {
     private final ObjectMapper objectMapper;
     private final ShipmentService shipmentService;
     private final PointService pointService;
+    private final ProductIndexSynchronizer productIndexSynchronizer;
 
     /**
      * outboxId에 해당하는 이벤트를 독립 트랜잭션으로 발행한다.
@@ -105,6 +107,16 @@ class OutboxEventProcessor {
                 Long orderId = toLong(p.get("orderId"));
                 pointService.earn(userId, paidAmount, orderId);
                 log.info("[Outbox] 포인트 적립 완료: userId={}, paidAmount={}, orderId={}", userId, paidAmount, orderId);
+            }
+            case PRODUCT_SYNC -> {
+                Long productId = toLong(p.get("productId"));
+                boolean delete = Boolean.parseBoolean(String.valueOf(p.get("delete")));
+                if (delete) {
+                    productIndexSynchronizer.deleteFromIndex(productId);
+                } else {
+                    productIndexSynchronizer.sync(productId);
+                }
+                log.info("[Outbox] ES 색인 재시도 성공: productId={}, delete={}", productId, delete);
             }
             case SHIPMENT_DELIVERED -> {
                 Long orderId = toLong(p.get("orderId"));

--- a/src/main/java/com/stockmanagement/common/outbox/OutboxEventStore.java
+++ b/src/main/java/com/stockmanagement/common/outbox/OutboxEventStore.java
@@ -31,11 +31,27 @@ public class OutboxEventStore {
      * @param event Outbox 저장을 지원하는 도메인 이벤트
      */
     public void save(OutboxSupport event) {
+        repository.save(toEntity(event));
+    }
+
+    /**
+     * 독립 트랜잭션(REQUIRES_NEW)으로 Outbox 이벤트를 저장한다.
+     *
+     * <p>AFTER_COMMIT 리스너처럼 이미 커밋된 트랜잭션 컨텍스트에서 호출할 때 사용한다.
+     * 그 컨텍스트에서 {@link #save}로 저장하면 커밋이 끝난 트랜잭션에 참여하여
+     * INSERT가 유실되므로 반드시 새 트랜잭션으로 커밋해야 한다.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void saveInNewTransaction(OutboxSupport event) {
+        repository.save(toEntity(event));
+    }
+
+    private OutboxEvent toEntity(OutboxSupport event) {
         try {
-            repository.save(OutboxEvent.builder()
+            return OutboxEvent.builder()
                     .eventType(event.outboxEventType())
                     .payload(objectMapper.writeValueAsString(event.toOutboxPayload()))
-                    .build());
+                    .build();
         } catch (JsonProcessingException ex) {
             throw new IllegalStateException("Outbox 이벤트 직렬화 실패: " + event.outboxEventType(), ex);
         }

--- a/src/main/java/com/stockmanagement/common/outbox/OutboxEventType.java
+++ b/src/main/java/com/stockmanagement/common/outbox/OutboxEventType.java
@@ -11,5 +11,7 @@ public enum OutboxEventType {
     SHIPMENT_CREATE,
     SHIPMENT_RETURNED,
     /** 결제 확정 후 포인트 적립 요청 — 실패 시 릴레이 스케줄러가 재시도한다. */
-    POINT_EARN
+    POINT_EARN,
+    /** ES 상품 색인 동기화 재시도 — 동기 색인 실패 시에만 저장되어 릴레이 스케줄러가 재시도한다. */
+    PRODUCT_SYNC
 }

--- a/src/main/java/com/stockmanagement/domain/product/service/ProductEventListener.java
+++ b/src/main/java/com/stockmanagement/domain/product/service/ProductEventListener.java
@@ -1,9 +1,7 @@
 package com.stockmanagement.domain.product.service;
 
 import com.stockmanagement.common.event.ProductSyncEvent;
-import com.stockmanagement.domain.order.repository.OrderItemRepository;
-import com.stockmanagement.domain.product.repository.ProductRepository;
-import com.stockmanagement.domain.product.review.repository.ReviewRepository;
+import com.stockmanagement.common.outbox.OutboxEventStore;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -18,16 +16,19 @@ import org.springframework.transaction.event.TransactionalEventListener;
  *
  * <p>비동기(@Async)를 사용하지 않는 이유: 검색 색인은 요청 스레드에서 완료되어야 통합 테스트에서
  * 인덱스 refresh 타이밍 문제 없이 즉시 검증 가능하며, 응답 시간 영향은 미미하다 (~10–50 ms).
+ *
+ * <p>동기 색인 실패 시 이벤트를 Outbox({@code PRODUCT_SYNC})에 저장하여
+ * 릴레이 스케줄러가 최대 5회 재시도한다 — ES 일시 장애가 영구 불일치로 남지 않는다.
+ * AFTER_COMMIT 컨텍스트에서는 이미 커밋된 트랜잭션에 참여하면 INSERT가 유실되므로
+ * {@link OutboxEventStore#saveInNewTransaction}(REQUIRES_NEW)을 사용한다.
  */
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class ProductEventListener {
 
-    private final ProductRepository productRepository;
-    private final ProductSearchService productSearchService;
-    private final ReviewRepository reviewRepository;
-    private final OrderItemRepository orderItemRepository;
+    private final ProductIndexSynchronizer indexSynchronizer;
+    private final OutboxEventStore outboxEventStore;
 
     /**
      * 상품 변경이 DB에 커밋된 후 ES 색인을 동기화한다.
@@ -37,34 +38,26 @@ public class ProductEventListener {
      */
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onProductSync(ProductSyncEvent event) {
-        if (event.isDelete()) {
-            safeDeleteFromIndex(event.getProductId());
-        } else {
-            syncToEs(event.getProductId());
+        try {
+            if (event.isDelete()) {
+                indexSynchronizer.deleteFromIndex(event.getProductId());
+            } else {
+                indexSynchronizer.sync(event.getProductId());
+            }
+        } catch (Exception e) {
+            log.error("[ProductEventListener] ES 색인 동기화 실패 — Outbox 재시도 위임. productId={}, delete={}",
+                    event.getProductId(), event.isDelete(), e);
+            enqueueRetry(event);
         }
     }
 
-    private void syncToEs(Long productId) {
+    /** 색인 실패 이벤트를 Outbox에 저장한다. 저장마저 실패하면 로그만 남긴다 (DB 장애 등). */
+    private void enqueueRetry(ProductSyncEvent event) {
         try {
-            productRepository.findById(productId).ifPresentOrElse(
-                    product -> {
-                        long reviewCount = reviewRepository.countByProductId(productId);
-                        long salesCount = orderItemRepository.sumSalesCountByProductId(productId);
-                        productSearchService.index(product, reviewCount, salesCount);
-                        log.debug("[ProductEventListener] ES 색인 완료. productId={}", productId);
-                    },
-                    () -> log.warn("[ProductEventListener] ES 색인 대상 상품 미존재. productId={}", productId)
-            );
+            outboxEventStore.saveInNewTransaction(event);
         } catch (Exception e) {
-            log.error("[ProductEventListener] ES 색인 실패 — DB/ES 불일치 발생. productId={}", productId, e);
-        }
-    }
-
-    private void safeDeleteFromIndex(Long productId) {
-        try {
-            productSearchService.deleteFromIndex(productId);
-        } catch (Exception e) {
-            log.error("[ProductEventListener] ES 색인 삭제 실패 — 삭제된 상품이 검색에 잔존할 수 있음. productId={}", productId, e);
+            log.error("[ProductEventListener] Outbox 저장 실패 — DB/ES 불일치 발생, 재색인 API로 복구 필요. productId={}",
+                    event.getProductId(), e);
         }
     }
 }

--- a/src/main/java/com/stockmanagement/domain/product/service/ProductIndexSynchronizer.java
+++ b/src/main/java/com/stockmanagement/domain/product/service/ProductIndexSynchronizer.java
@@ -1,0 +1,55 @@
+package com.stockmanagement.domain.product.service;
+
+import com.stockmanagement.domain.order.repository.OrderItemRepository;
+import com.stockmanagement.domain.product.repository.ProductRepository;
+import com.stockmanagement.domain.product.review.repository.ReviewRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * 상품 ES 색인 동기화 실행 컴포넌트.
+ *
+ * <p>DB에서 상품을 재로드하고 리뷰·판매 통계를 결합해 색인한다.
+ * 실패 시 예외를 전파하므로 호출자가 재시도 정책을 결정한다:
+ * <ul>
+ *   <li>{@link ProductEventListener} — 동기 1차 시도, 실패 시 Outbox 저장
+ *   <li>{@code OutboxEventProcessor} — Outbox 재시도 (최대 5회)
+ * </ul>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ProductIndexSynchronizer {
+
+    private final ProductRepository productRepository;
+    private final ProductSearchService productSearchService;
+    private final ReviewRepository reviewRepository;
+    private final OrderItemRepository orderItemRepository;
+
+    /**
+     * 상품을 DB에서 재로드하여 통계와 함께 색인한다.
+     * 상품이 존재하지 않으면 경고 로그만 남긴다 (색인 대상 없음 — 재시도 불필요).
+     *
+     * @throws RuntimeException ES 색인 실패 시 전파
+     */
+    public void sync(Long productId) {
+        productRepository.findById(productId).ifPresentOrElse(
+                product -> {
+                    long reviewCount = reviewRepository.countByProductId(productId);
+                    long salesCount = orderItemRepository.sumSalesCountByProductId(productId);
+                    productSearchService.index(product, reviewCount, salesCount);
+                },
+                () -> log.warn("[ProductIndexSynchronizer] 색인 대상 상품 미존재. productId={}", productId)
+        );
+    }
+
+    /**
+     * 상품을 ES 색인에서 삭제한다.
+     *
+     * @throws RuntimeException ES 삭제 실패 시 전파
+     */
+    public void deleteFromIndex(Long productId) {
+        productSearchService.deleteFromIndex(productId);
+    }
+}

--- a/src/test/java/com/stockmanagement/common/outbox/OutboxEventProcessorTest.java
+++ b/src/test/java/com/stockmanagement/common/outbox/OutboxEventProcessorTest.java
@@ -37,6 +37,7 @@ class OutboxEventProcessorTest {
     @Mock ApplicationEventPublisher eventPublisher;
     @Mock ShipmentService shipmentService;
     @Mock PointService pointService;
+    @Mock com.stockmanagement.domain.product.service.ProductIndexSynchronizer productIndexSynchronizer;
     @Spy  ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
 
     @InjectMocks OutboxEventProcessor processor;
@@ -204,6 +205,52 @@ class OutboxEventProcessorTest {
             assertThat(result).isTrue();
             verify(pointService).earn(5L, 50000L, 20L);
             assertThat(outbox.getPublishedAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("PRODUCT_SYNC(delete=false) → productIndexSynchronizer.sync() 호출")
+        void callsSynchronizerForProductSync() throws Exception {
+            String payload = objectMapper.writeValueAsString(
+                    Map.of("productId", 7, "delete", false));
+            OutboxEvent outbox = outboxEvent(14L, OutboxEventType.PRODUCT_SYNC, payload);
+            given(repository.findById(14L)).willReturn(Optional.of(outbox));
+
+            boolean result = processor.processOne(14L);
+
+            assertThat(result).isTrue();
+            verify(productIndexSynchronizer).sync(7L);
+            assertThat(outbox.getPublishedAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("PRODUCT_SYNC(delete=true) → productIndexSynchronizer.deleteFromIndex() 호출")
+        void callsSynchronizerForProductSyncDelete() throws Exception {
+            String payload = objectMapper.writeValueAsString(
+                    Map.of("productId", 8, "delete", true));
+            OutboxEvent outbox = outboxEvent(15L, OutboxEventType.PRODUCT_SYNC, payload);
+            given(repository.findById(15L)).willReturn(Optional.of(outbox));
+
+            boolean result = processor.processOne(15L);
+
+            assertThat(result).isTrue();
+            verify(productIndexSynchronizer).deleteFromIndex(8L);
+            assertThat(outbox.getPublishedAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("PRODUCT_SYNC — 색인 실패 시 retryCount 증가")
+        void productSyncFailureRecorded() throws Exception {
+            String payload = objectMapper.writeValueAsString(
+                    Map.of("productId", 9, "delete", false));
+            OutboxEvent outbox = outboxEvent(16L, OutboxEventType.PRODUCT_SYNC, payload);
+            given(repository.findById(16L)).willReturn(Optional.of(outbox));
+            doThrow(new RuntimeException("ES 연결 실패")).when(productIndexSynchronizer).sync(9L);
+
+            boolean result = processor.processOne(16L);
+
+            assertThat(result).isFalse();
+            assertThat(outbox.getRetryCount()).isEqualTo(1);
+            assertThat(outbox.getPublishedAt()).isNull();
         }
     }
 

--- a/src/test/java/com/stockmanagement/domain/product/service/ProductEventListenerTest.java
+++ b/src/test/java/com/stockmanagement/domain/product/service/ProductEventListenerTest.java
@@ -1,0 +1,80 @@
+package com.stockmanagement.domain.product.service;
+
+import com.stockmanagement.common.event.ProductSyncEvent;
+import com.stockmanagement.common.outbox.OutboxEventStore;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ProductEventListener 단위 테스트")
+class ProductEventListenerTest {
+
+    @Mock ProductIndexSynchronizer indexSynchronizer;
+    @Mock OutboxEventStore outboxEventStore;
+
+    @InjectMocks ProductEventListener listener;
+
+    @Test
+    @DisplayName("색인 성공 → Outbox 저장 없음")
+    void syncSuccess_noOutbox() {
+        listener.onProductSync(new ProductSyncEvent(1L, false));
+
+        verify(indexSynchronizer).sync(1L);
+        verify(outboxEventStore, never()).saveInNewTransaction(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("색인 삭제 성공 → deleteFromIndex 호출, Outbox 저장 없음")
+    void deleteSuccess_noOutbox() {
+        listener.onProductSync(new ProductSyncEvent(2L, true));
+
+        verify(indexSynchronizer).deleteFromIndex(2L);
+        verify(outboxEventStore, never()).saveInNewTransaction(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("색인 실패 → Outbox에 PRODUCT_SYNC 이벤트 저장 (재시도 위임)")
+    void syncFailure_savesOutbox() {
+        doThrow(new RuntimeException("ES 연결 실패")).when(indexSynchronizer).sync(3L);
+        ProductSyncEvent event = new ProductSyncEvent(3L, false);
+
+        listener.onProductSync(event); // 예외를 전파하지 않는다
+
+        ArgumentCaptor<ProductSyncEvent> captor = ArgumentCaptor.forClass(ProductSyncEvent.class);
+        verify(outboxEventStore).saveInNewTransaction(captor.capture());
+        assertThat(captor.getValue().getProductId()).isEqualTo(3L);
+        assertThat(captor.getValue().isDelete()).isFalse();
+    }
+
+    @Test
+    @DisplayName("색인 삭제 실패 → Outbox에 delete=true 이벤트 저장")
+    void deleteFailure_savesOutbox() {
+        doThrow(new RuntimeException("ES 연결 실패")).when(indexSynchronizer).deleteFromIndex(4L);
+
+        listener.onProductSync(new ProductSyncEvent(4L, true));
+
+        ArgumentCaptor<ProductSyncEvent> captor = ArgumentCaptor.forClass(ProductSyncEvent.class);
+        verify(outboxEventStore).saveInNewTransaction(captor.capture());
+        assertThat(captor.getValue().isDelete()).isTrue();
+    }
+
+    @Test
+    @DisplayName("Outbox 저장마저 실패 → 예외를 전파하지 않는다 (로그만)")
+    void outboxFailure_swallowed() {
+        doThrow(new RuntimeException("ES 연결 실패")).when(indexSynchronizer).sync(5L);
+        doThrow(new RuntimeException("DB 연결 실패")).when(outboxEventStore)
+                .saveInNewTransaction(org.mockito.ArgumentMatchers.any());
+
+        listener.onProductSync(new ProductSyncEvent(5L, false)); // 예외 없이 종료
+    }
+}


### PR DESCRIPTION
## 개요

`ProductEventListener`가 색인 실패를 로그만 남기고 끝내서 ES 일시 장애가 다음 상품 수정 전까지 **영구 DB/ES 불일치**로 남던 문제를 수정한다. 기존 Outbox 인프라(재시도 5회 + 지수 백오프 + dead-letter 메트릭)를 재사용한다.

## 설계

- **동기 1차 시도 유지**: 정상 경로의 색인 지연 없음 (기존 동작 그대로)
- **실패 시에만 Outbox 저장**: `PRODUCT_SYNC` 이벤트 → 릴레이 스케줄러가 재시도, 5회 초과 시 dead-letter 메트릭으로 노출 → 재색인 API(#210)로 복구
- 색인 로직을 `ProductIndexSynchronizer`로 추출해 리스너(1차)와 `OutboxEventProcessor`(재시도)가 공유 — 로직 중복 없음
- 재시도는 DB에서 상품을 재로드하므로 자연 멱등

## 주의점: `saveInNewTransaction`

리스너는 AFTER_COMMIT 단계에서 실행되는데, 이 시점에 기존 `save()`(MANDATORY)로 저장하면 **이미 커밋된 트랜잭션에 참여하여 INSERT가 조용히 유실**된다. 이를 위해 `OutboxEventStore.saveInNewTransaction()`(REQUIRES_NEW)을 추가했다. Outbox 저장마저 실패(DB 장애)하면 로그만 남긴다 — 이 경우 재색인 API가 최후 복구 수단.

## 테스트

- `ProductEventListenerTest` 신규 5건: 성공 시 Outbox 미저장 / 색인·삭제 실패 시 각각 저장 / Outbox 저장 실패 시 예외 미전파
- `OutboxEventProcessorTest` +3건: PRODUCT_SYNC sync·delete 디스패치, 실패 시 retryCount 증가
- outbox·product 단위 + ES 통합 테스트 전체 통과

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)