### PR TITLE
fix: ES minor 정리 — fallback 필터 통합·updatedAt·suggest rate limit (#214)

### DIFF
--- a/src/main/java/com/stockmanagement/domain/product/controller/ProductController.java
+++ b/src/main/java/com/stockmanagement/domain/product/controller/ProductController.java
@@ -1,6 +1,7 @@
 package com.stockmanagement.domain.product.controller;
 
 import com.stockmanagement.common.dto.ApiResponse;
+import com.stockmanagement.common.ratelimit.RateLimit;
 import com.stockmanagement.common.security.CurrentUserId;
 import com.stockmanagement.domain.product.dto.ProductCreateRequest;
 import com.stockmanagement.domain.product.dto.ProductResponse;
@@ -68,6 +69,7 @@ public class ProductController {
 
     @Operation(summary = "검색 자동완성", description = "검색어 prefix로 상품명 자동완성 후보를 반환한다. 최대 10건.")
     @GetMapping("/search/suggestions")
+    @RateLimit(limit = 30, windowSeconds = 60, keyType = RateLimit.KeyType.IP)
     public ApiResponse<SuggestResponse> suggest(
             @RequestParam @Size(min = 1, max = 200, message = "검색어는 1~200자여야 합니다.") String q) {
         return ApiResponse.ok(new SuggestResponse(productService.suggest(q, 10)));

--- a/src/main/java/com/stockmanagement/domain/product/document/ProductDocument.java
+++ b/src/main/java/com/stockmanagement/domain/product/document/ProductDocument.java
@@ -64,16 +64,14 @@ public class ProductDocument {
     @Field(type = FieldType.Date, format = {}, pattern = "uuuu-MM-dd'T'HH:mm:ss.SSSSSS||uuuu-MM-dd'T'HH:mm:ss.SSS||uuuu-MM-dd'T'HH:mm:ss")
     private LocalDateTime createdAt;
 
+    @Field(type = FieldType.Date, format = {}, pattern = "uuuu-MM-dd'T'HH:mm:ss.SSSSSS||uuuu-MM-dd'T'HH:mm:ss.SSS||uuuu-MM-dd'T'HH:mm:ss")
+    private LocalDateTime updatedAt;
+
     @Field(type = FieldType.Long)
     private long reviewCount;
 
     @Field(type = FieldType.Long)
     private long salesCount;
-
-    /** Product JPA 엔티티로부터 ES 문서를 생성한다. */
-    public static ProductDocument from(Product product) {
-        return from(product, 0L, 0L);
-    }
 
     /** Product JPA 엔티티 + 리뷰/판매 통계를 포함한 ES 문서를 생성한다. */
     public static ProductDocument from(Product product, long reviewCount, long salesCount) {
@@ -88,6 +86,7 @@ public class ProductDocument {
                 .status(product.getStatus() != null ? product.getStatus().name() : null)
                 .thumbnailUrl(product.getThumbnailUrl())
                 .createdAt(product.getCreatedAt())
+                .updatedAt(product.getUpdatedAt())
                 .reviewCount(reviewCount)
                 .salesCount(salesCount)
                 .build();
@@ -110,6 +109,7 @@ public class ProductDocument {
                 .thumbnailUrl(thumbnailUrl)
                 .status(status != null ? ProductStatus.valueOf(status) : null)
                 .createdAt(createdAt)
+                .updatedAt(updatedAt)
                 .build();
     }
 }

--- a/src/main/java/com/stockmanagement/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/stockmanagement/domain/product/repository/ProductRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -20,7 +21,7 @@ import java.util.stream.Collectors;
  * <p>Spring Data JPA의 쿼리 메서드 네이밍 규칙을 사용해 쿼리를 자동 생성한다.
  * 복잡한 동적 쿼리가 필요해지면 Querydsl 또는 @Query로 확장한다.
  */
-public interface ProductRepository extends JpaRepository<Product, Long> {
+public interface ProductRepository extends JpaRepository<Product, Long>, JpaSpecificationExecutor<Product> {
 
     /** SKU 중복 여부를 빠르게 확인 — 상품 등록 시 중복 검사용 */
     boolean existsBySku(String sku);
@@ -43,16 +44,6 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     Page<Product> findAll(Pageable pageable);
 
     /**
-     * ACTIVE 상품 중 상품명 또는 SKU로 검색 (대소문자 무시).
-     * countQuery 분리로 페이징 카운트 쿼리의 정확성 보장.
-     */
-    @Query(value = "SELECT p FROM Product p LEFT JOIN FETCH p.category WHERE p.status = :status AND " +
-                   "(LOWER(p.name) LIKE LOWER(CONCAT('%', :q, '%')) ESCAPE '!' OR LOWER(p.sku) LIKE LOWER(CONCAT('%', :q, '%')) ESCAPE '!')",
-           countQuery = "SELECT COUNT(p) FROM Product p WHERE p.status = :status AND " +
-                        "(LOWER(p.name) LIKE LOWER(CONCAT('%', :q, '%')) ESCAPE '!' OR LOWER(p.sku) LIKE LOWER(CONCAT('%', :q, '%')) ESCAPE '!')")
-    Page<Product> searchByStatus(@Param("status") ProductStatus status, @Param("q") String query, Pageable pageable);
-
-    /**
      * 전체 상태의 상품 중 상품명 또는 SKU로 검색 (대소문자 무시, 관리자 전용).
      * countQuery 분리로 페이징 카운트 쿼리의 정확성 보장.
      */
@@ -61,13 +52,6 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
            countQuery = "SELECT COUNT(p) FROM Product p WHERE " +
                         "LOWER(p.name) LIKE LOWER(CONCAT('%', :q, '%')) ESCAPE '!' OR LOWER(p.sku) LIKE LOWER(CONCAT('%', :q, '%')) ESCAPE '!'")
     Page<Product> searchAll(@Param("q") String query, Pageable pageable);
-
-    /** 카테고리 ID 목록 필터 — ACTIVE 상품 중 해당 카테고리에 속하는 상품만 조회 (하위 카테고리 포함 가능). */
-    @Query(value = "SELECT p FROM Product p LEFT JOIN FETCH p.category WHERE p.status = :status AND p.category.id IN :categoryIds",
-           countQuery = "SELECT COUNT(p) FROM Product p WHERE p.status = :status AND p.category.id IN :categoryIds")
-    Page<Product> findByStatusAndCategoryIdIn(@Param("status") ProductStatus status,
-                                              @Param("categoryIds") Collection<Long> categoryIds,
-                                              Pageable pageable);
 
     /**
      * 카테고리별 ACTIVE 상품 수를 배치 조회한다.

--- a/src/main/java/com/stockmanagement/domain/product/repository/ProductSpecification.java
+++ b/src/main/java/com/stockmanagement/domain/product/repository/ProductSpecification.java
@@ -1,0 +1,66 @@
+package com.stockmanagement.domain.product.repository;
+
+import com.stockmanagement.common.util.SqlUtils;
+import com.stockmanagement.domain.product.dto.ProductSearchRequest;
+import com.stockmanagement.domain.product.entity.Product;
+import com.stockmanagement.domain.product.entity.ProductStatus;
+import jakarta.persistence.criteria.Predicate;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * 상품 동적 검색 조건 빌더 (MySQL fallback용).
+ * JPA Criteria API를 사용해 null이 아닌 조건만 AND 결합한다.
+ *
+ * <p>ES 장애 시 fallback 경로와 categoryId 단독 조회에서 사용되며,
+ * 키워드(name/SKU LIKE)·가격 범위·카테고리명·카테고리 ID 필터를 모두 지원한다.
+ */
+public class ProductSpecification {
+
+    private ProductSpecification() {}
+
+    /**
+     * ACTIVE 상품 대상 검색 Specification을 생성한다.
+     *
+     * @param request     검색 조건 (q, minPrice, maxPrice, category) — 필드가 null이면 해당 조건 무시
+     * @param categoryIds 카테고리 ID 필터 (하위 카테고리 포함 가능) — 비어 있으면 무시
+     */
+    public static Specification<Product> activeWithFilters(ProductSearchRequest request,
+                                                           Collection<Long> categoryIds) {
+        return (root, query, cb) -> {
+            List<Predicate> predicates = new ArrayList<>();
+            predicates.add(cb.equal(root.get("status"), ProductStatus.ACTIVE));
+
+            // 키워드 — 상품명/SKU LIKE (대소문자 무시, ES multi_match의 축소판)
+            if (request.getQ() != null && !request.getQ().isBlank()) {
+                String pattern = "%" + SqlUtils.escapeLike(request.getQ()).toLowerCase() + "%";
+                predicates.add(cb.or(
+                        cb.like(cb.lower(root.get("name")), pattern, '!'),
+                        cb.like(cb.lower(root.get("sku")), pattern, '!')));
+            }
+
+            // 카테고리 ID 필터
+            if (categoryIds != null && !categoryIds.isEmpty()) {
+                predicates.add(root.get("category").get("id").in(categoryIds));
+            }
+
+            // 카테고리명 필터 (정확 일치)
+            if (request.getCategory() != null && !request.getCategory().isBlank()) {
+                predicates.add(cb.equal(root.get("category").get("name"), request.getCategory()));
+            }
+
+            // 가격 범위 필터
+            if (request.getMinPrice() != null) {
+                predicates.add(cb.greaterThanOrEqualTo(root.get("price"), request.getMinPrice()));
+            }
+            if (request.getMaxPrice() != null) {
+                predicates.add(cb.lessThanOrEqualTo(root.get("price"), request.getMaxPrice()));
+            }
+
+            return cb.and(predicates.toArray(new Predicate[0]));
+        };
+    }
+}

--- a/src/main/java/com/stockmanagement/domain/product/service/ProductSearchService.java
+++ b/src/main/java/com/stockmanagement/domain/product/service/ProductSearchService.java
@@ -139,15 +139,9 @@ public class ProductSearchService {
     }
 
     /**
-     * 상품을 Elasticsearch에 색인한다.
-     * ProductService의 create/update/changeStatus에서 호출된다.
+     * 리뷰/판매 통계를 포함해 상품을 Elasticsearch에 색인한다.
+     * {@link ProductIndexSynchronizer}에서 호출된다.
      */
-    public void index(Product product) {
-        productSearchRepository.save(ProductDocument.from(product));
-        log.debug("ES 색인 완료. productId={}", product.getId());
-    }
-
-    /** 리뷰/판매 통계를 포함한 ES 색인. */
     public void index(Product product, long reviewCount, long salesCount) {
         productSearchRepository.save(ProductDocument.from(product, reviewCount, salesCount));
         log.debug("ES 색인 완료. productId={} reviewCount={} salesCount={}", product.getId(), reviewCount, salesCount);

--- a/src/main/java/com/stockmanagement/domain/product/service/ProductService.java
+++ b/src/main/java/com/stockmanagement/domain/product/service/ProductService.java
@@ -22,6 +22,7 @@ import com.stockmanagement.domain.product.entity.Product;
 import com.stockmanagement.domain.product.entity.ProductStatus;
 import com.stockmanagement.domain.product.entity.ProductVariant;
 import com.stockmanagement.domain.product.repository.ProductRepository;
+import com.stockmanagement.domain.product.repository.ProductSpecification;
 import com.stockmanagement.domain.product.repository.ProductVariantRepository;
 import com.stockmanagement.domain.product.image.dto.ProductImageResponse;
 import com.stockmanagement.domain.product.image.repository.ProductImageRepository;
@@ -144,7 +145,8 @@ public class ProductService {
      *
      * <p>검색 조건({@code q}, {@code minPrice}, {@code maxPrice}, {@code category}, {@code sort})이
      * 하나라도 있으면 Elasticsearch로 검색하고, 없으면 MySQL 페이징 조회를 사용한다.
-     * ES 장애 시 MySQL로 fallback하여 서비스 가용성을 유지한다.
+     * ES 장애 시 MySQL로 fallback하며, 모든 필터를 Specification으로 동일하게 적용한다.
+     * (단, {@code popular}/{@code review} 정렬은 ES 전용 — fallback에서는 기본 정렬 사용)
      */
     public Page<ProductResponse> getList(Pageable pageable, ProductSearchRequest request, Long userId) {
         if (request != null && request.hasSearchCondition()) {
@@ -155,24 +157,27 @@ public class ProductService {
                 log.warn("Elasticsearch 검색 실패, MySQL fallback 사용. query={}", request.getQ(), e);
             }
         }
-        // ES 미사용 또는 fallback: sort/keyword를 MySQL에서 처리
+        // ES 미사용 또는 fallback: 필터를 Specification으로 MySQL에서 처리
         Pageable effectivePageable = toSortedPageable(pageable, request);
-        String keyword = request != null ? request.getQ() : null;
-        Long categoryId = request != null ? request.getCategoryId() : null;
-        Page<Product> products;
-        if (categoryId != null) {
-            Set<Long> categoryIds = new HashSet<>();
-            categoryIds.add(categoryId);
-            if (request.isIncludeChildren()) {
-                categoryIds.addAll(categoryRepository.findChildIdsByParentId(categoryId));
-            }
-            products = productRepository.findByStatusAndCategoryIdIn(ProductStatus.ACTIVE, categoryIds, effectivePageable);
-        } else if (keyword != null && !keyword.isBlank()) {
-            products = productRepository.searchByStatus(ProductStatus.ACTIVE, escapeLike(keyword), effectivePageable);
-        } else {
-            products = productRepository.findByStatus(ProductStatus.ACTIVE, effectivePageable);
-        }
+        boolean hasFilter = request != null
+                && (request.hasSearchCondition() || request.getCategoryId() != null);
+        Page<Product> products = hasFilter
+                ? productRepository.findAll(
+                        ProductSpecification.activeWithFilters(request, resolveCategoryIds(request)),
+                        effectivePageable)
+                : productRepository.findByStatus(ProductStatus.ACTIVE, effectivePageable);
         return enrichPage(products, userId);
+    }
+
+    /** categoryId 필터 대상 ID 집합 — includeChildren=true이면 하위 카테고리 포함 */
+    private Set<Long> resolveCategoryIds(ProductSearchRequest request) {
+        if (request.getCategoryId() == null) return Set.of();
+        Set<Long> categoryIds = new HashSet<>();
+        categoryIds.add(request.getCategoryId());
+        if (request.isIncludeChildren()) {
+            categoryIds.addAll(categoryRepository.findChildIdsByParentId(request.getCategoryId()));
+        }
+        return categoryIds;
     }
 
     /** sort 파라미터를 Pageable의 Sort로 변환 (MySQL fallback용) */
@@ -299,11 +304,6 @@ public class ProductService {
     }
 
     // ===== 내부 헬퍼 =====
-
-    /** LIKE 패턴 와일드카드(!, %, _)를 이스케이프한다. ESCAPE ! 기준. */
-    private static String escapeLike(String value) {
-        return com.stockmanagement.common.util.SqlUtils.escapeLike(value);
-    }
 
     /** 상품의 전체 variant 가용 재고를 합산한다. */
     private int sumAvailableByProductId(Long productId) {

--- a/src/test/java/com/stockmanagement/domain/product/service/ProductServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/product/service/ProductServiceTest.java
@@ -7,6 +7,7 @@ import com.stockmanagement.domain.inventory.repository.InventoryRepository;
 import com.stockmanagement.domain.product.category.repository.CategoryRepository;
 import com.stockmanagement.domain.product.dto.ProductCreateRequest;
 import com.stockmanagement.domain.product.dto.ProductResponse;
+import com.stockmanagement.domain.product.dto.ProductSearchRequest;
 import com.stockmanagement.domain.product.dto.ProductUpdateRequest;
 import com.stockmanagement.domain.product.entity.Product;
 import com.stockmanagement.domain.product.entity.ProductStatus;
@@ -30,6 +31,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -216,6 +218,56 @@ class ProductServiceTest {
 
             verify(productRepository).findByStatus(ProductStatus.ACTIVE, pageable);
         }
+
+        @Test
+        @DisplayName("ES 장애 시 가격 필터 포함 전체 조건을 Specification으로 fallback 조회한다")
+        void fallsBackToSpecificationOnEsFailure() {
+            Pageable pageable = PageRequest.of(0, 10);
+            ProductSearchRequest request = new ProductSearchRequest();
+            request.setQ("테스트");
+            request.setMinPrice(new BigDecimal("5000"));
+            given(productSearchService.search(any(), any()))
+                    .willThrow(new RuntimeException("ES down"));
+            given(productRepository.findAll(any(Specification.class), any(Pageable.class)))
+                    .willReturn(new PageImpl<>(List.of(product), pageable, 1));
+
+            Page<ProductResponse> result = productService.getList(pageable, request, null);
+
+            assertThat(result.getTotalElements()).isEqualTo(1);
+            verify(productRepository).findAll(any(Specification.class), any(Pageable.class));
+            verify(productRepository, never()).findByStatus(any(), any());
+        }
+
+        @Test
+        @DisplayName("categoryId만 있으면 ES 없이 Specification으로 조회한다")
+        void usesSpecificationForCategoryOnlyBrowsing() {
+            Pageable pageable = PageRequest.of(0, 10);
+            ProductSearchRequest request = new ProductSearchRequest();
+            request.setCategoryId(1L);
+            given(productRepository.findAll(any(Specification.class), any(Pageable.class)))
+                    .willReturn(new PageImpl<>(List.of(product), pageable, 1));
+
+            productService.getList(pageable, request, null);
+
+            verify(productSearchService, never()).search(any(), any());
+            verify(productRepository).findAll(any(Specification.class), any(Pageable.class));
+        }
+
+        @Test
+        @DisplayName("categoryId + includeChildren=true → 하위 카테고리 ID를 함께 조회한다")
+        void includesChildCategoryIds() {
+            Pageable pageable = PageRequest.of(0, 10);
+            ProductSearchRequest request = new ProductSearchRequest();
+            request.setCategoryId(1L);
+            request.setIncludeChildren(true);
+            given(categoryRepository.findChildIdsByParentId(1L)).willReturn(List.of(2L, 3L));
+            given(productRepository.findAll(any(Specification.class), any(Pageable.class)))
+                    .willReturn(Page.empty());
+
+            productService.getList(pageable, request, null);
+
+            verify(categoryRepository).findChildIdsByParentId(1L);
+        }
     }
 
     // ===== update() =====
@@ -288,7 +340,7 @@ class ProductServiceTest {
             productService.delete(1L);
 
             assertThat(product.getStatus()).isEqualTo(ProductStatus.DISCONTINUED);
-            verify(productRepository, never()).delete(any());
+            verify(productRepository, never()).delete(any(Product.class));
         }
 
         @Test

--- a/src/test/java/com/stockmanagement/integration/ProductSearchIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/ProductSearchIntegrationTest.java
@@ -213,6 +213,35 @@ class ProductSearchIntegrationTest extends AbstractIntegrationTest {
                 .andExpect(jsonPath("$.data.content[0].sku").value("IC-001"));
     }
 
+    // ===== 카테고리 ID 단독 조회 — MySQL Specification 경로 (#214) =====
+
+    @Test
+    @DisplayName("categoryId 단독 → MySQL Specification 경로에서 카테고리 필터 적용")
+    void browse_byCategoryIdOnly_mysqlPath() throws Exception {
+        createProduct("헤드셋", "SPEC-001", 90000, "음향기기");
+        createProduct("셔츠", "SPEC-002", 40000, "남성의류");
+        long categoryId = getOrCreateCategory("음향기기");
+
+        mockMvc.perform(get("/api/v1/products")
+                        .param("categoryId", String.valueOf(categoryId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalElements").value(1))
+                .andExpect(jsonPath("$.data.content[0].sku").value("SPEC-001"));
+    }
+
+    // ===== ES 경로 응답 스키마 — updatedAt 포함 (#214) =====
+
+    @Test
+    @DisplayName("ES 검색 결과에 updatedAt 포함 — MySQL 경로와 응답 스키마 일치")
+    void search_responseIncludesUpdatedAt() throws Exception {
+        createProduct("스탠드 조명", "UA-001", 60000, "조명");
+
+        mockMvc.perform(get("/api/v1/products").param("q", "스탠드 조명"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalElements").value(1))
+                .andExpect(jsonPath("$.data.content[0].updatedAt").isNotEmpty());
+    }
+
     // ===== 전체 재색인 (#210) =====
 
     @Test


### PR DESCRIPTION
## 개요
#214의 minor 항목 5건 처리 (4건 적용, 1건 검토 후 미적용).

## 변경 사항

### 1. MySQL fallback 필터 통합 — `ProductSpecification` 신설
기존 fallback은 키워드 또는 categoryId 하나만 처리하고 `minPrice`/`maxPrice`/`category`(이름) 필터를 표시 없이 무시했다.
- `ProductSpecification.activeWithFilters()`: 키워드(name/SKU LIKE, `ESCAPE '!'`)·가격 범위·카테고리명·카테고리 ID(하위 포함)를 null-safe AND 결합 (OrderSpecification 패턴)
- `ProductRepository`가 `JpaSpecificationExecutor` 상속, fallback 전용이던 `searchByStatus`/`findByStatusAndCategoryIdIn` 쿼리 제거
- 필터 없는 기본 목록 조회는 기존 `findByStatus`(fetch join) 유지 — 최다 빈도 경로 성능 보존
- `popular`/`review` 정렬은 ES 전용으로 유지 (fallback 시 기본 정렬, Javadoc 명시)

### 2. ES 경로 응답 스키마 일치 — `updatedAt`
`ProductDocument`에 `updatedAt` 필드 추가(createdAt과 동일 Date 매핑), `toProductResponse()`에 포함. 검색 조건 유무에 따라 `updatedAt`이 null로 바뀌던 불일치 해소.

### 3. 자동완성 rate limit
`GET /api/v1/products/search/suggestions`에 `@RateLimit(limit = 30, windowSeconds = 60, keyType = IP)` 적용 — 공개 엔드포인트의 키 입력당 ES 쿼리 남용 방지.

### 4. 미사용 오버로드 제거
`ProductSearchService.index(Product)` 및 이것만 사용하던 `ProductDocument.from(Product)` 제거 — 사용 시 reviewCount/salesCount를 0으로 덮어쓰는 함정 제거.

### 5. price double 정밀도 — 검토 후 미적용
KRW 정수 가격은 double의 정확 표현 범위(2^53) 내라 손실이 없고, enrich 단계에 상품 배치 조회를 추가하는 비용이 더 크다고 판단.

## 테스트
- `ProductServiceTest`: fallback Specification 경로 3건 추가 (ES 장애 fallback, categoryId 단독, includeChildren)
- `ProductSearchIntegrationTest`: categoryId 단독 MySQL 경로 필터링, ES 경로 updatedAt 포함 2건 추가
- 전체 테스트 스위트 통과 (BUILD SUCCESSFUL, Testcontainers 포함)

## 배포 참고
- ES 문서에 `updatedAt`을 채우려면 배포 후 재색인 API 1회 실행 필요 (#215의 categoryId 백필과 동일 시점에 처리 가능)

Closes #214