### PR TITLE
fix: ES 색인 stale 해소 — 리뷰·판매·카테고리명 변경 시 재색인 (#213)

### DIFF
--- a/src/main/java/com/stockmanagement/domain/order/service/OrderPaymentService.java
+++ b/src/main/java/com/stockmanagement/domain/order/service/OrderPaymentService.java
@@ -1,6 +1,7 @@
 package com.stockmanagement.domain.order.service;
 
 import com.stockmanagement.common.event.OrderCancelledEvent;
+import com.stockmanagement.common.event.ProductSyncEvent;
 import com.stockmanagement.common.exception.BusinessException;
 import com.stockmanagement.common.exception.ErrorCode;
 import com.stockmanagement.common.outbox.OutboxEventStore;
@@ -15,6 +16,7 @@ import com.stockmanagement.domain.order.repository.OrderStatusHistoryRepository;
 import com.stockmanagement.domain.point.service.PointService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -36,6 +38,7 @@ public class OrderPaymentService {
     private final PointService pointService;
     private final OutboxEventStore outboxEventStore;
     private final OrderStatusHistoryRepository historyRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     /**
      * 결제 완료 후 주문을 확정한다 — Payment 도메인에서 호출.
@@ -60,6 +63,7 @@ public class OrderPaymentService {
         }
 
         recordHistory(order.getId(), previousStatus, OrderStatus.CONFIRMED, null);
+        publishProductSync(order); // ES salesCount 갱신 (popular 정렬 최신화)
         return order;
     }
 
@@ -92,6 +96,7 @@ public class OrderPaymentService {
 
         recordHistory(order.getId(), previousStatus, OrderStatus.CANCELLED, null);
         outboxEventStore.save(new OrderCancelledEvent(order.getId(), order.getUserId(), "PAYMENT_REFUNDED"));
+        publishProductSync(order); // ES salesCount 갱신 (환불 시 판매량 차감 반영)
     }
 
     /**
@@ -136,6 +141,14 @@ public class OrderPaymentService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
         order.resetPaymentFailed();
         recordHistory(order.getId(), OrderStatus.PAYMENT_IN_PROGRESS, OrderStatus.PENDING, "system:stuck-payment-reset");
+    }
+
+    /** 주문에 포함된 상품들의 ES 재색인 이벤트를 발행한다 — 커밋 후 리스너가 salesCount를 재계산한다. */
+    private void publishProductSync(Order order) {
+        order.getItems().stream()
+                .map(item -> item.getProduct().getId())
+                .distinct()
+                .forEach(productId -> eventPublisher.publishEvent(new ProductSyncEvent(productId, false)));
     }
 
     private String currentUser() {

--- a/src/main/java/com/stockmanagement/domain/product/category/service/CategoryService.java
+++ b/src/main/java/com/stockmanagement/domain/product/category/service/CategoryService.java
@@ -7,10 +7,12 @@ import com.stockmanagement.domain.product.category.dto.CategoryResponse;
 import com.stockmanagement.domain.product.category.dto.CategoryUpdateRequest;
 import com.stockmanagement.domain.product.category.entity.Category;
 import com.stockmanagement.domain.product.category.repository.CategoryRepository;
+import com.stockmanagement.common.event.ProductSyncEvent;
 import com.stockmanagement.domain.product.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,6 +35,7 @@ public class CategoryService {
 
     private final CategoryRepository categoryRepository;
     private final ProductRepository productRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @CacheEvict(cacheNames = "categories", allEntries = true)
     @Transactional
@@ -121,7 +124,15 @@ public class CategoryService {
         }
 
         Category parent = resolveParent(request.getParentId());
+        boolean nameChanged = !newName.equals(category.getName());
         category.update(newName, request.getDescription(), parent);
+
+        // 카테고리명 변경 시 소속 상품 ES 재색인 — ES 문서가 카테고리를 이름(keyword)으로 저장하므로
+        // 갱신하지 않으면 이름 필터·키워드 검색이 옛 이름으로 남는다
+        if (nameChanged) {
+            productRepository.findIdsByCategoryId(id)
+                    .forEach(productId -> eventPublisher.publishEvent(new ProductSyncEvent(productId, false)));
+        }
         return CategoryResponse.from(category);
     }
 

--- a/src/main/java/com/stockmanagement/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/stockmanagement/domain/product/repository/ProductRepository.java
@@ -89,6 +89,10 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
            countQuery = "SELECT COUNT(DISTINCT p) FROM Product p LEFT JOIN Review r ON r.productId = p.id WHERE p.status = :status")
     Page<Product> findPopularByStatus(@Param("status") ProductStatus status, Pageable pageable);
 
+    /** 카테고리 소속 상품 ID 목록 — 카테고리명 변경 시 ES 재색인 대상 조회용 */
+    @Query("SELECT p.id FROM Product p WHERE p.category.id = :categoryId")
+    List<Long> findIdsByCategoryId(@Param("categoryId") Long categoryId);
+
     /** countActiveProductsByCategoryIds() 결과를 Map으로 변환한다. */
     default Map<Long, Long> countMapByCategoryIds(Collection<Long> ids) {
         return countActiveProductsByCategoryIds(ids).stream()

--- a/src/main/java/com/stockmanagement/domain/product/review/service/ReviewService.java
+++ b/src/main/java/com/stockmanagement/domain/product/review/service/ReviewService.java
@@ -13,8 +13,10 @@ import com.stockmanagement.domain.product.review.repository.ReviewRepository;
 import com.stockmanagement.domain.user.entity.User;
 import com.stockmanagement.domain.user.repository.UserRepository;
 import com.stockmanagement.common.dto.CursorPage;
+import com.stockmanagement.common.event.ProductSyncEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -36,6 +38,7 @@ public class ReviewService {
     private final ProductRepository productRepository;
     private final OrderRepository orderRepository;
     private final UserRepository userRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     /**
      * 리뷰를 작성한다.
@@ -64,7 +67,10 @@ public class ReviewService {
                 .content(request.getContent())
                 .build();
 
-        return ReviewResponse.from(reviewRepository.save(review));
+        ReviewResponse response = ReviewResponse.from(reviewRepository.save(review));
+        // ES 색인의 reviewCount 갱신 (review 정렬 최신화) — 커밋 후 리스너가 재색인
+        eventPublisher.publishEvent(new ProductSyncEvent(productId, false));
+        return response;
     }
 
     /**
@@ -156,6 +162,8 @@ public class ReviewService {
         }
 
         reviewRepository.delete(review);
+        // ES 색인의 reviewCount 갱신 — 커밋 후 리스너가 재색인
+        eventPublisher.publishEvent(new ProductSyncEvent(productId, false));
     }
 
     /**

--- a/src/test/java/com/stockmanagement/domain/order/service/OrderPaymentServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/order/service/OrderPaymentServiceTest.java
@@ -53,6 +53,9 @@ class OrderPaymentServiceTest {
     @Mock
     private OrderStatusHistoryRepository historyRepository;
 
+    @Mock
+    private org.springframework.context.ApplicationEventPublisher eventPublisher;
+
     @InjectMocks
     private OrderPaymentService orderPaymentService;
 
@@ -98,6 +101,17 @@ class OrderPaymentServiceTest {
     @Nested
     @DisplayName("confirm()")
     class Confirm {
+
+        @Test
+        @DisplayName("확정 시 상품 ES 재색인 이벤트 발행 — salesCount 갱신 (#213)")
+        void confirmPublishesProductSync() {
+            given(orderRepository.findByIdWithItemsForUpdate(1L)).willReturn(Optional.of(order));
+
+            orderPaymentService.confirm(1L);
+
+            verify(eventPublisher).publishEvent(
+                    any(com.stockmanagement.common.event.ProductSyncEvent.class));
+        }
 
         @Test
         @DisplayName("PENDING 주문 확정 — CONFIRMED 전환 및 재고 confirmAllocation 호출")

--- a/src/test/java/com/stockmanagement/domain/product/category/service/CategoryServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/product/category/service/CategoryServiceTest.java
@@ -37,6 +37,9 @@ class CategoryServiceTest {
     @Mock
     private ProductRepository productRepository;
 
+    @Mock
+    private org.springframework.context.ApplicationEventPublisher eventPublisher;
+
     @InjectMocks
     private CategoryService categoryService;
 
@@ -205,6 +208,37 @@ class CategoryServiceTest {
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                             .isEqualTo(ErrorCode.INVALID_INPUT));
+        }
+
+        @Test
+        @DisplayName("이름 변경 → 소속 상품 ES 재색인 이벤트 발행 (#213)")
+        void nameChangePublishesProductSync() {
+            given(categoryRepository.findById(1L)).willReturn(Optional.of(parent));
+
+            CategoryUpdateRequest request = mock(CategoryUpdateRequest.class);
+            given(request.getName()).willReturn("가전"); // "전자" → "가전"
+            given(request.getParentId()).willReturn(null);
+            given(categoryRepository.existsByNameAndIdNot("가전", 1L)).willReturn(false);
+            given(productRepository.findIdsByCategoryId(1L)).willReturn(java.util.List.of(10L, 11L));
+
+            categoryService.update(1L, request);
+
+            verify(eventPublisher, times(2))
+                    .publishEvent(any(com.stockmanagement.common.event.ProductSyncEvent.class));
+        }
+
+        @Test
+        @DisplayName("이름 미변경 → ES 재색인 이벤트 미발행")
+        void noNameChangeNoProductSync() {
+            given(categoryRepository.findById(1L)).willReturn(Optional.of(parent));
+
+            CategoryUpdateRequest request = mock(CategoryUpdateRequest.class);
+            given(request.getName()).willReturn("전자"); // 동일 이름
+            given(request.getParentId()).willReturn(null);
+
+            categoryService.update(1L, request);
+
+            verify(eventPublisher, never()).publishEvent(any());
         }
     }
 }

--- a/src/test/java/com/stockmanagement/domain/product/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/product/review/service/ReviewServiceTest.java
@@ -38,6 +38,7 @@ class ReviewServiceTest {
     @Mock private ProductRepository productRepository;
     @Mock private OrderRepository orderRepository;
     @Mock private UserRepository userRepository;
+    @Mock private org.springframework.context.ApplicationEventPublisher eventPublisher;
 
     @InjectMocks private ReviewService reviewService;
 
@@ -79,6 +80,8 @@ class ReviewServiceTest {
 
             assertThat(response.getRating()).isEqualTo(5);
             verify(reviewRepository).save(any());
+            // ES reviewCount 갱신용 재색인 이벤트 발행 (#213)
+            verify(eventPublisher).publishEvent(any(com.stockmanagement.common.event.ProductSyncEvent.class));
         }
 
         @Test
@@ -139,6 +142,8 @@ class ReviewServiceTest {
             reviewService.delete(1L, 10L, 2L);
 
             verify(reviewRepository).delete(r);
+            // ES reviewCount 갱신용 재색인 이벤트 발행 (#213)
+            verify(eventPublisher).publishEvent(any(com.stockmanagement.common.event.ProductSyncEvent.class));
         }
 
         @Test


### PR DESCRIPTION
## 개요

`ProductSyncEvent`가 상품 CRUD에서만 발행되어 ES 색인의 `reviewCount`/`salesCount`/카테고리명이 상품 수정 전까지 stale로 남던 문제를 수정한다.

## 변경

| 트리거 | 발행 위치 | 갱신 대상 |
|---|---|---|
| 리뷰 작성/삭제 | `ReviewService.create/delete` | reviewCount (`review` 정렬) |
| 결제 확정 | `OrderPaymentService.confirm` | salesCount (`popular` 정렬) |
| 전액 환불 | `OrderPaymentService.refund` | salesCount 차감 반영 |
| 카테고리명 변경 | `CategoryService.update` | category keyword (이름 필터·키워드 검색) |

- 모두 기존 `ProductSyncEvent` → AFTER_COMMIT 리스너 경로 재사용 (색인 로직 변경 없음)
- 카테고리명 변경은 소속 상품 ID 목록(`findIdsByCategoryId` 신규)을 순회하며 이벤트 발행 — 이름이 실제로 변경된 경우에만
- 주문 확정/환불은 주문 내 상품 ID를 distinct로 발행

## 트레이드오프

- 결제 확정 경로에 상품 수만큼 ES 색인이 추가되지만 AFTER_COMMIT이라 결제 트랜잭션에는 영향 없음 (ES 장애 시에도 socket-timeout 5s(#216) + Outbox 재시도(#217)로 방어)
- 상품 수가 많은 카테고리의 이름 변경은 관리자 요청이 느려질 수 있음 — 관리 작업 빈도상 허용, 대량이면 재색인 API(#215) 사용 가능

## 테스트

- 단위 테스트 5건 추가 (리뷰 작성/삭제 시 발행, 확정 시 발행, 카테고리명 변경 시 발행 / 미변경 시 미발행)
- 전체 테스트 스위트 통과

Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)