### PR TITLE
fix: ES fallback 발생 시 X-Search-Fallback 응답 헤더 추가 (#63)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -185,6 +185,9 @@ Authorization: Bearer <accessToken>
 | `sort` | `price_asc` \| `price_desc` \| `newest` \| `relevance` (기본) |
 | `page` / `size` | 페이징 (관리자·카탈로그 검색용) |
 
+> ES 장애로 MySQL LIKE fallback이 발생하면 응답 헤더 `X-Search-Fallback: true`가 추가된다.
+> LIKE는 ES 형태소 분석과 다른 결과를 반환할 수 있으므로, 프론트는 이 헤더로 안내 배너 노출 여부를 판단한다.
+
 ### `GET /api/products/search/suggestions`
 
 > 권한: 공개 | Elasticsearch prefix query 기반 자동완성

--- a/src/main/java/com/stockmanagement/domain/product/service/ProductService.java
+++ b/src/main/java/com/stockmanagement/domain/product/service/ProductService.java
@@ -41,6 +41,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 import java.util.HashSet;
 import java.util.List;
@@ -146,7 +148,11 @@ public class ProductService {
      * <p>검색 조건({@code q}, {@code minPrice}, {@code maxPrice}, {@code category}, {@code sort})이
      * 하나라도 있으면 Elasticsearch로 검색하고, 없으면 MySQL 페이징 조회를 사용한다.
      * ES 장애 시 MySQL로 fallback하며, 모든 필터를 Specification으로 동일하게 적용한다.
-     * (단, {@code popular}/{@code review} 정렬은 ES 전용 — fallback에서는 기본 정렬 사용)
+     * (단, {@code popular}/{@code review} 정렬은 ES 전용 — fallback에서는 기본 정렬 사용,
+     * ES의 형태소 분석 대신 LIKE 매칭이라 검색 결과가 달라질 수 있음)
+     *
+     * <p>fallback 발생 시 응답 헤더 {@code X-Search-Fallback: true}를 추가해 클라이언트가
+     * 검색 결과 품질 저하 가능성을 안내할 수 있게 한다.
      */
     public Page<ProductResponse> getList(Pageable pageable, ProductSearchRequest request, Long userId) {
         if (request != null && request.hasSearchCondition()) {
@@ -155,6 +161,7 @@ public class ProductService {
                 return enrichSearchResult(esResult, userId);
             } catch (Exception e) {
                 log.warn("Elasticsearch 검색 실패, MySQL fallback 사용. query={}", request.getQ(), e);
+                markSearchFallback();
             }
         }
         // ES 미사용 또는 fallback: 필터를 Specification으로 MySQL에서 처리
@@ -167,6 +174,17 @@ public class ProductService {
                         effectivePageable)
                 : productRepository.findByStatus(ProductStatus.ACTIVE, effectivePageable);
         return enrichPage(products, userId);
+    }
+
+    /**
+     * ES 장애로 MySQL fallback이 발생했음을 응답 헤더로 알린다.
+     * 요청 스코프 밖(배치 등)에서 호출될 수 있어 RequestAttributes 부재는 무시한다.
+     */
+    private void markSearchFallback() {
+        var attrs = RequestContextHolder.getRequestAttributes();
+        if (attrs instanceof ServletRequestAttributes servletAttrs) {
+            servletAttrs.getResponse().setHeader("X-Search-Fallback", "true");
+        }
     }
 
     /** categoryId 필터 대상 ID 집합 — includeChildren=true이면 하위 카테고리 포함 */

--- a/src/test/java/com/stockmanagement/domain/product/service/ProductServiceTest.java
+++ b/src/test/java/com/stockmanagement/domain/product/service/ProductServiceTest.java
@@ -239,6 +239,48 @@ class ProductServiceTest {
         }
 
         @Test
+        @DisplayName("ES 장애로 fallback 시 응답 헤더 X-Search-Fallback: true를 추가한다")
+        void setsFallbackHeaderOnEsFailure() {
+            Pageable pageable = PageRequest.of(0, 10);
+            ProductSearchRequest request = new ProductSearchRequest();
+            request.setQ("테스트");
+            given(productSearchService.search(any(), any())).willThrow(new RuntimeException("ES down"));
+            given(productRepository.findAll(any(Specification.class), any(Pageable.class)))
+                    .willReturn(Page.empty());
+
+            var mockRequest = new org.springframework.mock.web.MockHttpServletRequest();
+            var mockResponse = new org.springframework.mock.web.MockHttpServletResponse();
+            org.springframework.web.context.request.RequestContextHolder.setRequestAttributes(
+                    new org.springframework.web.context.request.ServletRequestAttributes(mockRequest, mockResponse));
+            try {
+                productService.getList(pageable, request, null);
+                assertThat(mockResponse.getHeader("X-Search-Fallback")).isEqualTo("true");
+            } finally {
+                org.springframework.web.context.request.RequestContextHolder.resetRequestAttributes();
+            }
+        }
+
+        @Test
+        @DisplayName("ES 정상 조회 시에는 fallback 헤더를 추가하지 않는다")
+        void doesNotSetFallbackHeaderOnEsSuccess() {
+            Pageable pageable = PageRequest.of(0, 10);
+            ProductSearchRequest request = new ProductSearchRequest();
+            request.setQ("테스트");
+            given(productSearchService.search(any(), any())).willReturn(Page.empty());
+
+            var mockRequest = new org.springframework.mock.web.MockHttpServletRequest();
+            var mockResponse = new org.springframework.mock.web.MockHttpServletResponse();
+            org.springframework.web.context.request.RequestContextHolder.setRequestAttributes(
+                    new org.springframework.web.context.request.ServletRequestAttributes(mockRequest, mockResponse));
+            try {
+                productService.getList(pageable, request, null);
+                assertThat(mockResponse.getHeader("X-Search-Fallback")).isNull();
+            } finally {
+                org.springframework.web.context.request.RequestContextHolder.resetRequestAttributes();
+            }
+        }
+
+        @Test
         @DisplayName("categoryId만 있으면 ES 없이 Specification으로 조회한다")
         void usesSpecificationForCategoryOnlyBrowsing() {
             Pageable pageable = PageRequest.of(0, 10);


### PR DESCRIPTION
## 개요
#63 처리 — ES 장애 시 MySQL LIKE fallback과 ES 형태소 분석 결과의 UX 불일치 이슈.

## 결정
빈 결과 반환 vs LIKE fallback 유지 중 "LIKE fallback 유지 + 안내 강화"로 결정 (제품 판단).
서비스 가용성을 우선하되, 결과 품질 저하 가능성을 클라이언트가 인지할 수 있도록 신호를 추가한다.

## 변경 사항
- `ProductService.getList()`에서 ES 검색 실패로 MySQL fallback이 발생하면 응답 헤더 `X-Search-Fallback: true`를 추가
- 요청 스코프 밖에서 호출될 가능성을 고려해 `RequestAttributes` 부재 시 조용히 무시 (배치 등 비-HTTP 컨텍스트 안전)
- `docs/API.md`에 헤더 동작 명시

## 테스트
- `ProductServiceTest`: fallback 발생 시 헤더 설정 / ES 정상 시 헤더 미설정 2건 추가
- 전체 테스트 스위트 통과 (BUILD SUCCESSFUL, Testcontainers 포함)

Closes #63
