### PR TITLE
docs: 코드 리뷰 minor 정리 — 주석·중복 규칙·Javadoc (#203)

### DIFF
--- a/src/main/java/com/stockmanagement/common/config/SecurityConfig.java
+++ b/src/main/java/com/stockmanagement/common/config/SecurityConfig.java
@@ -80,9 +80,8 @@ public class SecurityConfig {
                         .requestMatchers("/api/v1/auth/email/resend").authenticated()
                         .requestMatchers("/api/v1/auth/**").permitAll()
                         .requestMatchers("/api/v1/payments/webhook").permitAll()
-                        // Actuator — health/info/prometheus는 공개 (내부망 전용), 나머지는 ADMIN 전용
+                        // Actuator — health/info만 공개, 나머지(prometheus 포함)는 ADMIN 전용
                         .requestMatchers("/actuator/health", "/actuator/info").permitAll()
-                        .requestMatchers("/actuator/prometheus").hasRole("ADMIN")
                         .requestMatchers("/actuator/**").hasRole("ADMIN")
                         // Swagger UI — swagger.public=false(운영) 시 ADMIN 인증 필요
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html")

--- a/src/main/java/com/stockmanagement/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/stockmanagement/domain/payment/service/PaymentService.java
@@ -340,15 +340,6 @@ public class PaymentService {
         return PaymentResponse.from(payment);
     }
 
-    /**
-     * 주문 ID로 결제 정보를 조회한다. 결제 레코드가 없으면 빈 Optional을 반환한다.
-     * ADMIN은 전체 조회 가능, USER는 본인 주문만 조회 가능.
-     *
-     * @param orderId  조회할 주문 ID
-     * @param username 요청자 username
-     * @param isAdmin  ADMIN 여부
-     * @return 결제 정보 (없으면 Optional.empty())
-     */
     /** 현재 인증 사용자의 결제 목록을 최신순으로 페이징 조회한다. 주문 요약 정보 포함. */
     public Page<PaymentResponse> getMyPayments(Long userId, Pageable pageable) {
         Page<Payment> payments = paymentRepository.findByUserId(userId, pageable);
@@ -367,6 +358,15 @@ public class PaymentService {
         });
     }
 
+    /**
+     * 주문 ID로 결제 정보를 조회한다. 결제 레코드가 없으면 빈 Optional을 반환한다.
+     * ADMIN은 전체 조회 가능, USER는 본인 주문만 조회 가능.
+     *
+     * @param orderId 조회할 주문 ID
+     * @param userId  요청자 사용자 ID
+     * @param isAdmin ADMIN 여부
+     * @return 결제 정보 (없으면 Optional.empty())
+     */
     public Optional<PaymentResponse> getByOrderId(Long orderId, Long userId, boolean isAdmin) {
         if (!isAdmin) {
             Long ownerUserId = orderRepository.findUserIdById(orderId)


### PR DESCRIPTION
## 개요
#203의 3개 항목 중 2건 적용, 1건(CSP)은 장기 검토 항목으로 유지.

## 변경 사항

### 1. SecurityConfig actuator 주석·규칙 정리
- 주석 "health/info/prometheus는 공개"가 실제 규칙(`/actuator/prometheus` → ADMIN)과 불일치 → 주석을 코드 기준으로 수정
- `/actuator/prometheus` ADMIN 규칙은 바로 아래 `/actuator/**` ADMIN 규칙에 포함되므로 제거 (동작 변화 없음)

### 2. PaymentService Javadoc 위치 교정
- `getByOrderId`용 Javadoc이 `getMyPayments()` 위에 잘못 붙어 있던 것을 제자리로 이동
- 이미 제거된 `username` 파라미터 설명을 현재 시그니처(`userId`)에 맞게 갱신

### 3. CSP `script-src 'unsafe-inline'` — 미적용
Swagger·어드민 SPA 지원을 위한 의도적 트레이드오프로 유지. nonce 기반 CSP 전환은 프론트 정적 페이지 구조 변경이 필요해 별도 작업으로 분리하는 것이 적절.

## 테스트
- 동작 변화 없는 주석·중복 규칙 정리 — 컴파일 및 PaymentServiceTest 통과 확인

Closes #203
