### PR TITLE
release: ES 상품 검색 개선 반영 (#209~#214)

### DIFF
--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -91,6 +91,10 @@ ALB가 요청을 두 인스턴스에 분산하므로 동일 상품 주문이 Ser
 7. [N+1 쿼리 및 배치 처리 최적화](#7-n1-쿼리-및-배치-처리-최적화)
 8. [보안 취약점](#8-보안-취약점)
 9. [CategoryService Redis 캐시](#9-categoryservice-redis-캐시)
+10. [코드 리뷰 개선 항목](#10-코드-리뷰-개선-항목)
+11. [Self-Invocation으로 인한 부분 취소 트랜잭션 무효화](#11-self-invocation으로-인한-부분-취소-트랜잭션-무효화)
+12. [재고 락 획득 순서 불일치와 저재고 경보 중복](#12-재고-락-획득-순서-불일치와-저재고-경보-중복)
+13. [Elasticsearch 색인 정합성](#13-elasticsearch-색인-정합성)
 
 ---
 
@@ -787,6 +791,132 @@ public CategoryResponse create(CategoryCreateRequest request) { ... }
 
 ---
 
+## 11. Self-Invocation으로 인한 부분 취소 트랜잭션 무효화
+
+> 이슈 [#200](https://github.com/nameless0422/stock-management-api/issues/200) · PR [#204](https://github.com/nameless0422/stock-management-api/pull/204)
+
+### 배경 및 문제정의
+
+* **상황:** 전체 코드베이스 리뷰 중 주문 아이템 부분 취소(`OrderCommandService.cancelItems`)의 트랜잭션 경계를 검토
+* **문제:** `@Transactional(NOT_SUPPORTED)` 메서드가 같은 클래스의 `@Transactional` 메서드(`validateAndPrepare`, `applyItemCancel`)를 `this`로 직접 호출 — Spring 트랜잭션은 프록시 기반이므로 **자기 호출(self-invocation)에는 AOP가 적용되지 않는다**
+
+```
+cancelItems()  [@Transactional(NOT_SUPPORTED)]  ← 프록시 경유 (정상)
+ ├─ this.validateAndPrepare()  [@Transactional]  ← 프록시 우회 → 트랜잭션 없음
+ ├─ Toss 부분 환불 API 호출
+ └─ this.applyItemCancel()     [@Transactional]  ← 프록시 우회 → 트랜잭션 없음
+```
+
+`spring.jpa.open-in-view=false` 환경이므로 실제 동작은:
+
+* `FOR UPDATE` 비관적 락이 리포지토리 자체의 짧은 트랜잭션 종료와 함께 즉시 해제
+* 반환된 Order/OrderItem은 **detached 상태** → `item.cancel()`, `order.partialCancel()` 변경이 dirty checking 없이 **유실**
+* 반면 재고 해제·포인트 반환·이력 저장은 각자 프록시 트랜잭션으로 **커밋됨** → 정합성 붕괴
+* 주문 아이템이 ACTIVE로 남아 있으므로 동일 아이템 재취소가 검증을 통과 → **Toss 중복 환불 + 재고 이중 해제 반복 가능** (금전 손실)
+
+부분 취소 경로에 테스트가 한 건도 없어 779개 테스트가 이를 잡지 못했다.
+
+### 솔루션: Short TX를 별도 빈으로 분리
+
+결제 도메인이 이미 사용 중인 패턴(`PaymentTransactionHelper`)을 그대로 적용 — 외부 HTTP 호출 전후의 DB 연산을 **별도 빈**의 `@Transactional` 메서드로 분리하여 항상 프록시를 경유하게 한다.
+
+### 기능 구현
+
+* `OrderItemCancelTransactionHelper` 신설 — `validateAndPrepare`(검증 + 환불 금액 계산), `applyItemCancel`(아이템 취소 + 재고 해제 + 상태 전이)을 이동
+* `cancelItems()`는 분산 락 + Toss 호출 + 헬퍼 위임만 담당 (로직 변경 없음)
+* 회귀 통합 테스트 신설: 부분 취소 → 상태 **영속화** 검증, 동일 아이템 재취소 409 + Toss 재환불 없음(`times(1)`), 전체 취소 시 CANCELLED 전이
+
+### Trade-off
+
+클래스가 하나 늘어나지만, self-invocation 함정을 구조적으로 제거하고 결제 도메인과 동일한 패턴으로 통일된다. 대안인 self-injection(자기 자신 주입)은 순환 참조 경고와 가독성 문제로 배제했다.
+
+### 결과
+
+* 부분 취소의 상태 변경이 DB에 정상 영속화 — 중복 환불·재고 이중 해제 경로 차단
+* `@CacheEvict`도 프록시 경유로 정상 동작
+* 교훈: **Short TX 분리는 반드시 별도 빈으로** — 같은 클래스 내 `@Transactional` 호출은 무효
+
+---
+
+## 12. 재고 락 획득 순서 불일치와 저재고 경보 중복
+
+> 이슈 [#201](https://github.com/nameless0422/stock-management-api/issues/201), [#202](https://github.com/nameless0422/stock-management-api/issues/202) · PR [#205](https://github.com/nameless0422/stock-management-api/pull/205), [#206](https://github.com/nameless0422/stock-management-api/pull/206)
+
+### 배경 및 문제정의
+
+**(1) 락 순서 불일치 — 데드락 가능성 (#202)**
+
+주문 생성은 데드락 방지를 위해 variantId 오름차순으로 재고를 예약하지만, 취소·확정·환불 경로는 아이템 리스트 순서대로 비관적 락을 획득했다.
+
+```
+주문 A 확정: variant 1 락 → variant 2 락 대기
+주문 B 취소: variant 2 락 → variant 1 락 대기   ← 데드락
+```
+
+**(2) 저재고 경보 기준값 오류 (#201)**
+
+```java
+int availableBefore = inventory.getAvailable() + quantity; // reserve 호출 전인데 +quantity
+inventory.reserve(quantity);
+```
+
+`getAvailable()`이 이미 "reserve 전" 값인데 `quantity`를 더해 기준값이 부풀려짐 — 리팩터링 중 계산식의 위치만 이동하며 생긴 결함. 임계값 하향 돌파 감지(`before ≥ threshold && after < threshold`)가 왜곡되어 **이미 임계값 미만인 재고에서도 주문마다 경보 재발행** (관리자 중복 메일).
+
+### 솔루션
+
+* (1) `Order.getItemsSortedByVariant()` 공통 헬퍼 신설 — 다건 재고 락을 획득하는 **7개 경로 전체**(생성·취소·시스템취소·확정·환불·웹훅취소·부분취소)에 동일 정렬 적용
+* (2) `+ quantity` 제거 (한 줄)
+
+### Trade-off
+
+정렬 비용은 주문당 아이템 수(수 개) 수준으로 무시 가능. 공통 헬퍼로 묶어 새 경로 추가 시 정렬 누락이 재발하지 않도록 했다.
+
+### 결과
+
+* 모든 재고 락 경로가 동일한 순서로 획득 — 순서 역전에 의한 데드락 구조적 차단
+* 저재고 경보가 임계값을 처음 하향 돌파하는 순간에만 1회 발행 — 회귀 테스트로 고정 (수정 전 코드에서는 실패하는 테스트)
+
+---
+
+## 13. Elasticsearch 색인 정합성
+
+> 이슈 [#209](https://github.com/nameless0422/stock-management-api/issues/209)~[#213](https://github.com/nameless0422/stock-management-api/issues/213) · PR [#215](https://github.com/nameless0422/stock-management-api/pull/215)~[#218](https://github.com/nameless0422/stock-management-api/pull/218)
+
+### 배경 및 문제정의
+
+ES 도입 시 "색인을 만드는 것"에 집중한 나머지, **색인을 최신으로 유지하는 것**과 **깨졌을 때 복구하는 것** 두 축이 비어 있었다.
+
+| # | 문제 | 영향 |
+|---|------|------|
+| #209 | ES 문서에 categoryId 미색인 — `q`+`categoryId` 조합 시 ES 경로에서 카테고리 필터 **조용히 무시** | 잘못된 검색 결과 |
+| #210 | 전체 재색인 수단 없음 | ES 유실·매핑 변경 시 복구 불가 |
+| #211 | ES 클라이언트 타임아웃 미설정 (기본 socket 30초) | ES 행업 시 상품 쓰기·검색이 최대 30초 블록 |
+| #212 | 색인 실패 시 로그만 남김 | ES 일시 장애 → 영구 DB/ES 불일치 |
+| #213 | 리뷰·판매 통계, 카테고리명 변경 시 재색인 없음 | `popular`/`review` 정렬·카테고리 검색 stale |
+
+### 솔루션 및 기능 구현
+
+* **categoryId 필터 (#209):** `ProductDocument`에 `categoryId` 필드 추가, terms 필터 적용 (`includeChildren=true` 시 하위 카테고리 ID 포함)
+* **재색인 API (#210):** `POST /api/v1/admin/search/reindex` — 인덱스 재생성(@Setting/@Field 기반) 후 ACTIVE 상품 500건 단위 배치 색인, 리뷰·판매 통계는 배치 쿼리로 N+1 없이 결합
+* **fail-fast (#211):** `connection-timeout=1s`, `socket-timeout=5s` — MySQL fallback이 있으므로 빨리 실패하는 것이 옳은 정책
+* **Outbox 재시도 (#212):** 동기 색인 실패 시에만 `PRODUCT_SYNC` 이벤트를 Outbox에 저장 → 기존 릴레이 인프라가 최대 5회 재시도, 초과 시 dead-letter 메트릭 노출. AFTER_COMMIT 컨텍스트에서는 커밋이 끝난 트랜잭션에 참여하면 INSERT가 유실되므로 `saveInNewTransaction`(REQUIRES_NEW)으로 분리
+* **stale 해소 (#213):** 리뷰 작성/삭제, 결제 확정/환불, 카테고리명 변경 시 `ProductSyncEvent` 발행 — 기존 AFTER_COMMIT 리스너 경로 재사용
+
+### Trade-off
+
+* 재색인은 인덱스를 삭제 후 재생성하므로 진행 중 검색 결과가 부분적일 수 있음 — 관리자 작업 빈도상 허용
+* 결제 확정 경로에 상품 수만큼 ES 색인이 추가되지만 AFTER_COMMIT이라 결제 트랜잭션 자체에는 영향 없음, 장애 시에도 5초 타임아웃 + Outbox 재시도로 방어
+* 동기 1차 색인은 유지 — 전면 Outbox 경유로 바꾸면 색인 지연(릴레이 주기 5초)이 기본이 되어 검색 일관성이 나빠짐
+
+### 결과
+
+* `q`+`categoryId` 검색이 정확한 결과 반환 (수정 전에는 필터 무시로 2건 반환되던 통합 테스트 케이스로 고정)
+* ES 유실 시 재색인 API 1회로 복구 — 색인 유실 → 검색 0건 → 재색인 → 복구 시나리오 통합 테스트 검증
+* ES 일시 장애가 영구 불일치로 남지 않음 (Outbox 재시도 + dead-letter 가시성)
+* 인기순·리뷰순 정렬과 카테고리 검색이 실시간 데이터 반영
+
+---
+
 ## 테스트 커버리지 추이
 
 | 시점 | 테스트 수 |
@@ -803,3 +933,4 @@ public CategoryResponse create(CategoryCreateRequest request) { ... }
 | 비밀번호 재설정 API (#110) + 홈 화면 집계 API (#127) | **655개** |
 | 커서 기반 페이지네이션 전환 (#15, 12개 엔드포인트) | ~670개 |
 | ProductVariant 시스템 도입 (Product 1:N Variant 1:1 Inventory) | **779개** |
+| 전체 코드 리뷰 수정 (#11/#12) + ES 색인 정합성 (#13) | **~799개** (ES PR 머지 기준) |

--- a/src/main/java/com/stockmanagement/common/config/SecurityConfig.java
+++ b/src/main/java/com/stockmanagement/common/config/SecurityConfig.java
@@ -80,9 +80,8 @@ public class SecurityConfig {
                         .requestMatchers("/api/v1/auth/email/resend").authenticated()
                         .requestMatchers("/api/v1/auth/**").permitAll()
                         .requestMatchers("/api/v1/payments/webhook").permitAll()
-                        // Actuator — health/info/prometheus는 공개 (내부망 전용), 나머지는 ADMIN 전용
+                        // Actuator — health/info만 공개, 나머지(prometheus 포함)는 ADMIN 전용
                         .requestMatchers("/actuator/health", "/actuator/info").permitAll()
-                        .requestMatchers("/actuator/prometheus").hasRole("ADMIN")
                         .requestMatchers("/actuator/**").hasRole("ADMIN")
                         // Swagger UI — swagger.public=false(운영) 시 ADMIN 인증 필요
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html")

--- a/src/main/java/com/stockmanagement/common/event/ProductSyncEvent.java
+++ b/src/main/java/com/stockmanagement/common/event/ProductSyncEvent.java
@@ -1,5 +1,9 @@
 package com.stockmanagement.common.event;
 
+import com.stockmanagement.common.outbox.OutboxEventType;
+
+import java.util.Map;
+
 /**
  * 상품 Elasticsearch 동기화 이벤트.
  *
@@ -8,8 +12,11 @@ package com.stockmanagement.common.event;
  *
  * <p>트랜잭션 커밋 이후에 발행되도록 {@link ProductEventListener}에서
  * {@code @TransactionalEventListener(AFTER_COMMIT)}으로 처리한다.
+ *
+ * <p>동기 색인 실패 시에만 Outbox({@code PRODUCT_SYNC})에 저장되어
+ * 릴레이 스케줄러가 최대 5회 재시도한다.
  */
-public class ProductSyncEvent extends DomainEvent {
+public class ProductSyncEvent extends DomainEvent implements OutboxSupport {
 
     private final Long productId;
     private final boolean delete;
@@ -26,5 +33,15 @@ public class ProductSyncEvent extends DomainEvent {
 
     public boolean isDelete() {
         return delete;
+    }
+
+    @Override
+    public OutboxEventType outboxEventType() {
+        return OutboxEventType.PRODUCT_SYNC;
+    }
+
+    @Override
+    public Map<String, Object> toOutboxPayload() {
+        return Map.of("productId", productId, "delete", delete);
     }
 }

--- a/src/main/java/com/stockmanagement/common/outbox/OutboxEventProcessor.java
+++ b/src/main/java/com/stockmanagement/common/outbox/OutboxEventProcessor.java
@@ -9,6 +9,7 @@ import com.stockmanagement.common.event.ShipmentDeliveredEvent;
 import com.stockmanagement.common.event.ShipmentReturnedEvent;
 import com.stockmanagement.common.event.ShipmentShippedEvent;
 import com.stockmanagement.domain.point.service.PointService;
+import com.stockmanagement.domain.product.service.ProductIndexSynchronizer;
 import com.stockmanagement.domain.shipment.service.ShipmentService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -46,6 +47,7 @@ class OutboxEventProcessor {
     private final ObjectMapper objectMapper;
     private final ShipmentService shipmentService;
     private final PointService pointService;
+    private final ProductIndexSynchronizer productIndexSynchronizer;
 
     /**
      * outboxId에 해당하는 이벤트를 독립 트랜잭션으로 발행한다.
@@ -105,6 +107,16 @@ class OutboxEventProcessor {
                 Long orderId = toLong(p.get("orderId"));
                 pointService.earn(userId, paidAmount, orderId);
                 log.info("[Outbox] 포인트 적립 완료: userId={}, paidAmount={}, orderId={}", userId, paidAmount, orderId);
+            }
+            case PRODUCT_SYNC -> {
+                Long productId = toLong(p.get("productId"));
+                boolean delete = Boolean.parseBoolean(String.valueOf(p.get("delete")));
+                if (delete) {
+                    productIndexSynchronizer.deleteFromIndex(productId);
+                } else {
+                    productIndexSynchronizer.sync(productId);
+                }
+                log.info("[Outbox] ES 색인 재시도 성공: productId={}, delete={}", productId, delete);
             }
             case SHIPMENT_DELIVERED -> {
                 Long orderId = toLong(p.get("orderId"));

--- a/src/main/java/com/stockmanagement/common/outbox/OutboxEventStore.java
+++ b/src/main/java/com/stockmanagement/common/outbox/OutboxEventStore.java
@@ -31,11 +31,27 @@ public class OutboxEventStore {
      * @param event Outbox 저장을 지원하는 도메인 이벤트
      */
     public void save(OutboxSupport event) {
+        repository.save(toEntity(event));
+    }
+
+    /**
+     * 독립 트랜잭션(REQUIRES_NEW)으로 Outbox 이벤트를 저장한다.
+     *
+     * <p>AFTER_COMMIT 리스너처럼 이미 커밋된 트랜잭션 컨텍스트에서 호출할 때 사용한다.
+     * 그 컨텍스트에서 {@link #save}로 저장하면 커밋이 끝난 트랜잭션에 참여하여
+     * INSERT가 유실되므로 반드시 새 트랜잭션으로 커밋해야 한다.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void saveInNewTransaction(OutboxSupport event) {
+        repository.save(toEntity(event));
+    }
+
+    private OutboxEvent toEntity(OutboxSupport event) {
         try {
-            repository.save(OutboxEvent.builder()
+            return OutboxEvent.builder()
                     .eventType(event.outboxEventType())
                     .payload(objectMapper.writeValueAsString(event.toOutboxPayload()))
-                    .build());
+                    .build();
         } catch (JsonProcessingException ex) {
             throw new IllegalStateException("Outbox 이벤트 직렬화 실패: " + event.outboxEventType(), ex);
         }

--- a/src/main/java/com/stockmanagement/common/outbox/OutboxEventType.java
+++ b/src/main/java/com/stockmanagement/common/outbox/OutboxEventType.java
@@ -11,5 +11,7 @@ public enum OutboxEventType {
     SHIPMENT_CREATE,
     SHIPMENT_RETURNED,
     /** 결제 확정 후 포인트 적립 요청 — 실패 시 릴레이 스케줄러가 재시도한다. */
-    POINT_EARN
+    POINT_EARN,
+    /** ES 상품 색인 동기화 재시도 — 동기 색인 실패 시에만 저장되어 릴레이 스케줄러가 재시도한다. */
+    PRODUCT_SYNC
 }

--- a/src/main/java/com/stockmanagement/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/stockmanagement/domain/admin/controller/AdminController.java
@@ -5,11 +5,13 @@ import com.stockmanagement.domain.admin.dto.AdminOrderResponse;
 import com.stockmanagement.domain.admin.dto.DashboardResponse;
 import com.stockmanagement.domain.admin.dto.LowStockThresholdRequest;
 import com.stockmanagement.domain.admin.dto.LowStockThresholdResponse;
+import com.stockmanagement.domain.admin.dto.ReindexResponse;
 import com.stockmanagement.domain.admin.dto.RoleUpdateRequest;
 import com.stockmanagement.domain.admin.dto.ShippingPolicyRequest;
 import com.stockmanagement.domain.admin.dto.ShippingPolicyResponse;
 import com.stockmanagement.domain.admin.service.AdminService;
 import com.stockmanagement.domain.admin.setting.service.SystemSettingService;
+import com.stockmanagement.domain.product.service.ProductSearchService;
 import com.stockmanagement.domain.inventory.dto.DailyInventorySnapshotResponse;
 import com.stockmanagement.domain.order.dto.DailyOrderStatsResponse;
 import com.stockmanagement.domain.order.entity.OrderStatus;
@@ -50,6 +52,15 @@ public class AdminController {
 
     private final AdminService adminService;
     private final SystemSettingService systemSettingService;
+    private final ProductSearchService productSearchService;
+
+    @Operation(summary = "상품 검색 전체 재색인",
+            description = "ES 인덱스를 재생성하고 ACTIVE 상품 전체를 다시 색인한다. " +
+                    "매핑 변경·색인 유실·통계 stale 복구용. 재색인 중 검색 결과가 부분적일 수 있다.")
+    @PostMapping("/search/reindex")
+    public ApiResponse<ReindexResponse> reindexProducts() {
+        return ApiResponse.ok(new ReindexResponse(productSearchService.reindexAll()));
+    }
 
     @Operation(summary = "관리자 대시보드", description = "주문 통계, 매출(CONFIRMED 기준), 사용자 수, 저재고(available<10) 목록 반환.")
     @GetMapping("/dashboard")

--- a/src/main/java/com/stockmanagement/domain/admin/dto/ReindexResponse.java
+++ b/src/main/java/com/stockmanagement/domain/admin/dto/ReindexResponse.java
@@ -1,0 +1,13 @@
+package com.stockmanagement.domain.admin.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/** 상품 검색 전체 재색인 결과 응답. */
+@Getter
+@AllArgsConstructor
+public class ReindexResponse {
+
+    /** 색인된 상품 수 */
+    private final long indexedCount;
+}

--- a/src/main/java/com/stockmanagement/domain/order/repository/OrderItemRepository.java
+++ b/src/main/java/com/stockmanagement/domain/order/repository/OrderItemRepository.java
@@ -25,4 +25,12 @@ public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
            "AND oi.order.status IN (com.stockmanagement.domain.order.entity.OrderStatus.CONFIRMED, " +
            "com.stockmanagement.domain.order.entity.OrderStatus.CANCEL_IN_PROGRESS)")
     long sumSalesCountByProductId(@Param("productId") Long productId);
+
+    /** 결제 완료된 주문에서 상품별 누적 판매 수량 배치 조회 — [productId, sum] 배열 목록 (재색인용) */
+    @Query("SELECT oi.product.id, COALESCE(SUM(oi.quantity), 0) FROM OrderItem oi " +
+           "WHERE oi.product.id IN :productIds " +
+           "AND oi.order.status IN (com.stockmanagement.domain.order.entity.OrderStatus.CONFIRMED, " +
+           "com.stockmanagement.domain.order.entity.OrderStatus.CANCEL_IN_PROGRESS) " +
+           "GROUP BY oi.product.id")
+    List<Object[]> sumSalesCountByProductIdIn(@Param("productIds") List<Long> productIds);
 }

--- a/src/main/java/com/stockmanagement/domain/order/service/OrderPaymentService.java
+++ b/src/main/java/com/stockmanagement/domain/order/service/OrderPaymentService.java
@@ -1,6 +1,7 @@
 package com.stockmanagement.domain.order.service;
 
 import com.stockmanagement.common.event.OrderCancelledEvent;
+import com.stockmanagement.common.event.ProductSyncEvent;
 import com.stockmanagement.common.exception.BusinessException;
 import com.stockmanagement.common.exception.ErrorCode;
 import com.stockmanagement.common.outbox.OutboxEventStore;
@@ -15,6 +16,7 @@ import com.stockmanagement.domain.order.repository.OrderStatusHistoryRepository;
 import com.stockmanagement.domain.point.service.PointService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -36,6 +38,7 @@ public class OrderPaymentService {
     private final PointService pointService;
     private final OutboxEventStore outboxEventStore;
     private final OrderStatusHistoryRepository historyRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     /**
      * 결제 완료 후 주문을 확정한다 — Payment 도메인에서 호출.
@@ -60,6 +63,7 @@ public class OrderPaymentService {
         }
 
         recordHistory(order.getId(), previousStatus, OrderStatus.CONFIRMED, null);
+        publishProductSync(order); // ES salesCount 갱신 (popular 정렬 최신화)
         return order;
     }
 
@@ -92,6 +96,7 @@ public class OrderPaymentService {
 
         recordHistory(order.getId(), previousStatus, OrderStatus.CANCELLED, null);
         outboxEventStore.save(new OrderCancelledEvent(order.getId(), order.getUserId(), "PAYMENT_REFUNDED"));
+        publishProductSync(order); // ES salesCount 갱신 (환불 시 판매량 차감 반영)
     }
 
     /**
@@ -136,6 +141,14 @@ public class OrderPaymentService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
         order.resetPaymentFailed();
         recordHistory(order.getId(), OrderStatus.PAYMENT_IN_PROGRESS, OrderStatus.PENDING, "system:stuck-payment-reset");
+    }
+
+    /** 주문에 포함된 상품들의 ES 재색인 이벤트를 발행한다 — 커밋 후 리스너가 salesCount를 재계산한다. */
+    private void publishProductSync(Order order) {
+        order.getItems().stream()
+                .map(item -> item.getProduct().getId())
+                .distinct()
+                .forEach(productId -> eventPublisher.publishEvent(new ProductSyncEvent(productId, false)));
     }
 
     private String currentUser() {

--- a/src/main/java/com/stockmanagement/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/stockmanagement/domain/payment/service/PaymentService.java
@@ -340,15 +340,6 @@ public class PaymentService {
         return PaymentResponse.from(payment);
     }
 
-    /**
-     * 주문 ID로 결제 정보를 조회한다. 결제 레코드가 없으면 빈 Optional을 반환한다.
-     * ADMIN은 전체 조회 가능, USER는 본인 주문만 조회 가능.
-     *
-     * @param orderId  조회할 주문 ID
-     * @param username 요청자 username
-     * @param isAdmin  ADMIN 여부
-     * @return 결제 정보 (없으면 Optional.empty())
-     */
     /** 현재 인증 사용자의 결제 목록을 최신순으로 페이징 조회한다. 주문 요약 정보 포함. */
     public Page<PaymentResponse> getMyPayments(Long userId, Pageable pageable) {
         Page<Payment> payments = paymentRepository.findByUserId(userId, pageable);
@@ -367,6 +358,15 @@ public class PaymentService {
         });
     }
 
+    /**
+     * 주문 ID로 결제 정보를 조회한다. 결제 레코드가 없으면 빈 Optional을 반환한다.
+     * ADMIN은 전체 조회 가능, USER는 본인 주문만 조회 가능.
+     *
+     * @param orderId 조회할 주문 ID
+     * @param userId  요청자 사용자 ID
+     * @param isAdmin ADMIN 여부
+     * @return 결제 정보 (없으면 Optional.empty())
+     */
     public Optional<PaymentResponse> getByOrderId(Long orderId, Long userId, boolean isAdmin) {
         if (!isAdmin) {
             Long ownerUserId = orderRepository.findUserIdById(orderId)

--- a/src/main/java/com/stockmanagement/domain/product/category/service/CategoryService.java
+++ b/src/main/java/com/stockmanagement/domain/product/category/service/CategoryService.java
@@ -7,10 +7,12 @@ import com.stockmanagement.domain.product.category.dto.CategoryResponse;
 import com.stockmanagement.domain.product.category.dto.CategoryUpdateRequest;
 import com.stockmanagement.domain.product.category.entity.Category;
 import com.stockmanagement.domain.product.category.repository.CategoryRepository;
+import com.stockmanagement.common.event.ProductSyncEvent;
 import com.stockmanagement.domain.product.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,6 +35,7 @@ public class CategoryService {
 
     private final CategoryRepository categoryRepository;
     private final ProductRepository productRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @CacheEvict(cacheNames = "categories", allEntries = true)
     @Transactional
@@ -121,7 +124,15 @@ public class CategoryService {
         }
 
         Category parent = resolveParent(request.getParentId());
+        boolean nameChanged = !newName.equals(category.getName());
         category.update(newName, request.getDescription(), parent);
+
+        // 카테고리명 변경 시 소속 상품 ES 재색인 — ES 문서가 카테고리를 이름(keyword)으로 저장하므로
+        // 갱신하지 않으면 이름 필터·키워드 검색이 옛 이름으로 남는다
+        if (nameChanged) {
+            productRepository.findIdsByCategoryId(id)
+                    .forEach(productId -> eventPublisher.publishEvent(new ProductSyncEvent(productId, false)));
+        }
         return CategoryResponse.from(category);
     }
 

--- a/src/main/java/com/stockmanagement/domain/product/controller/ProductController.java
+++ b/src/main/java/com/stockmanagement/domain/product/controller/ProductController.java
@@ -1,6 +1,7 @@
 package com.stockmanagement.domain.product.controller;
 
 import com.stockmanagement.common.dto.ApiResponse;
+import com.stockmanagement.common.ratelimit.RateLimit;
 import com.stockmanagement.common.security.CurrentUserId;
 import com.stockmanagement.domain.product.dto.ProductCreateRequest;
 import com.stockmanagement.domain.product.dto.ProductResponse;
@@ -68,6 +69,7 @@ public class ProductController {
 
     @Operation(summary = "검색 자동완성", description = "검색어 prefix로 상품명 자동완성 후보를 반환한다. 최대 10건.")
     @GetMapping("/search/suggestions")
+    @RateLimit(limit = 30, windowSeconds = 60, keyType = RateLimit.KeyType.IP)
     public ApiResponse<SuggestResponse> suggest(
             @RequestParam @Size(min = 1, max = 200, message = "검색어는 1~200자여야 합니다.") String q) {
         return ApiResponse.ok(new SuggestResponse(productService.suggest(q, 10)));

--- a/src/main/java/com/stockmanagement/domain/product/document/ProductDocument.java
+++ b/src/main/java/com/stockmanagement/domain/product/document/ProductDocument.java
@@ -51,6 +51,10 @@ public class ProductDocument {
     @Field(type = FieldType.Keyword)
     private String category;
 
+    /** 카테고리 ID — categoryId 필터(하위 카테고리 포함) 대상 */
+    @Field(type = FieldType.Long)
+    private Long categoryId;
+
     @Field(type = FieldType.Keyword)
     private String status;
 
@@ -80,6 +84,7 @@ public class ProductDocument {
                 .price(product.getPrice() != null ? product.getPrice().doubleValue() : 0)
                 .sku(product.getSku())
                 .category(product.getCategoryName())
+                .categoryId(product.getCategory() != null ? product.getCategory().getId() : null)
                 .status(product.getStatus() != null ? product.getStatus().name() : null)
                 .thumbnailUrl(product.getThumbnailUrl())
                 .createdAt(product.getCreatedAt())
@@ -101,6 +106,7 @@ public class ProductDocument {
                 .price(getPriceAsBigDecimal())
                 .sku(sku)
                 .category(category)
+                .categoryId(categoryId)
                 .thumbnailUrl(thumbnailUrl)
                 .status(status != null ? ProductStatus.valueOf(status) : null)
                 .createdAt(createdAt)

--- a/src/main/java/com/stockmanagement/domain/product/document/ProductDocument.java
+++ b/src/main/java/com/stockmanagement/domain/product/document/ProductDocument.java
@@ -64,16 +64,14 @@ public class ProductDocument {
     @Field(type = FieldType.Date, format = {}, pattern = "uuuu-MM-dd'T'HH:mm:ss.SSSSSS||uuuu-MM-dd'T'HH:mm:ss.SSS||uuuu-MM-dd'T'HH:mm:ss")
     private LocalDateTime createdAt;
 
+    @Field(type = FieldType.Date, format = {}, pattern = "uuuu-MM-dd'T'HH:mm:ss.SSSSSS||uuuu-MM-dd'T'HH:mm:ss.SSS||uuuu-MM-dd'T'HH:mm:ss")
+    private LocalDateTime updatedAt;
+
     @Field(type = FieldType.Long)
     private long reviewCount;
 
     @Field(type = FieldType.Long)
     private long salesCount;
-
-    /** Product JPA 엔티티로부터 ES 문서를 생성한다. */
-    public static ProductDocument from(Product product) {
-        return from(product, 0L, 0L);
-    }
 
     /** Product JPA 엔티티 + 리뷰/판매 통계를 포함한 ES 문서를 생성한다. */
     public static ProductDocument from(Product product, long reviewCount, long salesCount) {
@@ -88,6 +86,7 @@ public class ProductDocument {
                 .status(product.getStatus() != null ? product.getStatus().name() : null)
                 .thumbnailUrl(product.getThumbnailUrl())
                 .createdAt(product.getCreatedAt())
+                .updatedAt(product.getUpdatedAt())
                 .reviewCount(reviewCount)
                 .salesCount(salesCount)
                 .build();
@@ -110,6 +109,7 @@ public class ProductDocument {
                 .thumbnailUrl(thumbnailUrl)
                 .status(status != null ? ProductStatus.valueOf(status) : null)
                 .createdAt(createdAt)
+                .updatedAt(updatedAt)
                 .build();
     }
 }

--- a/src/main/java/com/stockmanagement/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/stockmanagement/domain/product/repository/ProductRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -20,7 +21,7 @@ import java.util.stream.Collectors;
  * <p>Spring Data JPA의 쿼리 메서드 네이밍 규칙을 사용해 쿼리를 자동 생성한다.
  * 복잡한 동적 쿼리가 필요해지면 Querydsl 또는 @Query로 확장한다.
  */
-public interface ProductRepository extends JpaRepository<Product, Long> {
+public interface ProductRepository extends JpaRepository<Product, Long>, JpaSpecificationExecutor<Product> {
 
     /** SKU 중복 여부를 빠르게 확인 — 상품 등록 시 중복 검사용 */
     boolean existsBySku(String sku);
@@ -43,16 +44,6 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     Page<Product> findAll(Pageable pageable);
 
     /**
-     * ACTIVE 상품 중 상품명 또는 SKU로 검색 (대소문자 무시).
-     * countQuery 분리로 페이징 카운트 쿼리의 정확성 보장.
-     */
-    @Query(value = "SELECT p FROM Product p LEFT JOIN FETCH p.category WHERE p.status = :status AND " +
-                   "(LOWER(p.name) LIKE LOWER(CONCAT('%', :q, '%')) ESCAPE '!' OR LOWER(p.sku) LIKE LOWER(CONCAT('%', :q, '%')) ESCAPE '!')",
-           countQuery = "SELECT COUNT(p) FROM Product p WHERE p.status = :status AND " +
-                        "(LOWER(p.name) LIKE LOWER(CONCAT('%', :q, '%')) ESCAPE '!' OR LOWER(p.sku) LIKE LOWER(CONCAT('%', :q, '%')) ESCAPE '!')")
-    Page<Product> searchByStatus(@Param("status") ProductStatus status, @Param("q") String query, Pageable pageable);
-
-    /**
      * 전체 상태의 상품 중 상품명 또는 SKU로 검색 (대소문자 무시, 관리자 전용).
      * countQuery 분리로 페이징 카운트 쿼리의 정확성 보장.
      */
@@ -61,13 +52,6 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
            countQuery = "SELECT COUNT(p) FROM Product p WHERE " +
                         "LOWER(p.name) LIKE LOWER(CONCAT('%', :q, '%')) ESCAPE '!' OR LOWER(p.sku) LIKE LOWER(CONCAT('%', :q, '%')) ESCAPE '!'")
     Page<Product> searchAll(@Param("q") String query, Pageable pageable);
-
-    /** 카테고리 ID 목록 필터 — ACTIVE 상품 중 해당 카테고리에 속하는 상품만 조회 (하위 카테고리 포함 가능). */
-    @Query(value = "SELECT p FROM Product p LEFT JOIN FETCH p.category WHERE p.status = :status AND p.category.id IN :categoryIds",
-           countQuery = "SELECT COUNT(p) FROM Product p WHERE p.status = :status AND p.category.id IN :categoryIds")
-    Page<Product> findByStatusAndCategoryIdIn(@Param("status") ProductStatus status,
-                                              @Param("categoryIds") Collection<Long> categoryIds,
-                                              Pageable pageable);
 
     /**
      * 카테고리별 ACTIVE 상품 수를 배치 조회한다.

--- a/src/main/java/com/stockmanagement/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/stockmanagement/domain/product/repository/ProductRepository.java
@@ -89,6 +89,10 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
            countQuery = "SELECT COUNT(DISTINCT p) FROM Product p LEFT JOIN Review r ON r.productId = p.id WHERE p.status = :status")
     Page<Product> findPopularByStatus(@Param("status") ProductStatus status, Pageable pageable);
 
+    /** 카테고리 소속 상품 ID 목록 — 카테고리명 변경 시 ES 재색인 대상 조회용 */
+    @Query("SELECT p.id FROM Product p WHERE p.category.id = :categoryId")
+    List<Long> findIdsByCategoryId(@Param("categoryId") Long categoryId);
+
     /** countActiveProductsByCategoryIds() 결과를 Map으로 변환한다. */
     default Map<Long, Long> countMapByCategoryIds(Collection<Long> ids) {
         return countActiveProductsByCategoryIds(ids).stream()

--- a/src/main/java/com/stockmanagement/domain/product/repository/ProductSpecification.java
+++ b/src/main/java/com/stockmanagement/domain/product/repository/ProductSpecification.java
@@ -1,0 +1,66 @@
+package com.stockmanagement.domain.product.repository;
+
+import com.stockmanagement.common.util.SqlUtils;
+import com.stockmanagement.domain.product.dto.ProductSearchRequest;
+import com.stockmanagement.domain.product.entity.Product;
+import com.stockmanagement.domain.product.entity.ProductStatus;
+import jakarta.persistence.criteria.Predicate;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * 상품 동적 검색 조건 빌더 (MySQL fallback용).
+ * JPA Criteria API를 사용해 null이 아닌 조건만 AND 결합한다.
+ *
+ * <p>ES 장애 시 fallback 경로와 categoryId 단독 조회에서 사용되며,
+ * 키워드(name/SKU LIKE)·가격 범위·카테고리명·카테고리 ID 필터를 모두 지원한다.
+ */
+public class ProductSpecification {
+
+    private ProductSpecification() {}
+
+    /**
+     * ACTIVE 상품 대상 검색 Specification을 생성한다.
+     *
+     * @param request     검색 조건 (q, minPrice, maxPrice, category) — 필드가 null이면 해당 조건 무시
+     * @param categoryIds 카테고리 ID 필터 (하위 카테고리 포함 가능) — 비어 있으면 무시
+     */
+    public static Specification<Product> activeWithFilters(ProductSearchRequest request,
+                                                           Collection<Long> categoryIds) {
+        return (root, query, cb) -> {
+            List<Predicate> predicates = new ArrayList<>();
+            predicates.add(cb.equal(root.get("status"), ProductStatus.ACTIVE));
+
+            // 키워드 — 상품명/SKU LIKE (대소문자 무시, ES multi_match의 축소판)
+            if (request.getQ() != null && !request.getQ().isBlank()) {
+                String pattern = "%" + SqlUtils.escapeLike(request.getQ()).toLowerCase() + "%";
+                predicates.add(cb.or(
+                        cb.like(cb.lower(root.get("name")), pattern, '!'),
+                        cb.like(cb.lower(root.get("sku")), pattern, '!')));
+            }
+
+            // 카테고리 ID 필터
+            if (categoryIds != null && !categoryIds.isEmpty()) {
+                predicates.add(root.get("category").get("id").in(categoryIds));
+            }
+
+            // 카테고리명 필터 (정확 일치)
+            if (request.getCategory() != null && !request.getCategory().isBlank()) {
+                predicates.add(cb.equal(root.get("category").get("name"), request.getCategory()));
+            }
+
+            // 가격 범위 필터
+            if (request.getMinPrice() != null) {
+                predicates.add(cb.greaterThanOrEqualTo(root.get("price"), request.getMinPrice()));
+            }
+            if (request.getMaxPrice() != null) {
+                predicates.add(cb.lessThanOrEqualTo(root.get("price"), request.getMaxPrice()));
+            }
+
+            return cb.and(predicates.toArray(new Predicate[0]));
+        };
+    }
+}

--- a/src/main/java/com/stockmanagement/domain/product/review/service/ReviewService.java
+++ b/src/main/java/com/stockmanagement/domain/product/review/service/ReviewService.java
@@ -13,8 +13,10 @@ import com.stockmanagement.domain.product.review.repository.ReviewRepository;
 import com.stockmanagement.domain.user.entity.User;
 import com.stockmanagement.domain.user.repository.UserRepository;
 import com.stockmanagement.common.dto.CursorPage;
+import com.stockmanagement.common.event.ProductSyncEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -36,6 +38,7 @@ public class ReviewService {
     private final ProductRepository productRepository;
     private final OrderRepository orderRepository;
     private final UserRepository userRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     /**
      * 리뷰를 작성한다.
@@ -64,7 +67,10 @@ public class ReviewService {
                 .content(request.getContent())
                 .build();
 
-        return ReviewResponse.from(reviewRepository.save(review));
+        ReviewResponse response = ReviewResponse.from(reviewRepository.save(review));
+        // ES 색인의 reviewCount 갱신 (review 정렬 최신화) — 커밋 후 리스너가 재색인
+        eventPublisher.publishEvent(new ProductSyncEvent(productId, false));
+        return response;
     }
 
     /**
@@ -156,6 +162,8 @@ public class ReviewService {
         }
 
         reviewRepository.delete(review);
+        // ES 색인의 reviewCount 갱신 — 커밋 후 리스너가 재색인
+        eventPublisher.publishEvent(new ProductSyncEvent(productId, false));
     }
 
     /**

--- a/src/main/java/com/stockmanagement/domain/product/service/ProductEventListener.java
+++ b/src/main/java/com/stockmanagement/domain/product/service/ProductEventListener.java
@@ -1,9 +1,7 @@
 package com.stockmanagement.domain.product.service;
 
 import com.stockmanagement.common.event.ProductSyncEvent;
-import com.stockmanagement.domain.order.repository.OrderItemRepository;
-import com.stockmanagement.domain.product.repository.ProductRepository;
-import com.stockmanagement.domain.product.review.repository.ReviewRepository;
+import com.stockmanagement.common.outbox.OutboxEventStore;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -18,16 +16,19 @@ import org.springframework.transaction.event.TransactionalEventListener;
  *
  * <p>비동기(@Async)를 사용하지 않는 이유: 검색 색인은 요청 스레드에서 완료되어야 통합 테스트에서
  * 인덱스 refresh 타이밍 문제 없이 즉시 검증 가능하며, 응답 시간 영향은 미미하다 (~10–50 ms).
+ *
+ * <p>동기 색인 실패 시 이벤트를 Outbox({@code PRODUCT_SYNC})에 저장하여
+ * 릴레이 스케줄러가 최대 5회 재시도한다 — ES 일시 장애가 영구 불일치로 남지 않는다.
+ * AFTER_COMMIT 컨텍스트에서는 이미 커밋된 트랜잭션에 참여하면 INSERT가 유실되므로
+ * {@link OutboxEventStore#saveInNewTransaction}(REQUIRES_NEW)을 사용한다.
  */
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class ProductEventListener {
 
-    private final ProductRepository productRepository;
-    private final ProductSearchService productSearchService;
-    private final ReviewRepository reviewRepository;
-    private final OrderItemRepository orderItemRepository;
+    private final ProductIndexSynchronizer indexSynchronizer;
+    private final OutboxEventStore outboxEventStore;
 
     /**
      * 상품 변경이 DB에 커밋된 후 ES 색인을 동기화한다.
@@ -37,34 +38,26 @@ public class ProductEventListener {
      */
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onProductSync(ProductSyncEvent event) {
-        if (event.isDelete()) {
-            safeDeleteFromIndex(event.getProductId());
-        } else {
-            syncToEs(event.getProductId());
+        try {
+            if (event.isDelete()) {
+                indexSynchronizer.deleteFromIndex(event.getProductId());
+            } else {
+                indexSynchronizer.sync(event.getProductId());
+            }
+        } catch (Exception e) {
+            log.error("[ProductEventListener] ES 색인 동기화 실패 — Outbox 재시도 위임. productId={}, delete={}",
+                    event.getProductId(), event.isDelete(), e);
+            enqueueRetry(event);
         }
     }
 
-    private void syncToEs(Long productId) {
+    /** 색인 실패 이벤트를 Outbox에 저장한다. 저장마저 실패하면 로그만 남긴다 (DB 장애 등). */
+    private void enqueueRetry(ProductSyncEvent event) {
         try {
-            productRepository.findById(productId).ifPresentOrElse(
-                    product -> {
-                        long reviewCount = reviewRepository.countByProductId(productId);
-                        long salesCount = orderItemRepository.sumSalesCountByProductId(productId);
-                        productSearchService.index(product, reviewCount, salesCount);
-                        log.debug("[ProductEventListener] ES 색인 완료. productId={}", productId);
-                    },
-                    () -> log.warn("[ProductEventListener] ES 색인 대상 상품 미존재. productId={}", productId)
-            );
+            outboxEventStore.saveInNewTransaction(event);
         } catch (Exception e) {
-            log.error("[ProductEventListener] ES 색인 실패 — DB/ES 불일치 발생. productId={}", productId, e);
-        }
-    }
-
-    private void safeDeleteFromIndex(Long productId) {
-        try {
-            productSearchService.deleteFromIndex(productId);
-        } catch (Exception e) {
-            log.error("[ProductEventListener] ES 색인 삭제 실패 — 삭제된 상품이 검색에 잔존할 수 있음. productId={}", productId, e);
+            log.error("[ProductEventListener] Outbox 저장 실패 — DB/ES 불일치 발생, 재색인 API로 복구 필요. productId={}",
+                    event.getProductId(), e);
         }
     }
 }

--- a/src/main/java/com/stockmanagement/domain/product/service/ProductIndexSynchronizer.java
+++ b/src/main/java/com/stockmanagement/domain/product/service/ProductIndexSynchronizer.java
@@ -1,0 +1,55 @@
+package com.stockmanagement.domain.product.service;
+
+import com.stockmanagement.domain.order.repository.OrderItemRepository;
+import com.stockmanagement.domain.product.repository.ProductRepository;
+import com.stockmanagement.domain.product.review.repository.ReviewRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * 상품 ES 색인 동기화 실행 컴포넌트.
+ *
+ * <p>DB에서 상품을 재로드하고 리뷰·판매 통계를 결합해 색인한다.
+ * 실패 시 예외를 전파하므로 호출자가 재시도 정책을 결정한다:
+ * <ul>
+ *   <li>{@link ProductEventListener} — 동기 1차 시도, 실패 시 Outbox 저장
+ *   <li>{@code OutboxEventProcessor} — Outbox 재시도 (최대 5회)
+ * </ul>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ProductIndexSynchronizer {
+
+    private final ProductRepository productRepository;
+    private final ProductSearchService productSearchService;
+    private final ReviewRepository reviewRepository;
+    private final OrderItemRepository orderItemRepository;
+
+    /**
+     * 상품을 DB에서 재로드하여 통계와 함께 색인한다.
+     * 상품이 존재하지 않으면 경고 로그만 남긴다 (색인 대상 없음 — 재시도 불필요).
+     *
+     * @throws RuntimeException ES 색인 실패 시 전파
+     */
+    public void sync(Long productId) {
+        productRepository.findById(productId).ifPresentOrElse(
+                product -> {
+                    long reviewCount = reviewRepository.countByProductId(productId);
+                    long salesCount = orderItemRepository.sumSalesCountByProductId(productId);
+                    productSearchService.index(product, reviewCount, salesCount);
+                },
+                () -> log.warn("[ProductIndexSynchronizer] 색인 대상 상품 미존재. productId={}", productId)
+        );
+    }
+
+    /**
+     * 상품을 ES 색인에서 삭제한다.
+     *
+     * @throws RuntimeException ES 삭제 실패 시 전파
+     */
+    public void deleteFromIndex(Long productId) {
+        productSearchService.deleteFromIndex(productId);
+    }
+}

--- a/src/main/java/com/stockmanagement/domain/product/service/ProductSearchService.java
+++ b/src/main/java/com/stockmanagement/domain/product/service/ProductSearchService.java
@@ -139,15 +139,9 @@ public class ProductSearchService {
     }
 
     /**
-     * 상품을 Elasticsearch에 색인한다.
-     * ProductService의 create/update/changeStatus에서 호출된다.
+     * 리뷰/판매 통계를 포함해 상품을 Elasticsearch에 색인한다.
+     * {@link ProductIndexSynchronizer}에서 호출된다.
      */
-    public void index(Product product) {
-        productSearchRepository.save(ProductDocument.from(product));
-        log.debug("ES 색인 완료. productId={}", product.getId());
-    }
-
-    /** 리뷰/판매 통계를 포함한 ES 색인. */
     public void index(Product product, long reviewCount, long salesCount) {
         productSearchRepository.save(ProductDocument.from(product, reviewCount, salesCount));
         log.debug("ES 색인 완료. productId={} reviewCount={} salesCount={}", product.getId(), reviewCount, salesCount);

--- a/src/main/java/com/stockmanagement/domain/product/service/ProductSearchService.java
+++ b/src/main/java/com/stockmanagement/domain/product/service/ProductSearchService.java
@@ -1,29 +1,41 @@
 package com.stockmanagement.domain.product.service;
 
+import co.elastic.clients.elasticsearch._types.FieldValue;
 import co.elastic.clients.elasticsearch._types.SortOptions;
 import co.elastic.clients.elasticsearch._types.SortOrder;
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import com.stockmanagement.domain.order.repository.OrderItemRepository;
+import com.stockmanagement.domain.product.category.repository.CategoryRepository;
 import com.stockmanagement.domain.product.document.ProductDocument;
 import com.stockmanagement.domain.product.dto.ProductSearchRequest;
 import com.stockmanagement.domain.product.dto.ProductResponse;
 import com.stockmanagement.domain.product.entity.Product;
+import com.stockmanagement.domain.product.entity.ProductStatus;
+import com.stockmanagement.domain.product.repository.ProductRepository;
 import com.stockmanagement.domain.product.repository.ProductSearchRepository;
+import com.stockmanagement.domain.product.review.repository.ReviewRepository;
+import com.stockmanagement.domain.product.review.repository.ReviewStatsProjection;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.elasticsearch.client.elc.NativeQuery;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.IndexOperations;
 import org.springframework.data.elasticsearch.core.SearchHit;
 import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Elasticsearch 기반 상품 검색 서비스.
@@ -37,8 +49,15 @@ import java.util.Set;
 @RequiredArgsConstructor
 public class ProductSearchService {
 
+    /** 재색인 시 한 번에 색인하는 상품 수 — DB 조회·bulk 요청 크기의 균형 */
+    private static final int REINDEX_BATCH_SIZE = 500;
+
     private final ElasticsearchOperations elasticsearchOperations;
     private final ProductSearchRepository productSearchRepository;
+    private final CategoryRepository categoryRepository;
+    private final ProductRepository productRepository;
+    private final ReviewRepository reviewRepository;
+    private final OrderItemRepository orderItemRepository;
 
     /**
      * 동적 조건으로 상품을 검색한다.
@@ -78,6 +97,19 @@ public class ProductSearchService {
         // 카테고리 필터 (정확 일치)
         if (request.getCategory() != null && !request.getCategory().isBlank()) {
             boolQuery.filter(f -> f.term(t -> t.field("category").value(request.getCategory())));
+        }
+
+        // 카테고리 ID 필터 — includeChildren=true이면 하위 카테고리 포함
+        if (request.getCategoryId() != null) {
+            List<Long> categoryIds = new ArrayList<>();
+            categoryIds.add(request.getCategoryId());
+            if (request.isIncludeChildren()) {
+                categoryIds.addAll(categoryRepository.findChildIdsByParentId(request.getCategoryId()));
+            }
+            List<FieldValue> values = categoryIds.stream()
+                    .map(id -> FieldValue.of(id.longValue()))
+                    .toList();
+            boolQuery.filter(f -> f.terms(t -> t.field("categoryId").terms(ts -> ts.value(values))));
         }
 
         // 정렬 옵션
@@ -161,6 +193,63 @@ public class ProductSearchService {
             if (seen.size() >= size) break;
         }
         return new ArrayList<>(seen);
+    }
+
+    /**
+     * 전체 재색인 — 인덱스를 재생성하고 ACTIVE 상품 전체를 다시 색인한다 (ADMIN 전용).
+     *
+     * <p>ES 데이터 유실, 매핑 변경, 색인 stale 누적(리뷰/판매 통계, 카테고리명 변경) 복구용.
+     * 인덱스 삭제 후 배치 색인이 끝날 때까지 검색 결과가 부분적일 수 있다.
+     *
+     * <p>{@code @Transactional(readOnly = true)}: 배치 페이징 중 LAZY 카테고리 접근을 위해
+     * 영속성 컨텍스트를 메서드 전체에 유지한다.
+     *
+     * @return 색인된 상품 수
+     */
+    @Transactional(readOnly = true)
+    public long reindexAll() {
+        IndexOperations indexOps = elasticsearchOperations.indexOps(ProductDocument.class);
+        if (indexOps.exists()) {
+            indexOps.delete();
+        }
+        indexOps.createWithMapping();
+
+        long total = 0;
+        int page = 0;
+        Page<Product> products;
+        do {
+            products = productRepository.findByStatus(ProductStatus.ACTIVE,
+                    PageRequest.of(page, REINDEX_BATCH_SIZE, Sort.by("id")));
+            if (products.isEmpty()) {
+                break;
+            }
+            productSearchRepository.saveAll(buildDocuments(products.getContent()));
+            total += products.getNumberOfElements();
+            page++;
+        } while (products.hasNext());
+
+        indexOps.refresh();
+        log.info("[ES] 전체 재색인 완료: {}건", total);
+        return total;
+    }
+
+    /** 상품 배치에 리뷰·판매 통계를 배치 조회로 결합하여 ES 문서 목록을 생성한다. */
+    private List<ProductDocument> buildDocuments(List<Product> products) {
+        List<Long> ids = products.stream().map(Product::getId).toList();
+
+        Map<Long, Long> reviewCounts = reviewRepository.findReviewStatsByProductIdIn(ids).stream()
+                .collect(Collectors.toMap(
+                        ReviewStatsProjection::getProductId,
+                        ReviewStatsProjection::getReviewCount));
+
+        Map<Long, Long> salesCounts = orderItemRepository.sumSalesCountByProductIdIn(ids).stream()
+                .collect(Collectors.toMap(row -> (Long) row[0], row -> (Long) row[1]));
+
+        return products.stream()
+                .map(p -> ProductDocument.from(p,
+                        reviewCounts.getOrDefault(p.getId(), 0L),
+                        salesCounts.getOrDefault(p.getId(), 0L)))
+                .toList();
     }
 
     // ===== 내부 헬퍼 =====

--- a/src/main/java/com/stockmanagement/domain/product/service/ProductService.java
+++ b/src/main/java/com/stockmanagement/domain/product/service/ProductService.java
@@ -22,6 +22,7 @@ import com.stockmanagement.domain.product.entity.Product;
 import com.stockmanagement.domain.product.entity.ProductStatus;
 import com.stockmanagement.domain.product.entity.ProductVariant;
 import com.stockmanagement.domain.product.repository.ProductRepository;
+import com.stockmanagement.domain.product.repository.ProductSpecification;
 import com.stockmanagement.domain.product.repository.ProductVariantRepository;
 import com.stockmanagement.domain.product.image.dto.ProductImageResponse;
 import com.stockmanagement.domain.product.image.repository.ProductImageRepository;
@@ -144,7 +145,8 @@ public class ProductService {
      *
      * <p>검색 조건({@code q}, {@code minPrice}, {@code maxPrice}, {@code category}, {@code sort})이
      * 하나라도 있으면 Elasticsearch로 검색하고, 없으면 MySQL 페이징 조회를 사용한다.
-     * ES 장애 시 MySQL로 fallback하여 서비스 가용성을 유지한다.
+     * ES 장애 시 MySQL로 fallback하며, 모든 필터를 Specification으로 동일하게 적용한다.
+     * (단, {@code popular}/{@code review} 정렬은 ES 전용 — fallback에서는 기본 정렬 사용)
      */
     public Page<ProductResponse> getList(Pageable pageable, ProductSearchRequest request, Long userId) {
         if (request != null && request.hasSearchCondition()) {
@@ -155,24 +157,27 @@ public class ProductService {
                 log.warn("Elasticsearch 검색 실패, MySQL fallback 사용. query={}", request.getQ(), e);
             }
         }
-        // ES 미사용 또는 fallback: sort/keyword를 MySQL에서 처리
+        // ES 미사용 또는 fallback: 필터를 Specification으로 MySQL에서 처리
         Pageable effectivePageable = toSortedPageable(pageable, request);
-        String keyword = request != null ? request.getQ() : null;
-        Long categoryId = request != null ? request.getCategoryId() : null;
-        Page<Product> products;
-        if (categoryId != null) {
-            Set<Long> categoryIds = new HashSet<>();
-            categoryIds.add(categoryId);
-            if (request.isIncludeChildren()) {
-                categoryIds.addAll(categoryRepository.findChildIdsByParentId(categoryId));
-            }
-            products = productRepository.findByStatusAndCategoryIdIn(ProductStatus.ACTIVE, categoryIds, effectivePageable);
-        } else if (keyword != null && !keyword.isBlank()) {
-            products = productRepository.searchByStatus(ProductStatus.ACTIVE, escapeLike(keyword), effectivePageable);
-        } else {
-            products = productRepository.findByStatus(ProductStatus.ACTIVE, effectivePageable);
-        }
+        boolean hasFilter = request != null
+                && (request.hasSearchCondition() || request.getCategoryId() != null);
+        Page<Product> products = hasFilter
+                ? productRepository.findAll(
+                        ProductSpecification.activeWithFilters(request, resolveCategoryIds(request)),
+                        effectivePageable)
+                : productRepository.findByStatus(ProductStatus.ACTIVE, effectivePageable);
         return enrichPage(products, userId);
+    }
+
+    /** categoryId 필터 대상 ID 집합 — includeChildren=true이면 하위 카테고리 포함 */
+    private Set<Long> resolveCategoryIds(ProductSearchRequest request) {
+        if (request.getCategoryId() == null) return Set.of();
+        Set<Long> categoryIds = new HashSet<>();
+        categoryIds.add(request.getCategoryId());
+        if (request.isIncludeChildren()) {
+            categoryIds.addAll(categoryRepository.findChildIdsByParentId(request.getCategoryId()));
+        }
+        return categoryIds;
     }
 
     /** sort 파라미터를 Pageable의 Sort로 변환 (MySQL fallback용) */
@@ -299,11 +304,6 @@ public class ProductService {
     }
 
     // ===== 내부 헬퍼 =====
-
-    /** LIKE 패턴 와일드카드(!, %, _)를 이스케이프한다. ESCAPE ! 기준. */
-    private static String escapeLike(String value) {
-        return com.stockmanagement.common.util.SqlUtils.escapeLike(value);
-    }
 
     /** 상품의 전체 variant 가용 재고를 합산한다. */
     private int sumAvailableByProductId(Long productId) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -49,6 +49,10 @@ spring.data.redis.port=6379
 
 # ===== Elasticsearch =====
 spring.elasticsearch.uris=http://localhost:9200
+# fail-fast: ES 장애 시 MySQL fallback이 있으므로 짧게 끊는다 (기본 socket 30s → 상품 쓰기/검색 블로킹 방지)
+# socket 5s: 재색인 bulk(500건) 요청 여유 포함
+spring.elasticsearch.connection-timeout=1s
+spring.elasticsearch.socket-timeout=5s
 
 # ===== Cache =====
 spring.cache.type=redis

--- a/src/test/java/com/stockmanagement/common/outbox/OutboxEventProcessorTest.java
+++ b/src/test/java/com/stockmanagement/common/outbox/OutboxEventProcessorTest.java
@@ -37,6 +37,7 @@ class OutboxEventProcessorTest {
     @Mock ApplicationEventPublisher eventPublisher;
     @Mock ShipmentService shipmentService;
     @Mock PointService pointService;
+    @Mock com.stockmanagement.domain.product.service.ProductIndexSynchronizer productIndexSynchronizer;
     @Spy  ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
 
     @InjectMocks OutboxEventProcessor processor;
@@ -204,6 +205,52 @@ class OutboxEventProcessorTest {
             assertThat(result).isTrue();
             verify(pointService).earn(5L, 50000L, 20L);
             assertThat(outbox.getPublishedAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("PRODUCT_SYNC(delete=false) → productIndexSynchronizer.sync() 호출")
+        void callsSynchronizerForProductSync() throws Exception {
+            String payload = objectMapper.writeValueAsString(
+                    Map.of("productId", 7, "delete", false));
+            OutboxEvent outbox = outboxEvent(14L, OutboxEventType.PRODUCT_SYNC, payload);
+            given(repository.findById(14L)).willReturn(Optional.of(outbox));
+
+            boolean result = processor.processOne(14L);
+
+            assertThat(result).isTrue();
+            verify(productIndexSynchronizer).sync(7L);
+            assertThat(outbox.getPublishedAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("PRODUCT_SYNC(delete=true) → productIndexSynchronizer.deleteFromIndex() 호출")
+        void callsSynchronizerForProductSyncDelete() throws Exception {
+            String payload = objectMapper.writeValueAsString(
+                    Map.of("productId", 8, "delete", true));
+            OutboxEvent outbox = outboxEvent(15L, OutboxEventType.PRODUCT_SYNC, payload);
+            given(repository.findById(15L)).willReturn(Optional.of(outbox));
+
+            boolean result = processor.processOne(15L);
+
+            assertThat(result).isTrue();
+            verify(productIndexSynchronizer).deleteFromIndex(8L);
+            assertThat(outbox.getPublishedAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("PRODUCT_SYNC — 색인 실패 시 retryCount 증가")
+        void productSyncFailureRecorded() throws Exception {
+            String payload = objectMapper.writeValueAsString(
+                    Map.of("productId", 9, "delete", false));
+            OutboxEvent outbox = outboxEvent(16L, OutboxEventType.PRODUCT_SYNC, payload);
+            given(repository.findById(16L)).willReturn(Optional.of(outbox));
+            doThrow(new RuntimeException("ES 연결 실패")).when(productIndexSynchronizer).sync(9L);
+
+            boolean result = processor.processOne(16L);
+
+            assertThat(result).isFalse();
+            assertThat(outbox.getRetryCount()).isEqualTo(1);
+            assertThat(outbox.getPublishedAt()).isNull();
         }
     }
 

--- a/src/test/java/com/stockmanagement/domain/admin/controller/AdminControllerTest.java
+++ b/src/test/java/com/stockmanagement/domain/admin/controller/AdminControllerTest.java
@@ -51,6 +51,33 @@ class AdminControllerTest {
     @MockBean private JwtTokenProvider jwtTokenProvider;
     @MockBean private JwtBlacklist jwtBlacklist;
     @MockBean private UserService userService;
+    @MockBean private com.stockmanagement.domain.product.service.ProductSearchService productSearchService;
+
+    // ===== POST /api/admin/search/reindex =====
+
+    @Nested
+    @DisplayName("POST /api/admin/search/reindex")
+    class Reindex {
+
+        @Test
+        @WithMockUser(roles = "ADMIN")
+        @DisplayName("ADMIN → 200, 색인 건수 반환")
+        void reindexAsAdmin() throws Exception {
+            given(productSearchService.reindexAll()).willReturn(42L);
+
+            mockMvc.perform(post("/api/v1/admin/search/reindex"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.indexedCount").value(42));
+        }
+
+        @Test
+        @WithMockUser(roles = "USER")
+        @DisplayName("USER → 403")
+        void reindexAsUserForbidden() throws Exception {
+            mockMvc.perform(post("/api/v1/admin/search/reindex"))
+                    .andExpect(status().isForbidden());
+        }
+    }
 
     // ===== GET /api/admin/dashboard =====
 

--- a/src/test/java/com/stockmanagement/domain/order/service/OrderPaymentServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/order/service/OrderPaymentServiceTest.java
@@ -53,6 +53,9 @@ class OrderPaymentServiceTest {
     @Mock
     private OrderStatusHistoryRepository historyRepository;
 
+    @Mock
+    private org.springframework.context.ApplicationEventPublisher eventPublisher;
+
     @InjectMocks
     private OrderPaymentService orderPaymentService;
 
@@ -98,6 +101,17 @@ class OrderPaymentServiceTest {
     @Nested
     @DisplayName("confirm()")
     class Confirm {
+
+        @Test
+        @DisplayName("확정 시 상품 ES 재색인 이벤트 발행 — salesCount 갱신 (#213)")
+        void confirmPublishesProductSync() {
+            given(orderRepository.findByIdWithItemsForUpdate(1L)).willReturn(Optional.of(order));
+
+            orderPaymentService.confirm(1L);
+
+            verify(eventPublisher).publishEvent(
+                    any(com.stockmanagement.common.event.ProductSyncEvent.class));
+        }
 
         @Test
         @DisplayName("PENDING 주문 확정 — CONFIRMED 전환 및 재고 confirmAllocation 호출")

--- a/src/test/java/com/stockmanagement/domain/product/category/service/CategoryServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/product/category/service/CategoryServiceTest.java
@@ -37,6 +37,9 @@ class CategoryServiceTest {
     @Mock
     private ProductRepository productRepository;
 
+    @Mock
+    private org.springframework.context.ApplicationEventPublisher eventPublisher;
+
     @InjectMocks
     private CategoryService categoryService;
 
@@ -205,6 +208,37 @@ class CategoryServiceTest {
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                             .isEqualTo(ErrorCode.INVALID_INPUT));
+        }
+
+        @Test
+        @DisplayName("이름 변경 → 소속 상품 ES 재색인 이벤트 발행 (#213)")
+        void nameChangePublishesProductSync() {
+            given(categoryRepository.findById(1L)).willReturn(Optional.of(parent));
+
+            CategoryUpdateRequest request = mock(CategoryUpdateRequest.class);
+            given(request.getName()).willReturn("가전"); // "전자" → "가전"
+            given(request.getParentId()).willReturn(null);
+            given(categoryRepository.existsByNameAndIdNot("가전", 1L)).willReturn(false);
+            given(productRepository.findIdsByCategoryId(1L)).willReturn(java.util.List.of(10L, 11L));
+
+            categoryService.update(1L, request);
+
+            verify(eventPublisher, times(2))
+                    .publishEvent(any(com.stockmanagement.common.event.ProductSyncEvent.class));
+        }
+
+        @Test
+        @DisplayName("이름 미변경 → ES 재색인 이벤트 미발행")
+        void noNameChangeNoProductSync() {
+            given(categoryRepository.findById(1L)).willReturn(Optional.of(parent));
+
+            CategoryUpdateRequest request = mock(CategoryUpdateRequest.class);
+            given(request.getName()).willReturn("전자"); // 동일 이름
+            given(request.getParentId()).willReturn(null);
+
+            categoryService.update(1L, request);
+
+            verify(eventPublisher, never()).publishEvent(any());
         }
     }
 }

--- a/src/test/java/com/stockmanagement/domain/product/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/product/review/service/ReviewServiceTest.java
@@ -38,6 +38,7 @@ class ReviewServiceTest {
     @Mock private ProductRepository productRepository;
     @Mock private OrderRepository orderRepository;
     @Mock private UserRepository userRepository;
+    @Mock private org.springframework.context.ApplicationEventPublisher eventPublisher;
 
     @InjectMocks private ReviewService reviewService;
 
@@ -79,6 +80,8 @@ class ReviewServiceTest {
 
             assertThat(response.getRating()).isEqualTo(5);
             verify(reviewRepository).save(any());
+            // ES reviewCount 갱신용 재색인 이벤트 발행 (#213)
+            verify(eventPublisher).publishEvent(any(com.stockmanagement.common.event.ProductSyncEvent.class));
         }
 
         @Test
@@ -139,6 +142,8 @@ class ReviewServiceTest {
             reviewService.delete(1L, 10L, 2L);
 
             verify(reviewRepository).delete(r);
+            // ES reviewCount 갱신용 재색인 이벤트 발행 (#213)
+            verify(eventPublisher).publishEvent(any(com.stockmanagement.common.event.ProductSyncEvent.class));
         }
 
         @Test

--- a/src/test/java/com/stockmanagement/domain/product/service/ProductEventListenerTest.java
+++ b/src/test/java/com/stockmanagement/domain/product/service/ProductEventListenerTest.java
@@ -1,0 +1,80 @@
+package com.stockmanagement.domain.product.service;
+
+import com.stockmanagement.common.event.ProductSyncEvent;
+import com.stockmanagement.common.outbox.OutboxEventStore;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ProductEventListener 단위 테스트")
+class ProductEventListenerTest {
+
+    @Mock ProductIndexSynchronizer indexSynchronizer;
+    @Mock OutboxEventStore outboxEventStore;
+
+    @InjectMocks ProductEventListener listener;
+
+    @Test
+    @DisplayName("색인 성공 → Outbox 저장 없음")
+    void syncSuccess_noOutbox() {
+        listener.onProductSync(new ProductSyncEvent(1L, false));
+
+        verify(indexSynchronizer).sync(1L);
+        verify(outboxEventStore, never()).saveInNewTransaction(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("색인 삭제 성공 → deleteFromIndex 호출, Outbox 저장 없음")
+    void deleteSuccess_noOutbox() {
+        listener.onProductSync(new ProductSyncEvent(2L, true));
+
+        verify(indexSynchronizer).deleteFromIndex(2L);
+        verify(outboxEventStore, never()).saveInNewTransaction(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("색인 실패 → Outbox에 PRODUCT_SYNC 이벤트 저장 (재시도 위임)")
+    void syncFailure_savesOutbox() {
+        doThrow(new RuntimeException("ES 연결 실패")).when(indexSynchronizer).sync(3L);
+        ProductSyncEvent event = new ProductSyncEvent(3L, false);
+
+        listener.onProductSync(event); // 예외를 전파하지 않는다
+
+        ArgumentCaptor<ProductSyncEvent> captor = ArgumentCaptor.forClass(ProductSyncEvent.class);
+        verify(outboxEventStore).saveInNewTransaction(captor.capture());
+        assertThat(captor.getValue().getProductId()).isEqualTo(3L);
+        assertThat(captor.getValue().isDelete()).isFalse();
+    }
+
+    @Test
+    @DisplayName("색인 삭제 실패 → Outbox에 delete=true 이벤트 저장")
+    void deleteFailure_savesOutbox() {
+        doThrow(new RuntimeException("ES 연결 실패")).when(indexSynchronizer).deleteFromIndex(4L);
+
+        listener.onProductSync(new ProductSyncEvent(4L, true));
+
+        ArgumentCaptor<ProductSyncEvent> captor = ArgumentCaptor.forClass(ProductSyncEvent.class);
+        verify(outboxEventStore).saveInNewTransaction(captor.capture());
+        assertThat(captor.getValue().isDelete()).isTrue();
+    }
+
+    @Test
+    @DisplayName("Outbox 저장마저 실패 → 예외를 전파하지 않는다 (로그만)")
+    void outboxFailure_swallowed() {
+        doThrow(new RuntimeException("ES 연결 실패")).when(indexSynchronizer).sync(5L);
+        doThrow(new RuntimeException("DB 연결 실패")).when(outboxEventStore)
+                .saveInNewTransaction(org.mockito.ArgumentMatchers.any());
+
+        listener.onProductSync(new ProductSyncEvent(5L, false)); // 예외 없이 종료
+    }
+}

--- a/src/test/java/com/stockmanagement/domain/product/service/ProductServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/product/service/ProductServiceTest.java
@@ -7,6 +7,7 @@ import com.stockmanagement.domain.inventory.repository.InventoryRepository;
 import com.stockmanagement.domain.product.category.repository.CategoryRepository;
 import com.stockmanagement.domain.product.dto.ProductCreateRequest;
 import com.stockmanagement.domain.product.dto.ProductResponse;
+import com.stockmanagement.domain.product.dto.ProductSearchRequest;
 import com.stockmanagement.domain.product.dto.ProductUpdateRequest;
 import com.stockmanagement.domain.product.entity.Product;
 import com.stockmanagement.domain.product.entity.ProductStatus;
@@ -30,6 +31,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -216,6 +218,56 @@ class ProductServiceTest {
 
             verify(productRepository).findByStatus(ProductStatus.ACTIVE, pageable);
         }
+
+        @Test
+        @DisplayName("ES 장애 시 가격 필터 포함 전체 조건을 Specification으로 fallback 조회한다")
+        void fallsBackToSpecificationOnEsFailure() {
+            Pageable pageable = PageRequest.of(0, 10);
+            ProductSearchRequest request = new ProductSearchRequest();
+            request.setQ("테스트");
+            request.setMinPrice(new BigDecimal("5000"));
+            given(productSearchService.search(any(), any()))
+                    .willThrow(new RuntimeException("ES down"));
+            given(productRepository.findAll(any(Specification.class), any(Pageable.class)))
+                    .willReturn(new PageImpl<>(List.of(product), pageable, 1));
+
+            Page<ProductResponse> result = productService.getList(pageable, request, null);
+
+            assertThat(result.getTotalElements()).isEqualTo(1);
+            verify(productRepository).findAll(any(Specification.class), any(Pageable.class));
+            verify(productRepository, never()).findByStatus(any(), any());
+        }
+
+        @Test
+        @DisplayName("categoryId만 있으면 ES 없이 Specification으로 조회한다")
+        void usesSpecificationForCategoryOnlyBrowsing() {
+            Pageable pageable = PageRequest.of(0, 10);
+            ProductSearchRequest request = new ProductSearchRequest();
+            request.setCategoryId(1L);
+            given(productRepository.findAll(any(Specification.class), any(Pageable.class)))
+                    .willReturn(new PageImpl<>(List.of(product), pageable, 1));
+
+            productService.getList(pageable, request, null);
+
+            verify(productSearchService, never()).search(any(), any());
+            verify(productRepository).findAll(any(Specification.class), any(Pageable.class));
+        }
+
+        @Test
+        @DisplayName("categoryId + includeChildren=true → 하위 카테고리 ID를 함께 조회한다")
+        void includesChildCategoryIds() {
+            Pageable pageable = PageRequest.of(0, 10);
+            ProductSearchRequest request = new ProductSearchRequest();
+            request.setCategoryId(1L);
+            request.setIncludeChildren(true);
+            given(categoryRepository.findChildIdsByParentId(1L)).willReturn(List.of(2L, 3L));
+            given(productRepository.findAll(any(Specification.class), any(Pageable.class)))
+                    .willReturn(Page.empty());
+
+            productService.getList(pageable, request, null);
+
+            verify(categoryRepository).findChildIdsByParentId(1L);
+        }
     }
 
     // ===== update() =====
@@ -288,7 +340,7 @@ class ProductServiceTest {
             productService.delete(1L);
 
             assertThat(product.getStatus()).isEqualTo(ProductStatus.DISCONTINUED);
-            verify(productRepository, never()).delete(any());
+            verify(productRepository, never()).delete(any(Product.class));
         }
 
         @Test

--- a/src/test/java/com/stockmanagement/integration/ProductSearchIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/ProductSearchIntegrationTest.java
@@ -213,6 +213,35 @@ class ProductSearchIntegrationTest extends AbstractIntegrationTest {
                 .andExpect(jsonPath("$.data.content[0].sku").value("IC-001"));
     }
 
+    // ===== 카테고리 ID 단독 조회 — MySQL Specification 경로 (#214) =====
+
+    @Test
+    @DisplayName("categoryId 단독 → MySQL Specification 경로에서 카테고리 필터 적용")
+    void browse_byCategoryIdOnly_mysqlPath() throws Exception {
+        createProduct("헤드셋", "SPEC-001", 90000, "음향기기");
+        createProduct("셔츠", "SPEC-002", 40000, "남성의류");
+        long categoryId = getOrCreateCategory("음향기기");
+
+        mockMvc.perform(get("/api/v1/products")
+                        .param("categoryId", String.valueOf(categoryId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalElements").value(1))
+                .andExpect(jsonPath("$.data.content[0].sku").value("SPEC-001"));
+    }
+
+    // ===== ES 경로 응답 스키마 — updatedAt 포함 (#214) =====
+
+    @Test
+    @DisplayName("ES 검색 결과에 updatedAt 포함 — MySQL 경로와 응답 스키마 일치")
+    void search_responseIncludesUpdatedAt() throws Exception {
+        createProduct("스탠드 조명", "UA-001", 60000, "조명");
+
+        mockMvc.perform(get("/api/v1/products").param("q", "스탠드 조명"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalElements").value(1))
+                .andExpect(jsonPath("$.data.content[0].updatedAt").isNotEmpty());
+    }
+
     // ===== 전체 재색인 (#210) =====
 
     @Test

--- a/src/test/java/com/stockmanagement/integration/ProductSearchIntegrationTest.java
+++ b/src/test/java/com/stockmanagement/integration/ProductSearchIntegrationTest.java
@@ -161,6 +161,89 @@ class ProductSearchIntegrationTest extends AbstractIntegrationTest {
                 .andExpect(jsonPath("$.data.content[0].sku").value("TS-001"));
     }
 
+    // ===== 카테고리 ID 필터 — ES 경로 (#209) =====
+
+    @Test
+    @DisplayName("q + categoryId → 해당 카테고리 상품만 반환")
+    void search_byKeywordAndCategoryId() throws Exception {
+        createProduct("무선 마우스", "CID-001", 30000, "전자");
+        createProduct("무선 이어폰 파우치", "CID-002", 20000, "패션잡화");
+        long categoryId = getOrCreateCategory("전자");
+
+        // 수정 전에는 ES 경로에서 categoryId가 무시되어 2건이 반환됐다
+        mockMvc.perform(get("/api/v1/products")
+                        .param("q", "무선")
+                        .param("categoryId", String.valueOf(categoryId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalElements").value(1))
+                .andExpect(jsonPath("$.data.content[0].sku").value("CID-001"))
+                .andExpect(jsonPath("$.data.content[0].categoryId").value(categoryId));
+    }
+
+    @Test
+    @DisplayName("q + categoryId + includeChildren=true → 하위 카테고리 상품 포함")
+    void search_byKeywordAndCategoryId_includeChildren() throws Exception {
+        long parentId = getOrCreateCategory("가전");
+        String childBody = mockMvc.perform(post("/api/v1/categories")
+                        .header("Authorization", "Bearer " + adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(String.format("{\"name\":\"주방가전\",\"parentId\":%d}", parentId)))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        long childId = objectMapper.readTree(childBody).path("data").path("id").asLong();
+
+        createProduct("소형 냉장고", "IC-001", 300000, "가전");
+        createProduct("소형 전기포트", "IC-002", 40000, "주방가전");
+        // 다른 카테고리의 동일 키워드 상품 — 필터로 제외되어야 함
+        createProduct("소형 가방", "IC-003", 50000, "패션잡화");
+
+        mockMvc.perform(get("/api/v1/products")
+                        .param("q", "소형")
+                        .param("categoryId", String.valueOf(parentId))
+                        .param("includeChildren", "true"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalElements").value(2));
+
+        // includeChildren=false(기본) → 부모 카테고리 직속 상품만
+        mockMvc.perform(get("/api/v1/products")
+                        .param("q", "소형")
+                        .param("categoryId", String.valueOf(parentId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalElements").value(1))
+                .andExpect(jsonPath("$.data.content[0].sku").value("IC-001"));
+    }
+
+    // ===== 전체 재색인 (#210) =====
+
+    @Test
+    @DisplayName("색인 유실 후 관리자 재색인 → 검색 복구")
+    void reindex_restoresIndex() throws Exception {
+        createProduct("복구 노트북", "RI-001", 500000, "전자");
+        createProduct("복구 마우스", "RI-002", 30000, "전자");
+        long categoryId = getOrCreateCategory("전자");
+
+        // 색인 유실 시뮬레이션
+        productSearchRepository.deleteAll();
+        elasticsearchOperations.indexOps(ProductDocument.class).refresh();
+
+        mockMvc.perform(get("/api/v1/products").param("q", "복구"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalElements").value(0));
+
+        // 재색인 (ADMIN)
+        mockMvc.perform(post("/api/v1/admin/search/reindex")
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.indexedCount").value(2));
+
+        // 검색 복구 + 재생성된 매핑에서 categoryId 필터 동작 확인
+        mockMvc.perform(get("/api/v1/products")
+                        .param("q", "복구")
+                        .param("categoryId", String.valueOf(categoryId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalElements").value(2));
+    }
+
     // ===== 복합 필터 =====
 
     @Test


### PR DESCRIPTION
## 개요
2026-07 Elasticsearch 상품 검색 리뷰(#209~#214)에서 나온 이슈 전체를 master에 반영.

## 포함 내용
- #209+#210: ES categoryId 필터(하위 카테고리 포함) + 전체 재색인 관리자 API (`POST /api/v1/admin/search/reindex`)
- #211: ES 클라이언트 타임아웃 설정 (connection 1s, socket 5s) — 장애 시 fail-fast
- #212: 색인 실패 시 Outbox 기반 재시도 (`ProductIndexSynchronizer` + `saveInNewTransaction`)
- #213: 리뷰/판매 통계·카테고리명 변경 시 ES 색인 stale 해소 (ProductSyncEvent 발행 확대)
- #214: MySQL fallback 필터 통합(`ProductSpecification`), ES 응답 updatedAt 스키마 일치, suggest rate limit, 미사용 오버로드 제거
- IMPROVEMENTS.md 11~13 섹션 (리뷰 수정 과정 문서화)

## 배포 참고
- **master 배포 후 재색인 API 1회 실행 필요**: `POST /api/v1/admin/search/reindex` (ADMIN 인증) — 기존 ES 문서에 categoryId·updatedAt 백필

## 테스트
- 각 PR 단위로 전체 테스트 스위트 통과 확인 (Testcontainers 포함)
